### PR TITLE
Make better use of make's dependency resolution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alexwlchan/bundler-base
+FROM ruby:2.4-alpine
 
 LABEL maintainer "Alex Chan <alex@alexwlchan.net>"
 LABEL description "Build image for alexwlchan.net"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.4-alpine3.6
 
 LABEL maintainer "Alex Chan <alex@alexwlchan.net>"
 LABEL description "Build image for alexwlchan.net"

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ ROOT = $(shell git rev-parse --show-toplevel)
 SRC = $(ROOT)/src
 TESTS = $(ROOT)/tests
 
-.docker/bundler:
+.docker/bundler: bundler.Dockerfile
 	docker build --tag $(BUNDLER_IMAGE) --file bundler.Dockerfile .
 	mkdir -p .docker && touch .docker/bundler
 
-.docker/build: .docker/bundler
+.docker/build: .docker/bundler Dockerfile install_jekyll.sh install_specktre.sh
 	docker build --tag $(BUILD_IMAGE) .
 	mkdir -p .docker
 	touch .docker/build
 
-.docker/tests:
+.docker/tests: tests/Dockerfile tests/*.py tests/requirements* tests/tox.ini
 	docker build --tag $(TESTS_IMAGE) --file $(TESTS)/Dockerfile $(TESTS)
 	mkdir -p .docker
 	touch .docker/tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-BUNDLER_IMAGE = alexwlchan/bundler-base
 BUILD_IMAGE = alexwlchan/alexwlchan.net
 TESTS_IMAGE = alexwlchan/alexwlchan.net_tests
 SERVE_CONTAINER = server
@@ -10,10 +9,6 @@ RSYNC_DIR = /home/alexwlchan/sites/alexwlchan.net
 ROOT = $(shell git rev-parse --show-toplevel)
 SRC = $(ROOT)/src
 TESTS = $(ROOT)/tests
-
-.docker/bundler: bundler.Dockerfile
-	docker build --tag $(BUNDLER_IMAGE) --file bundler.Dockerfile .
-	mkdir -p .docker && touch .docker/bundler
 
 .docker/build: Dockerfile install_jekyll.sh install_specktre.sh
 	docker build --tag $(BUILD_IMAGE) .
@@ -80,12 +75,12 @@ test: .docker/tests
 		--link $(SERVE_CONTAINER) \
 		--tty $(TESTS_IMAGE)
 
-Gemfile.lock: .docker/bundler
+Gemfile.lock: Gemfile
 	docker run \
 		--volume $(ROOT):/site \
 		--workdir /site \
-		--tty $(BUNDLER_IMAGE) \
-		lock --update
+		--tty $(shell cat Dockerfile | grep FROM | awk '{print $$2}') \
+		bundle lock --update
 
 
 .PHONY: clean build watch serve serve-debug publish deploy test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TESTS = $(ROOT)/tests
 	docker build --tag $(BUNDLER_IMAGE) --file bundler.Dockerfile .
 	mkdir -p .docker && touch .docker/bundler
 
-.docker/build: .docker/bundler Dockerfile install_jekyll.sh install_specktre.sh
+.docker/build: Dockerfile install_jekyll.sh install_specktre.sh
 	docker build --tag $(BUILD_IMAGE) .
 	mkdir -p .docker
 	touch .docker/build

--- a/install_jekyll.sh
+++ b/install_jekyll.sh
@@ -23,11 +23,6 @@ apk add rsync
 apk add py2-pip
 pip install pygments
 
-# Fixes an issue where bundler complains about running as root.
-# In Docker, that doesn't matter!
-# https://github.com/docker-library/rails/issues/10
-bundle config --global silence_root_warning 1
-
 bundle install
 
 apk del --purge build-base


### PR DESCRIPTION
This just makes things a little easier locally – lockfiles and Docker images will be rebuilt automatically when their dependent resources are changed, rather than having to delete the old one first.

Plus pin to a specific Ruby version in the base image.