### PR TITLE
Define custom nginx config for the site container

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -38,6 +38,10 @@ do
 done
 set -o errexit
 
+# Once the server comes up, we add the nginx server.  This will come up
+# almost immediately, so we don't delay.
+make nginx-serve
+
 echo "*** Running the server tests"
 make test
 

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ nginx-serve:
 		--volume $(ROOT)/infra/alexwlchan.net.nginx.conf:/etc/nginx/nginx.conf \
 		--volume $(ROOT)/src/_site:/usr/share/nginx/html \
 		--publish 5858:80 \
+		--hostname alexwlchan \
 		--detach nginx:alpine
 
 include analytics/Makefile

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test: .docker/tests
 		--volume $(ROOT):/repo \
 		--env HOSTNAME=$(SERVE_CONTAINER) \
 		--link $(SERVE_CONTAINER) \
-		--link nginx_alexwlchan.net \
+		--link alexwlchan \
 		--tty --rm $(TESTS_IMAGE)
 
 Gemfile.lock: Gemfile
@@ -111,7 +111,7 @@ nginx-serve:
 		--volume $(ROOT)/src/_site:/usr/share/nginx/html \
 		--publish 5858:80 \
 		--hostname alexwlchan \
-		--name nginx_alexwlchan.net \
+		--name alexwlchan \
 		--detach nginx:alpine
 
 include analytics/Makefile

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,13 @@ renew-certbot:
 		--volume ~/.certbot/config:/etc/letsencrypt \
 		certbot/certbot certonly --webroot --webroot-path /site -d alexwlchan.net,www.alexwlchan.net
 
+nginx-serve:
+	docker run --rm \
+		--volume $(ROOT)/infra/alexwlchan.net.nginx.conf:/etc/nginx/nginx.conf \
+		--volume $(ROOT)/src/_site:/usr/share/nginx/html \
+		--publish 5858:80 \
+		--detach nginx:alpine
+
 include analytics/Makefile
 
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ test: .docker/tests
 		--volume $(ROOT):/repo \
 		--env HOSTNAME=$(SERVE_CONTAINER) \
 		--link $(SERVE_CONTAINER) \
+		--link nginx_alexwlchan.net \
 		--tty --rm $(TESTS_IMAGE)
 
 Gemfile.lock: Gemfile
@@ -110,6 +111,7 @@ nginx-serve:
 		--volume $(ROOT)/src/_site:/usr/share/nginx/html \
 		--publish 5858:80 \
 		--hostname alexwlchan \
+		--name nginx_alexwlchan.net \
 		--detach nginx:alpine
 
 include analytics/Makefile

--- a/infra/alexwlchan.net.nginx.conf
+++ b/infra/alexwlchan.net.nginx.conf
@@ -17,35 +17,11 @@ http {
 
     server {
         listen 80;
-        server_name alexwlchan.net;
-        return 301 https://alexwlchan.net$request_uri;
-    }
+        server_name alexwlchan;
 
-    server {
-        listen 80;
-        server_name www.alexwlchan.net;
-        return 301 https://alexwlchan.net$request_uri;
-    }
-
-    server {
-        listen 443 ssl;
-        ssl_certificate /certbot/config/live/alexwlchan.net/fullchain.pem;
-        ssl_certificate_key /certbot/config/live/alexwlchan.net/privkey.pem;
-        server_name www.alexwlchan.net;
-        return 301 https://alexwlchan.net$request_uri;
-    }
-
-    server {
-        listen 443 ssl;
-        server_name alexwlchan.net;
-        ssl_certificate /certbot/config/live/alexwlchan.net/fullchain.pem;
-        ssl_certificate_key /certbot/config/live/alexwlchan.net/privkey.pem;
-
-        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-
-       location /experiments/specktre {
-           return 410;
-       }
+        location /experiments/specktre {
+            return 410;
+        }
 
         location /tools/specktre {
             return 410;

--- a/infra/alexwlchan.net.nginx.conf
+++ b/infra/alexwlchan.net.nginx.conf
@@ -1,0 +1,77 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    server_tokens off;
+
+    server {
+        listen 80;
+        server_name alexwlchan.net;
+        return 301 https://alexwlchan.net$request_uri;
+    }
+
+    server {
+        listen 80;
+        server_name www.alexwlchan.net;
+        return 301 https://alexwlchan.net$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        ssl_certificate /certbot/config/live/alexwlchan.net/fullchain.pem;
+        ssl_certificate_key /certbot/config/live/alexwlchan.net/privkey.pem;
+        server_name www.alexwlchan.net;
+        return 301 https://alexwlchan.net$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        server_name alexwlchan.net;
+        ssl_certificate /certbot/config/live/alexwlchan.net/fullchain.pem;
+        ssl_certificate_key /certbot/config/live/alexwlchan.net/privkey.pem;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+       location /experiments/specktre {
+           return 410;
+       }
+
+        location /tools/specktre {
+            return 410;
+        }
+
+        error_page 404 /404.html;
+        location = /404.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
+
+        error_page 410 /410.html;
+        location = /410.html {
+            root /usr/share/nginx/html;
+            internal;
+        }
+    }
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/infra/alexwlchan.net.nginx.conf
+++ b/infra/alexwlchan.net.nginx.conf
@@ -38,6 +38,10 @@ http {
             root /usr/share/nginx/html;
             internal;
         }
+        
+        location / {
+            root /usr/share/nginx/html;
+        }
     }
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '

--- a/infra/alexwlchan.net.nginx.conf
+++ b/infra/alexwlchan.net.nginx.conf
@@ -1,14 +1,11 @@
-user  nginx;
-worker_processes  1;
+user nginx;
+worker_processes 1;
 
-error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
-
+error_log /var/log/nginx/error.log warn;
 
 events {
     worker_connections  1024;
 }
-
 
 http {
     include       /etc/nginx/mime.types;

--- a/infra/alexwlchan.net.nginx.conf
+++ b/infra/alexwlchan.net.nginx.conf
@@ -18,6 +18,11 @@ http {
     server {
         listen 80;
         server_name alexwlchan;
+        
+        root /usr/share/nginx/html;
+
+        error_page 404 /404/index.html;
+        error_page 410 /410/index.html;
 
         location /experiments/specktre {
             return 410;
@@ -25,22 +30,6 @@ http {
 
         location /tools/specktre {
             return 410;
-        }
-
-        error_page 404 /404.html;
-        location = /404.html {
-            root /usr/share/nginx/html;
-            internal;
-        }
-
-        error_page 410 /410.html;
-        location = /410.html {
-            root /usr/share/nginx/html;
-            internal;
-        }
-        
-        location / {
-            root /usr/share/nginx/html;
         }
     }
 
@@ -52,6 +41,4 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
-
-    include /etc/nginx/conf.d/*.conf;
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "~/sites/alexwlchan.net/404/index.html:/usr/share/nginx/html/404.html"
-      - "~/sites/alexwlchan.net/410/index.html:/usr/share/nginx/html/410.html"
       - "./nginx.conf:/etc/nginx/nginx.conf"
       - "~/.certbot:/certbot"
   bijou:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,4 +25,3 @@ services:
     volumes:
       - "~/sites/alexwlchan.net:/usr/share/nginx/html"
       - "./alexwlchan.net.nginx.conf:/etc/nginx/nginx.conf"
-      - "~/.certbot:/certbot"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -24,3 +24,5 @@ services:
     image: "nginx:alpine"
     volumes:
       - "~/sites/alexwlchan.net:/usr/share/nginx/html"
+      - "./alexwlchan.net.nginx.conf:/etc/nginx/nginx.conf"
+      - "~/.certbot:/certbot"

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -18,13 +18,7 @@ http {
 
     server {
         listen 80;
-        server_name alexwlchan.net;
-        return 301 https://alexwlchan.net$request_uri;
-    }
-
-    server {
-        listen 80;
-        server_name www.alexwlchan.net;
+        server_name alexwlchan.net www.alexwlchan.net;
         return 301 https://alexwlchan.net$request_uri;
     }
 
@@ -70,7 +64,7 @@ http {
 
     server {
         listen 80;
-        server_name www.bijouopera.co.uk;
+        server_name bijouopera.co.uk www.bijouopera.co.uk;
         return 301 https://bijouopera.co.uk$request_uri;
     }
 
@@ -80,12 +74,6 @@ http {
         ssl_certificate_key /certbot/config/live/bijouopera.co.uk/privkey.pem;
         server_name www.bijouopera.co.uk;
         return 301 https://bijouopera.co.uk$request_uri;
-    }
-
-    server {
-        listen 80;
-        server_name bijouopera.co.uk;
-        return 301 https://$host$request_uri;
     }
 
     server {

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -2,7 +2,6 @@ user  nginx;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;
-pid        /var/run/nginx.pid;
 
 
 events {
@@ -102,6 +101,4 @@ http {
 
     sendfile        on;
     keepalive_timeout  65;
-
-    include /etc/nginx/conf.d/*.conf;
 }

--- a/infra/nginx.conf
+++ b/infra/nginx.conf
@@ -57,34 +57,6 @@ http {
             proxy_redirect http://pygmentizr:80/ http://$server_name/;
         }
 
-       location /experiments/specktre {
-           return 410;
-       }
-
-        location /tools/specktre {
-            return 410;
-        }
-
-        # The nginx container serving the site returns its own 404/410 page, so
-        # we use that setting to catch that and return our own page.  Arguably the
-        # downstream container should be returning the correct message itself...
-        # but I configured this at 11:30pm on a Saturday evening when the downstream
-        # ran vanilla nginx, and I CBA to set up its own config file.
-        # TODO: Go back and do this properly.
-        proxy_intercept_errors on;
-
-        error_page 404 /404.html;
-        location = /404.html {
-            root /usr/share/nginx/html;
-            internal;
-        }
-
-        error_page 410 /410.html;
-        location = /410.html {
-            root /usr/share/nginx/html;
-            internal;
-        }
-
         location / {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,13 @@ def hostname():
 
 
 @pytest.fixture
+def nginx_hostname():
+    host = os.environ.get('HOSTNAME', 'localhost')
+    port = os.environ.get('PORT', 5858)
+    return '%s:%s' % (host, port)
+
+
+@pytest.fixture
 def baseurl(hostname):
     return 'http://%s/' % hostname
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def hostname():
 
 @pytest.fixture
 def nginx_hostname():
-    host = os.environ.get('HOSTNAME', 'localhost')
+    host = os.environ.get('HOSTNAME', 'alexwlchan')
     port = os.environ.get('PORT', 5858)
     return '%s:%s' % (host, port)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,9 +14,7 @@ def hostname():
 
 @pytest.fixture
 def nginx_hostname():
-    host = os.environ.get('HOSTNAME', 'alexwlchan')
-    port = os.environ.get('PORT', 5858)
-    return '%s:%s' % (host, port)
+    return 'alexwlchan:80'
 
 
 @pytest.fixture

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -1,0 +1,14 @@
+# -*- encoding: utf-8
+
+import requests
+import pytest
+
+
+@pytest.mark.parametrize('path, expected_status', [
+    ('/tools/specktre', 410),
+    ('/experiments/specktre', 410),
+])
+def test_nginx_resolves_correctly(nginx_hostname, path, expected_status):
+    resp = requests.get('http://%s/%s' % (nginx_hostname, path))
+    assert resp.status_code == expected_status
+    

--- a/tests/test_nginx.py
+++ b/tests/test_nginx.py
@@ -9,6 +9,5 @@ import pytest
     ('/experiments/specktre', 410),
 ])
 def test_nginx_resolves_correctly(nginx_hostname, path, expected_status):
-    resp = requests.get('http://%s/%s' % (nginx_hostname, path))
+    resp = requests.get('http://%s%s' % (nginx_hostname, path))
     assert resp.status_code == expected_status
-    


### PR DESCRIPTION
This patch is a precursor to some work on #113 – now there’s some nginx config that lives inside the alexwlchan.net container, which is a good place to put additional redirects and 410s.