### PR TITLE
Fix YouTube links in the RSS feed

### DIFF
--- a/src/_plugins/youtube.rb
+++ b/src/_plugins/youtube.rb
@@ -31,7 +31,7 @@ module Jekyll
         new_node = Nokogiri::HTML.fragment("<p><a href=\"#{url}\">#{url}</a></p>")
         f_node.replace(new_node)
       end
-      doc.to_s
+      doc.at_xpath("//body").to_s["<body>".length..-"</body>".length]
     end
 
   end

--- a/src/_plugins/youtube.rb
+++ b/src/_plugins/youtube.rb
@@ -8,6 +8,27 @@
 require 'cgi'
 require 'uri'
 
+module Jekyll
+  module YouTubeAtomFeedFilters
+
+    # According to https://github.com/rubys/feedvalidator, embedding
+    # <iframe> in an RSS feed can be a security risk, so instead we replace
+    # such YouTube iframes with a flat link to the page.
+    #
+    # TODO: Regex matching is crappy, use Nokogiri to do it properly.
+    #
+    # Params:
+    # +html+:: HTML string to clean.
+    #
+    def fix_youtube_iframes(html)
+      doc = Nokogiri::HTML.fragment(html)
+      doc.xpath('style|@style|.//@style|@data-lang|.//@data-lang|@controls|.//@controls').remove
+      doc.to_s
+    end
+
+  end
+end
+
 
 module Jekyll
   class YouTubeTag < Liquid::Tag
@@ -28,4 +49,6 @@ EOT
   end
 end
 
+
+Liquid::Template::register_filter(Jekyll::YouTubeAtomFeedFilters)
 Liquid::Template.register_tag('youtube', Jekyll::YouTubeTag)

--- a/src/_plugins/youtube.rb
+++ b/src/_plugins/youtube.rb
@@ -1,0 +1,31 @@
+# This is a plugin for embedding YouTube videos.
+#
+# Insert the full URL of the YouTube video in question, for example:
+#
+#     {% youtube https://www.youtube.com/watch?v=Ej2EJVMkTKw %}
+#
+
+require 'cgi'
+require 'uri'
+
+
+module Jekyll
+  class YouTubeTag < Liquid::Tag
+
+    def initialize(tag_name, text, tokens)
+      super
+      @url = text.split(" ").last
+      query_string = URI.parse(@url).query
+      @video_id = CGI.parse(query_string)["v"].first
+    end
+
+    def render(context)
+      path = "/slides/#{@deck}/#{@deck}.#{@number.to_s.rjust(3, '0')}.png"
+<<-EOT
+<iframe width="560" height="315" src="https://www.youtube.com/embed/#{@video_id}" frameborder="0" allowfullscreen></iframe>
+EOT
+    end
+  end
+end
+
+Liquid::Template.register_tag('youtube', Jekyll::YouTubeTag)

--- a/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
+++ b/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
@@ -27,7 +27,7 @@ My spoken and written voice are quite different, but it gets the general gist ac
 
 If you'd prefer, you can watch the conference video on YouTube:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Ej2EJVMkTKw" frameborder="0" allowfullscreen></iframe>
+{% youtube https://www.youtube.com/watch?v=Ej2EJVMkTKw %}
 
 [pycon]: http://2017.pyconuk.org/sessions/talks/using-privilege-to-help-not-hurt-diversity/
 

--- a/src/feeds/all.atom.xml
+++ b/src/feeds/all.atom.xml
@@ -25,7 +25,7 @@ layout: default_xml
       <updated>{{ post.last_modified_at | default: post.date | date_to_xmlschema }}</updated>
       <id>{{ post.id | absolute_url | xml_escape }}</id>
       <content type="html" xml:base="{{ post.url | absolute_url | xml_escape }}">
-        {{ post.content | strip | strip_html_attrs | normalize_whitespace | xml_escape }}
+        {{ post.content | strip | strip_html_attrs | fix_youtube_iframes | normalize_whitespace | xml_escape }}
 
         {%- if post.link %}&lt;a href="{{ post.url }}"&gt;&amp;infin;&lt;/a&gt;{% endif -%}
       </content>


### PR DESCRIPTION
feedvalidator whinges about an `<iframe>` tag appearing in the RSS; this patch flips it to be converted to an `<a>` link in its own paragraph if it ever appears in RSS.