### PR TITLE
Move minipost: into the theme block

### DIFF
--- a/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
+++ b/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
@@ -1,11 +1,12 @@
 ---
 date: 2016-07-28 21:03:00 +0000
 layout: post
-minipost: true
 slug: chasing-redirects-and-url-shorteners
 summary: A quick Python function to follow a redirect to its eventual conclusion.
 tags: python
 title: 'Python snippets: Chasing redirects and URL shorteners'
+theme:
+  minipost: true
 ---
 
 Quick post today.

--- a/src/_posts/2016/2016-08-07-clean-up-directories.md
+++ b/src/_posts/2016/2016-08-07-clean-up-directories.md
@@ -1,11 +1,12 @@
 ---
 date: 2016-08-07 22:46:00 +0000
 layout: post
-minipost: true
 slug: clean-up-directories
 summary: A pair of Python scripts I've been using to clean up my mess of directories.
 tags: python
 title: 'Python snippets: Cleaning up empty/nearly empty directories'
+theme:
+  minipost: true
 ---
 
 Last month, I wrote about [some tools](/2016/07/clearing-disk-space-on-os-x/) I'd been using to clear disk space on my Mac.

--- a/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
+++ b/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
@@ -1,10 +1,11 @@
 ---
 date: 2016-08-19 23:34:00 +0000
 layout: post
-minipost: true
 slug: is-a-url-from-tumblr
 tags: tumblr python
 title: 'Python snippets: Is a URL from a Tumblr post?'
+theme:
+  minipost: true
 ---
 
 I've been writing some code recently that takes a URL, and performs some special actions if that URL is a Tumblr post.

--- a/src/_posts/2016/2016-08-31-query-strings.md
+++ b/src/_posts/2016/2016-08-31-query-strings.md
@@ -1,10 +1,11 @@
 ---
 date: 2016-08-31 20:05:00 +0000
 layout: post
-minipost: true
 slug: dealing-with-query-strings
 tags: python
 title: 'Python snippet: dealing with query strings in URLs'
+theme:
+  minipost: true
 ---
 
 I spend a lot of time dealing with URLs: in particular, with URL [query strings][wiki_qs].

--- a/src/_posts/2016/2016-10-01-a-tally-on-the-command-line.md
+++ b/src/_posts/2016/2016-10-01-a-tally-on-the-command-line.md
@@ -1,10 +1,11 @@
 ---
 date: 2016-10-01 21:23:00 +0000
 layout: post
-minipost: true
 slug: a-shell-alias-for-tallying
 tags: shell-scripting
 title: A shell alias for tallying data
+theme:
+  minipost: true
 ---
 
 Here's a tiny shell alias that I find useful when going through data on the command line.

--- a/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
+++ b/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
@@ -1,11 +1,12 @@
 ---
 date: 2017-01-07 23:10:00 +0000
 layout: post
-minipost: true
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python,
   it might not be necessary.
 tags: python fandom
 title: Experiments with AO3 and Python
+theme:
+  minipost: true
 ---
 
 Recently, I've been writing some scripts that need to get data from [AO3][ao3][^1].


### PR DESCRIPTION
Turns out the templates already expected it to be there, and it was only the front matter that was broken!

Resolves #47.