### PR TITLE
Tweak CSS for accessibility

### DIFF
--- a/src/_scss/_aside.scss
+++ b/src/_scss/_aside.scss
@@ -1,13 +1,21 @@
 aside {
   background: url('/theme/specktre_#{colorToHexString($primary-color)}.png') $primary-color;
   background-size: auto 100%;
+  @media print {
+    background: none;
+    border-bottom: 2px solid $primary-color;
+  }
 
   #aside_inner {
     @include central_element();
 
     &, a, a:visited {
       color: white;
+      @media print {
+        color: $primary-color;
+      }
     }
+
     a:hover {
       text-decoration: none;
     }

--- a/src/_scss/_post.scss
+++ b/src/_scss/_post.scss
@@ -15,6 +15,5 @@
     &, &:visited {
       color: $primary-color;
     }
-    text-decoration: none;
   }
 }


### PR DESCRIPTION
Resolves #42. Just an extra link underline, and some tweaked print styles. Most stuff was either good enough already, or in areas of CSS that I don’t use.