### PR TITLE
Re-enable support for footnotes

### DIFF
--- a/src/_config.yml
+++ b/src/_config.yml
@@ -37,7 +37,7 @@ pagination:
 markdown: redcarpet
 
 redcarpet:
-  extensions: ["smart"]
+  extensions: ["footnotes", "smart"]
 
 plugins:
   - jekyll-paginate-v2

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -40,7 +40,7 @@ def test_pages_appear_correctly(path):
     ('feeds/all.atom.xml', '</entry><entry>'),
 
     # Footnotes are rendered correctly
-    ('2017/01/scrape-logged-in-ao3', '<a class="footnote-ref"')
+    ('2017/01/scrape-logged-in-ao3', '<a href="#fn1" rel="footnote">1</a>')
 ])
 def test_text_appears_in_pages(path, text_in_page):
     resp = requests.get(f'http://localhost:5757/{path}')

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -38,6 +38,9 @@ def test_pages_appear_correctly(path):
     # the template and *should* be minified in the output.
     ('feeds/all.atom.xml', '<author><name>Alex Chan</name>'),
     ('feeds/all.atom.xml', '</entry><entry>'),
+
+    # Footnotes are rendered correctly
+    ('2017/01/scrape-logged-in-ao3', '<a class="footnote-ref"')
 ])
 def test_text_appears_in_pages(path, text_in_page):
     resp = requests.get(f'http://localhost:5757/{path}')


### PR DESCRIPTION
I noticed they’d broken when I switched to Jekyll. Includes a test they don’t get broken again.