### PR TITLE
Publish drafts with a time as well as a date, and other front matter fixes

### DIFF
--- a/src/_plugins/publish_drafts.rb
+++ b/src/_plugins/publish_drafts.rb
@@ -32,6 +32,15 @@ def publish_all_drafts(source_dir)
       new_name = File.join(source_dir, "_posts", now.strftime("%Y"), "#{now.strftime('%Y-%m-%d')}-#{name}")
       File.rename(entry, new_name)
 
+      # Now we write the exact date and time into the top of the file.
+      # This means that if I publish more than one post on the same day,
+      # they have an unambiguous ordering.
+      doc = File.read(new_name)
+      doc = doc.gsub(
+        /layout:\s+post\s*\n/,
+        "layout: post\ndate: #{now.strftime('%Y-%m-%d %H:%M:%S')}")
+      File.open(new_name, 'w') { |f| f.write(doc) }
+
       puts "*** Creating Git commit for #{entry}"
       Shell.execute!("git rm #{entry}")
       Shell.execute!("git add #{new_name}")

--- a/src/_plugins/publish_drafts.rb
+++ b/src/_plugins/publish_drafts.rb
@@ -38,7 +38,7 @@ def publish_all_drafts(source_dir)
       doc = File.read(new_name)
       doc = doc.gsub(
         /layout:\s+post\s*\n/,
-        "layout: post\ndate: #{now.strftime('%Y-%m-%d %H:%M:%S')}")
+        "layout: post\ndate: #{now}")
       File.open(new_name, 'w') { |f| f.write(doc) }
 
       puts "*** Creating Git commit for #{entry}"

--- a/src/_posts/2012/2012-12-30-hypercritical.md
+++ b/src/_posts/2012/2012-12-30-hypercritical.md
@@ -1,6 +1,6 @@
 ---
-date: 2012-12-30 00:07:00 +0000
 layout: post
+date: 2012-12-30 00:07:00 +0000
 summary: My thoughts on the ending of Hypercritical, a podcast by John Siracusa.
 tags: podcasts
 title: Hypercritical

--- a/src/_posts/2013/2013-01-10-zero.md
+++ b/src/_posts/2013/2013-01-10-zero.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-01-10 00:41:00 +0000
 layout: post
+date: 2013-01-10 00:41:00 +0000
 summary: An essay about the number zero that I wrote for school.
 tags: maths
 title: Zero

--- a/src/_posts/2013/2013-01-10-zero.md
+++ b/src/_posts/2013/2013-01-10-zero.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-01-10 00:41:00 +0000
 layout: post
-slug: zero
 summary: An essay about the number zero that I wrote for school.
 tags: maths
 title: Zero

--- a/src/_posts/2013/2013-02-13-darwin.md
+++ b/src/_posts/2013/2013-02-13-darwin.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-02-13 10:33:00 +0000
 layout: post
-slug: darwin
 summary: Looking at whether Darwin ever missed out on birthday cake for pancakes
 tags: dates maths python
 title: Darwin, pancakes and birthdays

--- a/src/_posts/2013/2013-02-13-darwin.md
+++ b/src/_posts/2013/2013-02-13-darwin.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-02-13 10:33:00 +0000
 layout: post
+date: 2013-02-13 10:33:00 +0000
 summary: Looking at whether Darwin ever missed out on birthday cake for pancakes
 tags: dates maths python
 title: Darwin, pancakes and birthdays

--- a/src/_posts/2013/2013-03-06-candybar.md
+++ b/src/_posts/2013/2013-03-06-candybar.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-03-06 23:46:00 +0000
 layout: post
-slug: candybar
 summary: Some recommendations for alternative icon sets to use with the Mac theming
   app Candybar.
 tags: os-x

--- a/src/_posts/2013/2013-03-06-candybar.md
+++ b/src/_posts/2013/2013-03-06-candybar.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-03-06 23:46:00 +0000
 layout: post
+date: 2013-03-06 23:46:00 +0000
 summary: Some recommendations for alternative icon sets to use with the Mac theming
   app Candybar.
 tags: os-x

--- a/src/_posts/2013/2013-03-30-timezone-bug.md
+++ b/src/_posts/2013/2013-03-30-timezone-bug.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-03-30 19:57:00 +0000
 layout: post
-slug: timezone-bug
 summary: A strange bug with OS X's timezone handling
 tags: dates os-x
 title: Strange clock bug in OS X

--- a/src/_posts/2013/2013-03-30-timezone-bug.md
+++ b/src/_posts/2013/2013-03-30-timezone-bug.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-03-30 19:57:00 +0000
 layout: post
+date: 2013-03-30 19:57:00 +0000
 summary: A strange bug with OS X's timezone handling
 tags: dates os-x
 title: Strange clock bug in OS X

--- a/src/_posts/2013/2013-03-31-pinboard-backups.md
+++ b/src/_posts/2013/2013-03-31-pinboard-backups.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-03-31 11:13:00 +0000
 layout: post
+date: 2013-03-31 11:13:00 +0000
 summary: A script for automatically backing up bookmarks from Pinboard
 tags: pinboard python
 title: Automatic Pinboard backups

--- a/src/_posts/2013/2013-03-31-pinboard-backups.md
+++ b/src/_posts/2013/2013-03-31-pinboard-backups.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-03-31 11:13:00 +0000
 layout: post
-slug: pinboard-backups
 summary: A script for automatically backing up bookmarks from Pinboard
 tags: pinboard python
 title: Automatic Pinboard backups

--- a/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
+++ b/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-05-11 12:26:00 +0000
 layout: post
+date: 2013-05-11 12:26:00 +0000
 summary: A barely advertised feature of Tumblr that lets you get an RSS feed of external
   audio posts.
 tags: podcasts tumblr

--- a/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
+++ b/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-05-11 12:26:00 +0000
 layout: post
-slug: rss-podcasts-tumblr
 summary: A barely advertised feature of Tumblr that lets you get an RSS feed of external
   audio posts.
 tags: podcasts tumblr

--- a/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
+++ b/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-08-06 09:52:00 +0000
 layout: post
+date: 2013-08-06 09:52:00 +0000
 tags: tumblr python
 title: Finding untagged posts on Tumblr
 ---

--- a/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
+++ b/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-08-06 09:52:00 +0000
 layout: post
-slug: untagged-tumblr-posts
 tags: tumblr python
 title: Finding untagged posts on Tumblr
 ---

--- a/src/_posts/2013/2013-08-20-google-maps.md
+++ b/src/_posts/2013/2013-08-20-google-maps.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-08-20 10:47:00 +0000
 layout: post
+date: 2013-08-20 10:47:00 +0000
 summary: A bookmarklet to hide some of the UI chrome in the new design of Google Maps.
 tags: javascript
 title: Cleaning up Google Maps

--- a/src/_posts/2013/2013-08-20-google-maps.md
+++ b/src/_posts/2013/2013-08-20-google-maps.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-08-20 10:47:00 +0000
 layout: post
-slug: google-maps
 summary: A bookmarklet to hide some of the UI chrome in the new design of Google Maps.
 tags: javascript
 title: Cleaning up Google Maps

--- a/src/_posts/2013/2013-11-13-textmate-quick-look.md
+++ b/src/_posts/2013/2013-11-13-textmate-quick-look.md
@@ -1,6 +1,6 @@
 ---
-date: 2013-11-13 08:16:00 +0000
 layout: post
+date: 2013-11-13 08:16:00 +0000
 summary: Disabling the Quick Look plugin that comes in the TextMate 2 alpha.
 tags: textmate os-x
 title: TextMate 2 and Quick Look

--- a/src/_posts/2013/2013-11-13-textmate-quick-look.md
+++ b/src/_posts/2013/2013-11-13-textmate-quick-look.md
@@ -1,7 +1,6 @@
 ---
 date: 2013-11-13 08:16:00 +0000
 layout: post
-slug: textmate-quick-look
 summary: Disabling the Quick Look plugin that comes in the TextMate 2 alpha.
 tags: textmate os-x
 title: TextMate 2 and Quick Look

--- a/src/_posts/2014/2014-04-20-veil.md
+++ b/src/_posts/2014/2014-04-20-veil.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-04-20 09:58:00 +0000
 layout: post
+date: 2014-04-20 09:58:00 +0000
 tags: harry potter
 title: Pulling back the veil
 ---

--- a/src/_posts/2014/2014-04-20-veil.md
+++ b/src/_posts/2014/2014-04-20-veil.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-04-20 09:58:00 +0000
 layout: post
-slug: veil
 tags: harry potter
 title: Pulling back the veil
 ---

--- a/src/_posts/2014/2014-05-12-part-ii-advice.md
+++ b/src/_posts/2014/2014-05-12-part-ii-advice.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-05-12 15:53:00 +0000
 layout: post
-slug: part-ii-advice
 summary: Some suggestions for second year Cambridge maths students looking for work
   over the summer.
 tags: maths cambridge

--- a/src/_posts/2014/2014-05-12-part-ii-advice.md
+++ b/src/_posts/2014/2014-05-12-part-ii-advice.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-05-12 15:53:00 +0000
 layout: post
+date: 2014-05-12 15:53:00 +0000
 summary: Some suggestions for second year Cambridge maths students looking for work
   over the summer.
 tags: maths cambridge

--- a/src/_posts/2014/2014-05-14-part-ia-exams.md
+++ b/src/_posts/2014/2014-05-14-part-ia-exams.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-05-14 21:10:00 +0000
 layout: post
+date: 2014-05-14 21:10:00 +0000
 summary: Some advice for IA Mathmos sitting Tripos
 tags: cambridge maths
 title: Some Part IA exam advice

--- a/src/_posts/2014/2014-05-14-part-ia-exams.md
+++ b/src/_posts/2014/2014-05-14-part-ia-exams.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-05-14 21:10:00 +0000
 layout: post
-slug: part-ia-exams
 summary: Some advice for IA Mathmos sitting Tripos
 tags: cambridge maths
 title: Some Part IA exam advice

--- a/src/_posts/2014/2014-06-13-site-updates.md
+++ b/src/_posts/2014/2014-06-13-site-updates.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-06-13 00:03:00 +0000
 layout: post
+date: 2014-06-13 00:03:00 +0000
 title: Some site updates
 ---
 

--- a/src/_posts/2014/2014-06-13-site-updates.md
+++ b/src/_posts/2014/2014-06-13-site-updates.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-06-13 00:03:00 +0000
 layout: post
-slug: site-updates
 title: Some site updates
 ---
 

--- a/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
+++ b/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-06-13 07:50:00 +0000
 layout: post
+date: 2014-06-13 07:50:00 +0000
 tags: tumblr
 title: Finding untagged posts on Tumblr, redux
 ---

--- a/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
+++ b/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-06-13 07:50:00 +0000
 layout: post
-slug: untagged-tumblr-posts-redux
 tags: tumblr
 title: Finding untagged posts on Tumblr, redux
 ---

--- a/src/_posts/2014/2014-06-23-instapaper-urls.md
+++ b/src/_posts/2014/2014-06-23-instapaper-urls.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-06-23 13:04:00 +0000
 layout: post
-slug: instapaper-urls
 tags: instapaper applescript
 title: Catching instapaper:// URLs from ReadKit
 ---

--- a/src/_posts/2014/2014-06-23-instapaper-urls.md
+++ b/src/_posts/2014/2014-06-23-instapaper-urls.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-06-23 13:04:00 +0000
 layout: post
+date: 2014-06-23 13:04:00 +0000
 tags: instapaper applescript
 title: Catching instapaper:// URLs from ReadKit
 ---

--- a/src/_posts/2014/2014-06-29-skeletor.md
+++ b/src/_posts/2014/2014-06-29-skeletor.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-06-29 10:11:00 +0000
 layout: post
+date: 2014-06-29 10:11:00 +0000
 tags: skeletor podcasts
 title: Skeletor!
 ---

--- a/src/_posts/2014/2014-06-29-skeletor.md
+++ b/src/_posts/2014/2014-06-29-skeletor.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-06-29 10:11:00 +0000
 layout: post
-slug: skeletor
 tags: skeletor podcasts
 title: Skeletor!
 ---

--- a/src/_posts/2014/2014-07-11-latex-alpha.md
+++ b/src/_posts/2014/2014-07-11-latex-alpha.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-07-11 07:43:00 +0000
 layout: post
+date: 2014-07-11 07:43:00 +0000
 tags: latex wolfram-alpha
 title: Getting plaintext <span class="latex">L<sup>a</sup>T<sub>e</sub>X</span> from
   Wolfram Alpha

--- a/src/_posts/2014/2014-07-11-latex-alpha.md
+++ b/src/_posts/2014/2014-07-11-latex-alpha.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-07-11 07:43:00 +0000
 layout: post
-slug: latex-alpha
 tags: latex wolfram-alpha
 title: Getting plaintext <span class="latex">L<sup>a</sup>T<sub>e</sub>X</span> from
   Wolfram Alpha

--- a/src/_posts/2014/2014-07-18-overcast.md
+++ b/src/_posts/2014/2014-07-18-overcast.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-07-18 02:39:00 +0000
 layout: post
+date: 2014-07-18 02:39:00 +0000
 summary: Some thoughts on Marco Arment's new podcast player, Overcast.
 tags: podcasts
 title: Thoughts on Overcast

--- a/src/_posts/2014/2014-07-18-overcast.md
+++ b/src/_posts/2014/2014-07-18-overcast.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-07-18 02:39:00 +0000
 layout: post
-slug: overcast
 summary: Some thoughts on Marco Arment's new podcast player, Overcast.
 tags: podcasts
 title: Thoughts on Overcast

--- a/src/_posts/2014/2014-08-28-alfred-screenshots.md
+++ b/src/_posts/2014/2014-08-28-alfred-screenshots.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-08-28 00:32:00 +0000
 layout: post
-slug: alfred-screenshots
 tags: alfred applescript
 title: A quick Alfred workflow for opening recent screenshots
 ---

--- a/src/_posts/2014/2014-08-28-alfred-screenshots.md
+++ b/src/_posts/2014/2014-08-28-alfred-screenshots.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-08-28 00:32:00 +0000
 layout: post
+date: 2014-08-28 00:32:00 +0000
 tags: alfred applescript
 title: A quick Alfred workflow for opening recent screenshots
 ---

--- a/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
+++ b/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-08-29 22:06:00 +0000
 layout: post
+date: 2014-08-29 22:06:00 +0000
 tags: textexpander
 title: A TextExpander snippet for Amazon affiliate links
 ---

--- a/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
+++ b/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-08-29 22:06:00 +0000
 layout: post
-slug: textexpander-amazon-affiliates
 tags: textexpander
 title: A TextExpander snippet for Amazon affiliate links
 ---

--- a/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
+++ b/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-08-31 12:12:00 +0000
 layout: post
-slug: untagged-tumblr-updates
 tags: tumblr
 title: Updates to my site for finding untagged Tumblr posts
 ---

--- a/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
+++ b/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-08-31 12:12:00 +0000
 layout: post
+date: 2014-08-31 12:12:00 +0000
 tags: tumblr
 title: Updates to my site for finding untagged Tumblr posts
 ---

--- a/src/_posts/2014/2014-09-05-new-standing-desk.md
+++ b/src/_posts/2014/2014-09-05-new-standing-desk.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-09-05 19:14:00 +0000
 layout: post
+date: 2014-09-05 19:14:00 +0000
 summary: A standing desk that I built solely from IKEA parts.
 tags: personal
 title: My new standing desk

--- a/src/_posts/2014/2014-09-05-new-standing-desk.md
+++ b/src/_posts/2014/2014-09-05-new-standing-desk.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-09-05 19:14:00 +0000
 layout: post
-slug: new-standing-desk
 summary: A standing desk that I built solely from IKEA parts.
 tags: personal
 title: My new standing desk

--- a/src/_posts/2014/2014-09-14-404-pages.md
+++ b/src/_posts/2014/2014-09-14-404-pages.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-09-14 00:13:00 +0000
 layout: post
+date: 2014-09-14 00:13:00 +0000
 tags: pelican python
 title: Playing with 404 pages
 ---

--- a/src/_posts/2014/2014-09-14-404-pages.md
+++ b/src/_posts/2014/2014-09-14-404-pages.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-09-14 00:13:00 +0000
 layout: post
-slug: 404-pages
 tags: pelican python
 title: Playing with 404 pages
 ---

--- a/src/_posts/2014/2014-10-01-notes-on-tumblr.md
+++ b/src/_posts/2014/2014-10-01-notes-on-tumblr.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-10-01 18:34:00 +0000
 layout: post
+date: 2014-10-01 18:34:00 +0000
 tags: tumblr
 title: Notes on Tumblr
 ---

--- a/src/_posts/2014/2014-10-28-virtualfish.md
+++ b/src/_posts/2014/2014-10-28-virtualfish.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-10-28 20:06:00 +0000
 layout: post
+date: 2014-10-28 20:06:00 +0000
 tags: fish-shell shell-scripting
 title: '"Missing argument at index 2" in fish'
 ---

--- a/src/_posts/2014/2014-10-28-virtualfish.md
+++ b/src/_posts/2014/2014-10-28-virtualfish.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-10-28 20:06:00 +0000
 layout: post
-slug: virtualfish
 tags: fish-shell shell-scripting
 title: '"Missing argument at index 2" in fish'
 ---

--- a/src/_posts/2014/2014-11-02-ranged-strings.md
+++ b/src/_posts/2014/2014-11-02-ranged-strings.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-11-02 16:19:00 +0000
 layout: post
-slug: ranged-strings
 tags: python
 title: Unpacking sets and ranges from a single string
 ---

--- a/src/_posts/2014/2014-11-02-ranged-strings.md
+++ b/src/_posts/2014/2014-11-02-ranged-strings.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-11-02 16:19:00 +0000
 layout: post
+date: 2014-11-02 16:19:00 +0000
 tags: python
 title: Unpacking sets and ranges from a single string
 ---

--- a/src/_posts/2014/2014-12-06-mathis-cars.md
+++ b/src/_posts/2014/2014-12-06-mathis-cars.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-06 09:08:00 +0000
 layout: post
+date: 2014-12-06 09:08:00 +0000
 link: http://ignorethecode.net/blog/2014/12/04/apple_carplay_android_auto/
 title: Lukas Mathis on iOS CarPlay and Android Auto
 ---

--- a/src/_posts/2014/2014-12-06-mathis-cars.md
+++ b/src/_posts/2014/2014-12-06-mathis-cars.md
@@ -2,7 +2,6 @@
 date: 2014-12-06 09:08:00 +0000
 layout: post
 link: http://ignorethecode.net/blog/2014/12/04/apple_carplay_android_auto/
-slug: mathis-cars
 title: Lukas Mathis on iOS CarPlay and Android Auto
 ---
 

--- a/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
+++ b/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-06 22:42:00 +0000
 layout: post
+date: 2014-12-06 22:42:00 +0000
 link: http://gouwens.net/skeletors-all-the-way-down
 tags: skeletor podcasts
 title: Skeletors All the Way Down

--- a/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
+++ b/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
@@ -2,7 +2,6 @@
 date: 2014-12-06 22:42:00 +0000
 layout: post
 link: http://gouwens.net/skeletors-all-the-way-down
-slug: skeletors-all-the-way-down
 tags: skeletor podcasts
 title: Skeletors All the Way Down
 ---

--- a/src/_posts/2014/2014-12-10-acronyms.md
+++ b/src/_posts/2014/2014-12-10-acronyms.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-10 08:12:00 +0000
 layout: post
+date: 2014-12-10 08:12:00 +0000
 tags: python
 title: Acronyms
 ---

--- a/src/_posts/2014/2014-12-13-kitchen-sink-security.md
+++ b/src/_posts/2014/2014-12-13-kitchen-sink-security.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-12-13 07:37:00 +0000
 layout: post
-slug: kitchen-sink-security
 title: Kitchen sink security
 ---
 

--- a/src/_posts/2014/2014-12-13-kitchen-sink-security.md
+++ b/src/_posts/2014/2014-12-13-kitchen-sink-security.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-13 07:37:00 +0000
 layout: post
+date: 2014-12-13 07:37:00 +0000
 title: Kitchen sink security
 ---
 

--- a/src/_posts/2014/2014-12-19-golems.md
+++ b/src/_posts/2014/2014-12-19-golems.md
@@ -2,7 +2,6 @@
 date: 2014-12-19 12:00:00 +0000
 layout: post
 link: http://worldbuilding.stackexchange.com/q/2906/2575
-slug: golems
 title: How could Golems best be used to defend a modern day city of Prague?
 ---
 

--- a/src/_posts/2014/2014-12-19-golems.md
+++ b/src/_posts/2014/2014-12-19-golems.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-19 12:00:00 +0000
 layout: post
+date: 2014-12-19 12:00:00 +0000
 link: http://worldbuilding.stackexchange.com/q/2906/2575
 title: How could Golems best be used to defend a modern day city of Prague?
 ---

--- a/src/_posts/2014/2014-12-28-imessage-export.md
+++ b/src/_posts/2014/2014-12-28-imessage-export.md
@@ -2,7 +2,6 @@
 date: 2014-12-28 13:00:00 +0000
 layout: post
 link: https://github.com/alexwlchan/imessage-archive
-slug: imessage-export
 tags: os-x python
 title: A script for exporting from iMessage
 ---

--- a/src/_posts/2014/2014-12-28-imessage-export.md
+++ b/src/_posts/2014/2014-12-28-imessage-export.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-28 13:00:00 +0000
 layout: post
+date: 2014-12-28 13:00:00 +0000
 link: https://github.com/alexwlchan/imessage-archive
 tags: os-x python
 title: A script for exporting from iMessage

--- a/src/_posts/2014/2014-12-28-war-on-christmas.md
+++ b/src/_posts/2014/2014-12-28-war-on-christmas.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-28 12:00:00 +0000
 layout: post
+date: 2014-12-28 12:00:00 +0000
 link: http://www.motherjones.com/media/2013/12/war-on-christmas-north-pole-invasion
 title: What would happen if we really went to war against Christmas?
 ---

--- a/src/_posts/2014/2014-12-28-war-on-christmas.md
+++ b/src/_posts/2014/2014-12-28-war-on-christmas.md
@@ -2,7 +2,6 @@
 date: 2014-12-28 12:00:00 +0000
 layout: post
 link: http://www.motherjones.com/media/2013/12/war-on-christmas-north-pole-invasion
-slug: war-on-christmas
 title: What would happen if we really went to war against Christmas?
 ---
 

--- a/src/_posts/2014/2014-12-29-pelican-linkposts.md
+++ b/src/_posts/2014/2014-12-29-pelican-linkposts.md
@@ -1,6 +1,6 @@
 ---
-date: 2014-12-29 08:26:00 +0000
 layout: post
+date: 2014-12-29 08:26:00 +0000
 tags: pelican python
 title: RSS linkposts in Pelican
 ---

--- a/src/_posts/2014/2014-12-29-pelican-linkposts.md
+++ b/src/_posts/2014/2014-12-29-pelican-linkposts.md
@@ -1,7 +1,6 @@
 ---
 date: 2014-12-29 08:26:00 +0000
 layout: post
-slug: pelican-linkposts
 tags: pelican python
 title: RSS linkposts in Pelican
 ---

--- a/src/_posts/2015/2015-01-06-bbfc-podcast.md
+++ b/src/_posts/2015/2015-01-06-bbfc-podcast.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-01-06 21:22:00 +0000
 layout: post
+date: 2015-01-06 21:22:00 +0000
 link: http://www.empireonline.com/news/story.asp?NID=37746
 tags: podcasts
 title: Empire's BBFC Ratings Podcast Special

--- a/src/_posts/2015/2015-01-06-bbfc-podcast.md
+++ b/src/_posts/2015/2015-01-06-bbfc-podcast.md
@@ -2,7 +2,6 @@
 date: 2015-01-06 21:22:00 +0000
 layout: post
 link: http://www.empireonline.com/news/story.asp?NID=37746
-slug: bbfc-podcast
 tags: podcasts
 title: Empire's BBFC Ratings Podcast Special
 ---

--- a/src/_posts/2015/2015-01-16-govuk.md
+++ b/src/_posts/2015/2015-01-16-govuk.md
@@ -2,7 +2,6 @@
 date: 2015-01-16 20:55:00 +0000
 layout: post
 link: https://www.gov.uk/register-to-vote
-slug: govuk
 tags: politics
 title: "Register to vote \u2013 GOV.UK"
 ---

--- a/src/_posts/2015/2015-01-16-govuk.md
+++ b/src/_posts/2015/2015-01-16-govuk.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-01-16 20:55:00 +0000
 layout: post
+date: 2015-01-16 20:55:00 +0000
 link: https://www.gov.uk/register-to-vote
 tags: politics
 title: "Register to vote \u2013 GOV.UK"

--- a/src/_posts/2015/2015-01-25-kings-cross-problems.md
+++ b/src/_posts/2015/2015-01-25-kings-cross-problems.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-01-25 16:26:00 +0000
 layout: post
+date: 2015-01-25 16:26:00 +0000
 link: http://www.londonreconnections.com/2015/know-run-story-behind-xmas-kings-cross-problems/
 title: What went wrong at King's Cross over Christmas?
 ---

--- a/src/_posts/2015/2015-01-25-kings-cross-problems.md
+++ b/src/_posts/2015/2015-01-25-kings-cross-problems.md
@@ -2,7 +2,6 @@
 date: 2015-01-25 16:26:00 +0000
 layout: post
 link: http://www.londonreconnections.com/2015/know-run-story-behind-xmas-kings-cross-problems/
-slug: kings-cross-problems
 title: What went wrong at King's Cross over Christmas?
 ---
 

--- a/src/_posts/2015/2015-02-09-swift-let.md
+++ b/src/_posts/2015/2015-02-09-swift-let.md
@@ -2,7 +2,6 @@
 date: 2015-02-09 21:09:00 +0000
 layout: post
 link: https://developer.apple.com/swift/blog/?id=22
-slug: swift-let
 tags: swift
 title: Swift 1.2 improves the "let" keyword, and other improvements
 ---

--- a/src/_posts/2015/2015-02-09-swift-let.md
+++ b/src/_posts/2015/2015-02-09-swift-let.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-02-09 21:09:00 +0000
 layout: post
+date: 2015-02-09 21:09:00 +0000
 link: https://developer.apple.com/swift/blog/?id=22
 tags: swift
 title: Swift 1.2 improves the "let" keyword, and other improvements

--- a/src/_posts/2015/2015-02-12-lists.md
+++ b/src/_posts/2015/2015-02-12-lists.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-02-12 12:00:00 +0000
 layout: post
-slug: lists
 summary: A bookmarklet to add checkboxes to lists in the browser.
 tags: javascript
 title: Adding checkboxes to lists

--- a/src/_posts/2015/2015-02-12-lists.md
+++ b/src/_posts/2015/2015-02-12-lists.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-02-12 12:00:00 +0000
 layout: post
+date: 2015-02-12 12:00:00 +0000
 summary: A bookmarklet to add checkboxes to lists in the browser.
 tags: javascript
 title: Adding checkboxes to lists

--- a/src/_posts/2015/2015-02-22-1password.md
+++ b/src/_posts/2015/2015-02-22-1password.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-02-22 12:00:00 +0000
 layout: post
+date: 2015-02-22 12:00:00 +0000
 title: Tidying up my 1Password
 ---
 

--- a/src/_posts/2015/2015-02-22-1password.md
+++ b/src/_posts/2015/2015-02-22-1password.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-02-22 12:00:00 +0000
 layout: post
-slug: 1password
 title: Tidying up my 1Password
 ---
 

--- a/src/_posts/2015/2015-02-22-flask-notes.md
+++ b/src/_posts/2015/2015-02-22-flask-notes.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-02-22 08:00:00 +0000
 layout: post
+date: 2015-02-22 08:00:00 +0000
 link: https://charlesleifer.com/blog/saturday-morning-hack-a-little-note-taking-app-with-flask/
 tags: python
 title: A Flask app for taking notes

--- a/src/_posts/2015/2015-02-22-flask-notes.md
+++ b/src/_posts/2015/2015-02-22-flask-notes.md
@@ -2,7 +2,6 @@
 date: 2015-02-22 08:00:00 +0000
 layout: post
 link: https://charlesleifer.com/blog/saturday-morning-hack-a-little-note-taking-app-with-flask/
-slug: flask-notes
 tags: python
 title: A Flask app for taking notes
 ---

--- a/src/_posts/2015/2015-03-05-python-firewall.md
+++ b/src/_posts/2015/2015-03-05-python-firewall.md
@@ -2,7 +2,6 @@
 date: 2015-03-05 08:24:00 +0000
 layout: post
 link: http://stackoverflow.com/q/19688841/1558022
-slug: python-firewall
 tags: python, os x
 title: Adding Python to the OS X firewall
 ---

--- a/src/_posts/2015/2015-03-05-python-firewall.md
+++ b/src/_posts/2015/2015-03-05-python-firewall.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-03-05 08:24:00 +0000
 layout: post
+date: 2015-03-05 08:24:00 +0000
 link: http://stackoverflow.com/q/19688841/1558022
 tags: python, os x
 title: Adding Python to the OS X firewall

--- a/src/_posts/2015/2015-03-07-pygmentizr.md
+++ b/src/_posts/2015/2015-03-07-pygmentizr.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-03-07 10:44:00 +0000
 layout: post
+date: 2015-03-07 10:44:00 +0000
 summary: A web app for applying syntax highlighting to code using the Pygments library.
 tags: python
 title: Pygmentizr

--- a/src/_posts/2015/2015-03-07-pygmentizr.md
+++ b/src/_posts/2015/2015-03-07-pygmentizr.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-03-07 10:44:00 +0000
 layout: post
-slug: pygmentizr
 summary: A web app for applying syntax highlighting to code using the Pygments library.
 tags: python
 title: Pygmentizr

--- a/src/_posts/2015/2015-03-29-exam-advice.md
+++ b/src/_posts/2015/2015-03-29-exam-advice.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-03-29 13:30:00 +0000
 layout: post
+date: 2015-03-29 13:30:00 +0000
 link: http://alexwlchan.net/exams
 summary: Some advice for students sitting technical exams
 tags: maths

--- a/src/_posts/2015/2015-03-29-exam-advice.md
+++ b/src/_posts/2015/2015-03-29-exam-advice.md
@@ -2,7 +2,6 @@
 date: 2015-03-29 13:30:00 +0000
 layout: post
 link: http://alexwlchan.net/exams
-slug: exam-advice
 summary: Some advice for students sitting technical exams
 tags: maths
 title: Some exam advice

--- a/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
+++ b/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-05-16 11:51:00 +0000
 layout: post
+date: 2015-05-16 11:51:00 +0000
 summary: How to paste text directly from OS X into the iOS Simulator.
 tags: os-x
 title: One-step paste in the iOS Simulator

--- a/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
+++ b/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-05-16 11:51:00 +0000
 layout: post
-slug: one-step-paste-simulator
 summary: How to paste text directly from OS X into the iOS Simulator.
 tags: os-x
 title: One-step paste in the iOS Simulator

--- a/src/_posts/2015/2015-05-17-nvalt-and-marked.md
+++ b/src/_posts/2015/2015-05-17-nvalt-and-marked.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-05-17 20:16:00 +0000
 layout: post
-slug: nvalt-and-marked
 summary: A Python script that takes a note from nvALT and opens it in Marked.
 tags: python
 title: Previewing notes from nvALT in Marked

--- a/src/_posts/2015/2015-05-17-nvalt-and-marked.md
+++ b/src/_posts/2015/2015-05-17-nvalt-and-marked.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-05-17 20:16:00 +0000
 layout: post
+date: 2015-05-17 20:16:00 +0000
 summary: A Python script that takes a note from nvALT and opens it in Marked.
 tags: python
 title: Previewing notes from nvALT in Marked

--- a/src/_posts/2015/2015-05-22-raft-algorithm.md
+++ b/src/_posts/2015/2015-05-22-raft-algorithm.md
@@ -2,7 +2,6 @@
 date: 2015-05-22 17:40:00 +0000
 layout: post
 link: http://thesecretlivesofdata.com/raft/
-slug: raft-algorithm
 summary: A visualisation of the Raft consensus algorithm.
 title: <em>The Secret Lives of Data</em>, a visualisation of the Raft algorithm
 ---

--- a/src/_posts/2015/2015-05-22-raft-algorithm.md
+++ b/src/_posts/2015/2015-05-22-raft-algorithm.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-05-22 17:40:00 +0000
 layout: post
+date: 2015-05-22 17:40:00 +0000
 link: http://thesecretlivesofdata.com/raft/
 summary: A visualisation of the Raft consensus algorithm.
 title: <em>The Secret Lives of Data</em>, a visualisation of the Raft algorithm

--- a/src/_posts/2015/2015-05-26-github-contributions.md
+++ b/src/_posts/2015/2015-05-26-github-contributions.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-05-26 19:13:00 +0000
 layout: post
+date: 2015-05-26 19:13:00 +0000
 summary: I made a clone of GitHub's Contributions graph to use as a motivational tool.
 title: Cloning GitHub's Contributions chart
 ---

--- a/src/_posts/2015/2015-05-26-github-contributions.md
+++ b/src/_posts/2015/2015-05-26-github-contributions.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-05-26 19:13:00 +0000
 layout: post
-slug: github-contributions
 summary: I made a clone of GitHub's Contributions graph to use as a motivational tool.
 title: Cloning GitHub's Contributions chart
 ---

--- a/src/_posts/2015/2015-06-02-git-info-exclude.md
+++ b/src/_posts/2015/2015-06-02-git-info-exclude.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-06-02 18:09:00 +0000
 layout: post
-slug: git-info-exclude
 summary: Another way to ignore untracked files in Git.
 tags: git
 title: 'Useful Git features: a per-clone exclude file'

--- a/src/_posts/2015/2015-06-02-git-info-exclude.md
+++ b/src/_posts/2015/2015-06-02-git-info-exclude.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-06-02 18:09:00 +0000
 layout: post
+date: 2015-06-02 18:09:00 +0000
 summary: Another way to ignore untracked files in Git.
 tags: git
 title: 'Useful Git features: a per-clone exclude file'

--- a/src/_posts/2015/2015-06-22-safer-file-copying.md
+++ b/src/_posts/2015/2015-06-22-safer-file-copying.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-06-22 23:20:00 +0000
 layout: post
+date: 2015-06-22 23:20:00 +0000
 summary: A Python script for non-destructive file copying/moving.
 tags: python
 title: Safer file copying in Python

--- a/src/_posts/2015/2015-06-22-safer-file-copying.md
+++ b/src/_posts/2015/2015-06-22-safer-file-copying.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-06-22 23:20:00 +0000
 layout: post
-slug: safer-file-copying
 summary: A Python script for non-destructive file copying/moving.
 tags: python
 title: Safer file copying in Python

--- a/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
+++ b/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-06-29 17:55:00 +0000
 layout: post
+date: 2015-06-29 17:55:00 +0000
 summary: Configuring an IPython notebook server that is always running and easily
   accessible in Windows.
 tags: python windows

--- a/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
+++ b/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-06-29 17:55:00 +0000
 layout: post
-slug: persistent-ipython-notebooks
 summary: Configuring an IPython notebook server that is always running and easily
   accessible in Windows.
 tags: python windows

--- a/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
+++ b/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
@@ -2,7 +2,6 @@
 date: 2015-07-27 20:36:00 +0000
 layout: post
 link: http://redsymbol.net/articles/bash-exit-traps/
-slug: exit-traps-in-bash
 tags: bash shell-scripting
 title: 'Useful Bash features: exit traps'
 ---

--- a/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
+++ b/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-07-27 20:36:00 +0000
 layout: post
+date: 2015-07-27 20:36:00 +0000
 link: http://redsymbol.net/articles/bash-exit-traps/
 tags: bash shell-scripting
 title: 'Useful Bash features: exit traps'

--- a/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
+++ b/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-08-19 22:55:00 +0000
 layout: post
+date: 2015-08-19 22:55:00 +0000
 link: http://finduntaggedtumblrposts.com
 summary: A new version of my site for finding untagged Tumblr posts.
 tags: tumblr

--- a/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
+++ b/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
@@ -2,7 +2,6 @@
 date: 2015-08-19 22:55:00 +0000
 layout: post
 link: http://finduntaggedtumblrposts.com
-slug: untagged-tumblr-v2
 summary: A new version of my site for finding untagged Tumblr posts.
 tags: tumblr
 title: Finding even more untagged posts on Tumblr

--- a/src/_posts/2015/2015-09-06-effective-python.md
+++ b/src/_posts/2015/2015-09-06-effective-python.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-09-06 18:42:00 +0000
 layout: post
-slug: effective-python
 summary: A review of Effective Python, by Brett Slatkin.
 tags: python books
 title: 'Review: Effective Python'

--- a/src/_posts/2015/2015-09-06-effective-python.md
+++ b/src/_posts/2015/2015-09-06-effective-python.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-09-06 18:42:00 +0000
 layout: post
+date: 2015-09-06 18:42:00 +0000
 summary: A review of Effective Python, by Brett Slatkin.
 tags: python books
 title: 'Review: Effective Python'

--- a/src/_posts/2015/2015-09-16-http2-by-stealth.md
+++ b/src/_posts/2015/2015-09-16-http2-by-stealth.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-09-16 20:59:00 +0000
 layout: post
-slug: http2-by-stealth
 summary: Apple has quietly adopted HTTP/2 in iOS 9 and El Capitan, and (almost) nobody
   noticed.
 tags: os-x http/2

--- a/src/_posts/2015/2015-09-16-http2-by-stealth.md
+++ b/src/_posts/2015/2015-09-16-http2-by-stealth.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-09-16 20:59:00 +0000
 layout: post
+date: 2015-09-16 20:59:00 +0000
 summary: Apple has quietly adopted HTTP/2 in iOS 9 and El Capitan, and (almost) nobody
   noticed.
 tags: os-x http/2

--- a/src/_posts/2015/2015-09-20-spotlight-suggestions.md
+++ b/src/_posts/2015/2015-09-20-spotlight-suggestions.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-09-20 09:32:00 +0000
 layout: post
-slug: spotlight-suggestions
 summary: In iOS 9, you can turn off the News in Spotlight by toggling Spotlight Suggestions.
   But what else does this disable?
 tags: ios

--- a/src/_posts/2015/2015-09-20-spotlight-suggestions.md
+++ b/src/_posts/2015/2015-09-20-spotlight-suggestions.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-09-20 09:32:00 +0000
 layout: post
+date: 2015-09-20 09:32:00 +0000
 summary: In iOS 9, you can turn off the News in Spotlight by toggling Spotlight Suggestions.
   But what else does this disable?
 tags: ios

--- a/src/_posts/2015/2015-10-12-getting-started-testing.md
+++ b/src/_posts/2015/2015-10-12-getting-started-testing.md
@@ -2,7 +2,6 @@
 date: 2015-10-12 08:23:00 +0000
 layout: post
 link: https://www.youtube.com/watch?v=FxSsnHeWQBY
-slug: getting-started-testing
 tags: python
 title: Getting Started Testing, by Ned Batchelder
 ---

--- a/src/_posts/2015/2015-10-12-getting-started-testing.md
+++ b/src/_posts/2015/2015-10-12-getting-started-testing.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-10-12 08:23:00 +0000
 layout: post
+date: 2015-10-12 08:23:00 +0000
 link: https://www.youtube.com/watch?v=FxSsnHeWQBY
 tags: python
 title: Getting Started Testing, by Ned Batchelder

--- a/src/_posts/2015/2015-11-02-quick-shell-docker.md
+++ b/src/_posts/2015/2015-11-02-quick-shell-docker.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-02 22:07:00 +0000
 layout: post
+date: 2015-11-02 22:07:00 +0000
 summary: A Bash function for quickly getting shell access to Docker containers.
 tags: docker bash shell-scripting
 title: Quick shell access for Docker containers

--- a/src/_posts/2015/2015-11-02-quick-shell-docker.md
+++ b/src/_posts/2015/2015-11-02-quick-shell-docker.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-11-02 22:07:00 +0000
 layout: post
-slug: quick-shell-docker
 summary: A Bash function for quickly getting shell access to Docker containers.
 tags: docker bash shell-scripting
 title: Quick shell access for Docker containers

--- a/src/_posts/2015/2015-11-03-bbc-micro-bit.md
+++ b/src/_posts/2015/2015-11-03-bbc-micro-bit.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-03 22:12:00 +0000
 layout: post
+date: 2015-11-03 22:12:00 +0000
 link: http://www.bbc.co.uk/programmes/articles/4hVG2Br1W1LKCmw8nSm9WnQ/introducing-the-bbc-micro-bit
 tags: python
 title: Python and the BBC micro:bit

--- a/src/_posts/2015/2015-11-03-bbc-micro-bit.md
+++ b/src/_posts/2015/2015-11-03-bbc-micro-bit.md
@@ -2,7 +2,6 @@
 date: 2015-11-03 22:12:00 +0000
 layout: post
 link: http://www.bbc.co.uk/programmes/articles/4hVG2Br1W1LKCmw8nSm9WnQ/introducing-the-bbc-micro-bit
-slug: bbc-micro-bit
 tags: python
 title: Python and the BBC micro:bit
 ---

--- a/src/_posts/2015/2015-11-13-beyond-pep8.md
+++ b/src/_posts/2015/2015-11-13-beyond-pep8.md
@@ -2,7 +2,6 @@
 date: 2015-11-13 07:40:00 +0000
 layout: post
 link: https://www.youtube.com/watch?v=wf-BqAjZb8M
-slug: beyond-pep8
 tags: python
 title: 'Beyond PEP 8: Best practices for beautiful intelligible code'
 ---

--- a/src/_posts/2015/2015-11-13-beyond-pep8.md
+++ b/src/_posts/2015/2015-11-13-beyond-pep8.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-13 07:40:00 +0000
 layout: post
+date: 2015-11-13 07:40:00 +0000
 link: https://www.youtube.com/watch?v=wf-BqAjZb8M
 tags: python
 title: 'Beyond PEP 8: Best practices for beautiful intelligible code'

--- a/src/_posts/2015/2015-11-14-operation-fortitude.md
+++ b/src/_posts/2015/2015-11-14-operation-fortitude.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-14 22:02:00 +0000
 layout: post
+date: 2015-11-14 22:02:00 +0000
 title: Email with a purpose
 ---
 

--- a/src/_posts/2015/2015-11-14-operation-fortitude.md
+++ b/src/_posts/2015/2015-11-14-operation-fortitude.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-11-14 22:02:00 +0000
 layout: post
-slug: operation-fortitude
 title: Email with a purpose
 ---
 

--- a/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
+++ b/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-11-15 21:50:00 +0000
 layout: post
-slug: export-urls-from-safari-reading-list
 summary: A Python script for getting a list of URLs from Safari Reading List.
 tags: os-x python
 title: Export a list of URLs from Safari Reading List

--- a/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
+++ b/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-15 21:50:00 +0000
 layout: post
+date: 2015-11-15 21:50:00 +0000
 summary: A Python script for getting a list of URLs from Safari Reading List.
 tags: os-x python
 title: Export a list of URLs from Safari Reading List

--- a/src/_posts/2015/2015-11-30-backups-and-docker.md
+++ b/src/_posts/2015/2015-11-30-backups-and-docker.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-11-30 22:39:00 +0000
 layout: post
-slug: backups-and-docker
 summary: The Docker folder on your computer can quickly fill up space. Don't forget
   to exclude it from backups.
 tags: docker

--- a/src/_posts/2015/2015-11-30-backups-and-docker.md
+++ b/src/_posts/2015/2015-11-30-backups-and-docker.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-11-30 22:39:00 +0000
 layout: post
+date: 2015-11-30 22:39:00 +0000
 summary: The Docker folder on your computer can quickly fill up space. Don't forget
   to exclude it from backups.
 tags: docker

--- a/src/_posts/2015/2015-12-10-simpler-syndication.md
+++ b/src/_posts/2015/2015-12-10-simpler-syndication.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-12-10 08:15:00 +0000
 layout: post
+date: 2015-12-10 08:15:00 +0000
 link: http://leancrew.com/all-this/2015/11/simpler-syndication/
 tags: python
 title: Simpler syndication, by Dr. Drang

--- a/src/_posts/2015/2015-12-10-simpler-syndication.md
+++ b/src/_posts/2015/2015-12-10-simpler-syndication.md
@@ -2,7 +2,6 @@
 date: 2015-12-10 08:15:00 +0000
 layout: post
 link: http://leancrew.com/all-this/2015/11/simpler-syndication/
-slug: simpler-syndication
 tags: python
 title: Simpler syndication, by Dr. Drang
 ---

--- a/src/_posts/2015/2015-12-13-pretty-print.md
+++ b/src/_posts/2015/2015-12-13-pretty-print.md
@@ -1,6 +1,6 @@
 ---
-date: 2015-12-13 17:15:00 +0000
 layout: post
+date: 2015-12-13 17:15:00 +0000
 tags: shell-scripting
 title: Pretty printing JSON and XML in the shell
 ---

--- a/src/_posts/2015/2015-12-13-pretty-print.md
+++ b/src/_posts/2015/2015-12-13-pretty-print.md
@@ -1,7 +1,6 @@
 ---
 date: 2015-12-13 17:15:00 +0000
 layout: post
-slug: pretty-print
 tags: shell-scripting
 title: Pretty printing JSON and XML in the shell
 ---

--- a/src/_posts/2016/2016-01-03-incomparable-best-of.md
+++ b/src/_posts/2016/2016-01-03-incomparable-best-of.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-01-03 16:53:00 +0000
 layout: post
+date: 2016-01-03 16:53:00 +0000
 tags: podcasts
 title: The Incomparable's "Best Of" 2015
 ---

--- a/src/_posts/2016/2016-01-03-incomparable-best-of.md
+++ b/src/_posts/2016/2016-01-03-incomparable-best-of.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-01-03 16:53:00 +0000
 layout: post
-slug: incomparable-best-of
 tags: podcasts
 title: The Incomparable's "Best Of" 2015
 ---

--- a/src/_posts/2016/2016-01-17-fusion-drive.md
+++ b/src/_posts/2016/2016-01-17-fusion-drive.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-01-17 13:13:00 +0000
 layout: post
-slug: fusion-drive
 summary: If you send a Mac with a Fusion Drive to get repaired to the Apple Store,
   make sure it comes back in one piece.
 title: A cautionary tale about Fusion Drive repairs

--- a/src/_posts/2016/2016-01-17-fusion-drive.md
+++ b/src/_posts/2016/2016-01-17-fusion-drive.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-01-17 13:13:00 +0000
 layout: post
+date: 2016-01-17 13:13:00 +0000
 summary: If you send a Mac with a Fusion Drive to get repaired to the Apple Store,
   make sure it comes back in one piece.
 title: A cautionary tale about Fusion Drive repairs

--- a/src/_posts/2016/2016-01-20-skeletor-2015.md
+++ b/src/_posts/2016/2016-01-20-skeletor-2015.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-01-20 19:38:00 +0000
 layout: post
+date: 2016-01-20 19:38:00 +0000
 link: /skeletor
 summary: Updating the Skeletor clip loop chart for the 2015 Clip Show.
 tags: skeletor podcasts

--- a/src/_posts/2016/2016-01-20-skeletor-2015.md
+++ b/src/_posts/2016/2016-01-20-skeletor-2015.md
@@ -2,7 +2,6 @@
 date: 2016-01-20 19:38:00 +0000
 layout: post
 link: /skeletor
-slug: skeletor-2015
 summary: Updating the Skeletor clip loop chart for the 2015 Clip Show.
 tags: skeletor podcasts
 title: The Skeletor clip loop, 2015 edition

--- a/src/_posts/2016/2016-01-25-harry-potter-ipod.md
+++ b/src/_posts/2016/2016-01-25-harry-potter-ipod.md
@@ -2,7 +2,6 @@
 date: 2016-01-25 17:22:00 +0000
 layout: post
 link: http://www.512pixels.net/blog/2016/1/the-harry-potter-collectors-ipod
-slug: harry-potter-ipod
 tags: ipod harry-potter
 title: The Harry Potter Collector's iPod
 ---

--- a/src/_posts/2016/2016-01-25-harry-potter-ipod.md
+++ b/src/_posts/2016/2016-01-25-harry-potter-ipod.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-01-25 17:22:00 +0000
 layout: post
+date: 2016-01-25 17:22:00 +0000
 link: http://www.512pixels.net/blog/2016/1/the-harry-potter-collectors-ipod
 tags: ipod harry-potter
 title: The Harry Potter Collector's iPod

--- a/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
+++ b/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-02-09 12:49:00 +0000
 layout: post
-slug: saved-by-the-prompt
 summary: It turns out that an SSH client on your iPhone can be really handy.
 tags: ios
 title: Saved by the Prompt

--- a/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
+++ b/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-02-09 12:49:00 +0000
 layout: post
+date: 2016-02-09 12:49:00 +0000
 summary: It turns out that an SSH client on your iPhone can be really handy.
 tags: ios
 title: Saved by the Prompt

--- a/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
+++ b/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-02-24 08:16:00 +0000
 layout: post
+date: 2016-02-24 08:16:00 +0000
 summary: "I have some TextExpander snippets that I use to cut out words I don\u2019\
   t want to write."
 tags: textexpander writethedocs

--- a/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
+++ b/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-02-24 08:16:00 +0000
 layout: post
-slug: how-i-use-textexpander-to-curb-my-language
 summary: "I have some TextExpander snippets that I use to cut out words I don\u2019\
   t want to write."
 tags: textexpander writethedocs

--- a/src/_posts/2016/2016-03-08-backup-paranoia.md
+++ b/src/_posts/2016/2016-03-08-backup-paranoia.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-03-08 08:52:00 +0000
 layout: post
+date: 2016-03-08 08:52:00 +0000
 summary: Running a backup is good protection against data loss, but it's not perfect.  I
   take extra measures to ensure I have really safe backups.
 tags: backups

--- a/src/_posts/2016/2016-03-27-exclusive-create-python.md
+++ b/src/_posts/2016/2016-03-27-exclusive-create-python.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-03-27 10:33:00 +0000
 layout: post
+date: 2016-03-27 10:33:00 +0000
 summary: If you want to create a file, but only if it doesn't already exist, Python
   3 has a helpful new file mode `x`.
 tags: python

--- a/src/_posts/2016/2016-03-27-exclusive-create-python.md
+++ b/src/_posts/2016/2016-03-27-exclusive-create-python.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-03-27 10:33:00 +0000
 layout: post
-slug: exclusive-create-python
 summary: If you want to create a file, but only if it doesn't already exist, Python
   3 has a helpful new file mode `x`.
 tags: python

--- a/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
+++ b/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-03-29 07:56:00 +0000
 layout: post
+date: 2016-03-29 07:56:00 +0000
 summary: Using Alfred and a Python script to retrieve artwork from the iTunes, App
   and Mac App Stores.
 tags: alfred python

--- a/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
+++ b/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-03-29 07:56:00 +0000
 layout: post
-slug: itunes-images-with-alfred
 summary: Using Alfred and a Python script to retrieve artwork from the iTunes, App
   and Mac App Stores.
 tags: alfred python

--- a/src/_posts/2016/2016-04-08-regexes-are-code.md
+++ b/src/_posts/2016/2016-04-08-regexes-are-code.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-04-08 13:03:00 +0000
 layout: post
-slug: regexes-are-code
 summary: Regexes have a reputation for being unreadable monsters, but it doesn't have
   to be that way.
 tags: regex

--- a/src/_posts/2016/2016-04-08-regexes-are-code.md
+++ b/src/_posts/2016/2016-04-08-regexes-are-code.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-04-08 13:03:00 +0000
 layout: post
+date: 2016-04-08 13:03:00 +0000
 summary: Regexes have a reputation for being unreadable monsters, but it doesn't have
   to be that way.
 tags: regex

--- a/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
+++ b/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-04-16 14:32:00 +0000
 layout: post
-slug: hiding-the-youtube-search-bar
 summary: "I\u2019ve adapted my bookmarklet for tidying up Google Maps to hide the\
   \ YouTube search bar."
 tags: javascript

--- a/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
+++ b/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-04-16 14:32:00 +0000
 layout: post
+date: 2016-04-16 14:32:00 +0000
 summary: "I\u2019ve adapted my bookmarklet for tidying up Google Maps to hide the\
   \ YouTube search bar."
 tags: javascript

--- a/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
+++ b/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-05-01 19:55:00 +0000
 layout: post
+date: 2016-05-01 19:55:00 +0000
 summary: "Debugging a strange interaction between TextMate and OS X\u2019s security\
   \ system."
 tags: os-x textmate

--- a/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
+++ b/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-05-01 19:55:00 +0000
 layout: post
-slug: os-x-hates-textmate
 summary: "Debugging a strange interaction between TextMate and OS X\u2019s security\
   \ system."
 tags: os-x textmate

--- a/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf-.md
+++ b/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf-.md
@@ -3,7 +3,6 @@ date: 2016-05-05 21:03:00 +0000
 desc: "If for some reason you create a file called `-rf *`, it\u2019s possible to\
   \ delete it safely. But really, don\u2019t create it in the first place."
 layout: post
-slug: safely-deleting-a-file-called-rf-
 tags: linux shell-scripting
 title: "Safely deleting a file called \u2018-rf *\u2019"
 ---

--- a/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf-.md
+++ b/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf-.md
@@ -1,8 +1,8 @@
 ---
+layout: post
 date: 2016-05-05 21:03:00 +0000
 desc: "If for some reason you create a file called `-rf *`, it\u2019s possible to\
   \ delete it safely. But really, don\u2019t create it in the first place."
-layout: post
 tags: linux shell-scripting
 title: "Safely deleting a file called \u2018-rf *\u2019"
 ---

--- a/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
+++ b/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-05-10 12:41:00 +0000
 layout: post
-slug: python-smtplib-and-fastmail
 summary: A quick python-smtplib wrapper for sending emails through FastMail.
 tags: python
 title: A Python smtplib wrapper for FastMail

--- a/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
+++ b/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-05-10 12:41:00 +0000
 layout: post
+date: 2016-05-10 12:41:00 +0000
 summary: A quick python-smtplib wrapper for sending emails through FastMail.
 tags: python
 title: A Python smtplib wrapper for FastMail

--- a/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
+++ b/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-05-16 21:02:00 +0000
 layout: post
+date: 2016-05-16 21:02:00 +0000
 summary: A Python script for finding 404 errors in my Apache web logs - and by extension,
   broken pages.
 tags: python apache

--- a/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
+++ b/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-05-16 21:02:00 +0000
 layout: post
-slug: finding-404s-in-apache-logs
 summary: A Python script for finding 404 errors in my Apache web logs - and by extension,
   broken pages.
 tags: python apache

--- a/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
+++ b/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
@@ -2,7 +2,6 @@
 date: 2016-06-09 08:29:00 +0000
 layout: post
 link: /talks/hypothesis-intro/
-slug: introduction-to-property-based-testing
 summary: Slides from my talk about property-based testing at CamPUG.
 tags: python talks
 title: Introduction to property-based testing

--- a/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
+++ b/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-06-09 08:29:00 +0000
 layout: post
+date: 2016-06-09 08:29:00 +0000
 link: /talks/hypothesis-intro/
 summary: Slides from my talk about property-based testing at CamPUG.
 tags: python talks

--- a/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
+++ b/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-06-16 08:50:00 +0000
 layout: post
+date: 2016-06-16 08:50:00 +0000
 summary: A Python script I wrote that let me sends web pages from my Mac and my iPhone
   to my Kindle.
 tags: python

--- a/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
+++ b/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-06-16 08:50:00 +0000
 layout: post
-slug: reading-web-pages-on-my-kindle
 summary: A Python script I wrote that let me sends web pages from my Mac and my iPhone
   to my Kindle.
 tags: python

--- a/src/_posts/2016/2016-06-23-toothbrush-subscriptions.md
+++ b/src/_posts/2016/2016-06-23-toothbrush-subscriptions.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-06-23 22:44:00 +0000
 layout: post
+date: 2016-06-23 22:44:00 +0000
 link: https://www.amazon.co.uk/Subscribe-Save-Health-Beauty-Grocery/b?ie=UTF8&node=423139031
 title: A subscription for my toothbrush
 ---

--- a/src/_posts/2016/2016-06-23-toothbrush-subscriptions.md
+++ b/src/_posts/2016/2016-06-23-toothbrush-subscriptions.md
@@ -2,7 +2,6 @@
 date: 2016-06-23 22:44:00 +0000
 layout: post
 link: https://www.amazon.co.uk/Subscribe-Save-Health-Beauty-Grocery/b?ie=UTF8&node=423139031
-slug: toothbrush-subscriptions
 title: A subscription for my toothbrush
 ---
 

--- a/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
+++ b/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-07-04 07:42:00 +0000
 layout: post
-slug: clearing-disk-space-on-os-x
 summary: "A few tools and utilities I\u2019ve been using to help clear disk space\
   \ on my Mac."
 tags: os-x

--- a/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
+++ b/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-07-04 07:42:00 +0000
 layout: post
+date: 2016-07-04 07:42:00 +0000
 summary: "A few tools and utilities I\u2019ve been using to help clear disk space\
   \ on my Mac."
 tags: os-x

--- a/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
+++ b/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-07-28 21:03:00 +0000
 layout: post
-slug: chasing-redirects-and-url-shorteners
 summary: A quick Python function to follow a redirect to its eventual conclusion.
 tags: python
 title: 'Python snippets: Chasing redirects and URL shorteners'

--- a/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
+++ b/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-07-28 21:03:00 +0000
 layout: post
+date: 2016-07-28 21:03:00 +0000
 summary: A quick Python function to follow a redirect to its eventual conclusion.
 tags: python
 title: 'Python snippets: Chasing redirects and URL shorteners'

--- a/src/_posts/2016/2016-08-07-clean-up-directories.md
+++ b/src/_posts/2016/2016-08-07-clean-up-directories.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-08-07 22:46:00 +0000
 layout: post
-slug: clean-up-directories
 summary: A pair of Python scripts I've been using to clean up my mess of directories.
 tags: python
 title: 'Python snippets: Cleaning up empty/nearly empty directories'

--- a/src/_posts/2016/2016-08-07-clean-up-directories.md
+++ b/src/_posts/2016/2016-08-07-clean-up-directories.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-08-07 22:46:00 +0000
 layout: post
+date: 2016-08-07 22:46:00 +0000
 summary: A pair of Python scripts I've been using to clean up my mess of directories.
 tags: python
 title: 'Python snippets: Cleaning up empty/nearly empty directories'

--- a/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
+++ b/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-08-19 23:34:00 +0000
 layout: post
+date: 2016-08-19 23:34:00 +0000
 tags: tumblr python
 title: 'Python snippets: Is a URL from a Tumblr post?'
 theme:

--- a/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
+++ b/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-08-19 23:34:00 +0000
 layout: post
-slug: is-a-url-from-tumblr
 tags: tumblr python
 title: 'Python snippets: Is a URL from a Tumblr post?'
 theme:

--- a/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
+++ b/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-08-31 20:05:00 +0000
 layout: post
-slug: dealing-with-query-strings
 tags: python
 title: 'Python snippet: dealing with query strings in URLs'
 theme:

--- a/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
+++ b/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-08-31 20:05:00 +0000
 layout: post
+date: 2016-08-31 20:05:00 +0000
 tags: python
 title: 'Python snippet: dealing with query strings in URLs'
 theme:

--- a/src/_posts/2016/2016-09-17-speech-to-text.md
+++ b/src/_posts/2016/2016-09-17-speech-to-text.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-09-17 22:08:00 +0000
 layout: post
+date: 2016-09-17 22:08:00 +0000
 summary: Live captioning of conference talks was an unexpected bonus at this year's
   PyCon UK.
 tags: pycon conferences

--- a/src/_posts/2016/2016-09-17-speech-to-text.md
+++ b/src/_posts/2016/2016-09-17-speech-to-text.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-09-17 22:08:00 +0000
 layout: post
-slug: speech-to-text
 summary: Live captioning of conference talks was an unexpected bonus at this year's
   PyCon UK.
 tags: pycon conferences

--- a/src/_posts/2016/2016-09-19-silence-is-golden.md
+++ b/src/_posts/2016/2016-09-19-silence-is-golden.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-09-19 10:17:00 +0000
 layout: post
+date: 2016-09-19 10:17:00 +0000
 summary: PyCon had a dedicated quiet room for people to get some downtime, and I think
   it's a great idea.
 tags: pycon conferences

--- a/src/_posts/2016/2016-09-23-please-use-aspell.md
+++ b/src/_posts/2016/2016-09-23-please-use-aspell.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-09-23 07:40:00 +0000
 layout: post
-slug: please-use-aspell
 tags: writethedocs
 title: aspell, a command-line spell checker
 ---

--- a/src/_posts/2016/2016-09-23-please-use-aspell.md
+++ b/src/_posts/2016/2016-09-23-please-use-aspell.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-09-23 07:40:00 +0000
 layout: post
+date: 2016-09-23 07:40:00 +0000
 tags: writethedocs
 title: aspell, a command-line spell checker
 ---

--- a/src/_posts/2016/2016-09-30-travelling-tech-bag.md
+++ b/src/_posts/2016/2016-09-30-travelling-tech-bag.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-09-30 08:04:00 +0000
 layout: post
+date: 2016-09-30 08:04:00 +0000
 title: My travelling tech bag
 ---
 

--- a/src/_posts/2016/2016-09-30-travelling-tech-bag.md
+++ b/src/_posts/2016/2016-09-30-travelling-tech-bag.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-09-30 08:04:00 +0000
 layout: post
-slug: travelling-tech-bag
 title: My travelling tech bag
 ---
 

--- a/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
+++ b/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-10-01 21:23:00 +0000
 layout: post
+date: 2016-10-01 21:23:00 +0000
 tags: shell-scripting
 title: A shell alias for tallying data
 theme:

--- a/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
+++ b/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-10-01 21:23:00 +0000
 layout: post
-slug: a-shell-alias-for-tallying
 tags: shell-scripting
 title: A shell alias for tallying data
 theme:

--- a/src/_posts/2016/2016-10-08-why-i-use-pytest.md
+++ b/src/_posts/2016/2016-10-08-why-i-use-pytest.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-10-08 18:31:00 +0000
 layout: post
+date: 2016-10-08 18:31:00 +0000
 summary: Why py.test is my unit test framework of choice in Python.
 tags: python
 title: Why I use py.test

--- a/src/_posts/2016/2016-10-08-why-i-use-pytest.md
+++ b/src/_posts/2016/2016-10-08-why-i-use-pytest.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-10-08 18:31:00 +0000
 layout: post
-slug: why-i-use-pytest
 summary: Why py.test is my unit test framework of choice in Python.
 tags: python
 title: Why I use py.test

--- a/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
+++ b/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-10-21 12:18:00 +0000
 layout: post
-slug: tiling-the-plane-with-pillow
 summary: Using the Python Imaging Library to draw regular tilings of squares, triangles
   and hexagons.
 tags: python maths

--- a/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
+++ b/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-10-21 12:18:00 +0000
 layout: post
+date: 2016-10-21 12:18:00 +0000
 summary: Using the Python Imaging Library to draw regular tilings of squares, triangles
   and hexagons.
 tags: python maths

--- a/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
+++ b/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
@@ -2,7 +2,6 @@
 date: 2016-10-22 21:03:00 +0000
 hero: 2016/specktre_0slu5ilk.png
 layout: post
-slug: wallpapers-with-pillow
 summary: 'Take a regular tiling of the plane, and apply a random colouring: voila,
   a unique wallpaper, courtesy of the Python Imaging Library.'
 tags: python

--- a/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
+++ b/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
@@ -1,7 +1,7 @@
 ---
+layout: post
 date: 2016-10-22 21:03:00 +0000
 hero: 2016/specktre_0slu5ilk.png
-layout: post
 summary: 'Take a regular tiling of the plane, and apply a random colouring: voila,
   a unique wallpaper, courtesy of the Python Imaging Library.'
 tags: python

--- a/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
+++ b/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
@@ -1,4 +1,5 @@
 ---
+layout: post
 date:       2016-10-30 09:12:00 +0000
 layout:     post
 slug:       the-a-stands-for-asexual

--- a/src/_posts/2016/2016-11-16-you-should-use-keyring.md
+++ b/src/_posts/2016/2016-11-16-you-should-use-keyring.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-11-16 07:48:00 +0000
 layout: post
-slug: you-should-use-keyring
 summary: If you need to store passwords in a Python application, use the keyring module
   to keep them safe.
 tags: python security

--- a/src/_posts/2016/2016-11-16-you-should-use-keyring.md
+++ b/src/_posts/2016/2016-11-16-you-should-use-keyring.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-11-16 07:48:00 +0000
 layout: post
+date: 2016-11-16 07:48:00 +0000
 summary: If you need to store passwords in a Python application, use the keyring module
   to keep them safe.
 tags: python security

--- a/src/_posts/2016/2016-11-30-low-tech-productivity.md
+++ b/src/_posts/2016/2016-11-30-low-tech-productivity.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-11-30 19:07:00 +0000
 layout: post
-slug: low-tech-productivity
 summary: A few suggestions for "low tech devices" that aid in the process of generating
   ideas.
 tags: productivity

--- a/src/_posts/2016/2016-11-30-low-tech-productivity.md
+++ b/src/_posts/2016/2016-11-30-low-tech-productivity.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-11-30 19:07:00 +0000
 layout: post
+date: 2016-11-30 19:07:00 +0000
 summary: A few suggestions for "low tech devices" that aid in the process of generating
   ideas.
 tags: productivity

--- a/src/_posts/2016/2016-12-01-strings-are-terrible.md
+++ b/src/_posts/2016/2016-12-01-strings-are-terrible.md
@@ -1,7 +1,6 @@
 ---
 date: 2016-12-01 07:43:00 +0000
 layout: post
-slug: strings-are-terrible
 summary: 'Pop quiz: if I lowercase a string, does it still have the same length as
   the original string?'
 tags: unicode hypothesis python

--- a/src/_posts/2016/2016-12-01-strings-are-terrible.md
+++ b/src/_posts/2016/2016-12-01-strings-are-terrible.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-12-01 07:43:00 +0000
 layout: post
+date: 2016-12-01 07:43:00 +0000
 summary: 'Pop quiz: if I lowercase a string, does it still have the same length as
   the original string?'
 tags: unicode hypothesis python

--- a/src/_posts/2016/2016-12-28-slack-history.md
+++ b/src/_posts/2016/2016-12-28-slack-history.md
@@ -2,7 +2,6 @@
 date: 2016-12-28 10:29:00 +0000
 layout: post
 link: https://pypi.org/project/slack-history/
-slug: slack-history
 tags: python slack
 title: A tool for backing up your message history from Slack
 ---

--- a/src/_posts/2016/2016-12-28-slack-history.md
+++ b/src/_posts/2016/2016-12-28-slack-history.md
@@ -1,6 +1,6 @@
 ---
-date: 2016-12-28 10:29:00 +0000
 layout: post
+date: 2016-12-28 10:29:00 +0000
 link: https://pypi.org/project/slack-history/
 tags: python slack
 title: A tool for backing up your message history from Slack

--- a/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
+++ b/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-01-07 23:10:00 +0000
 layout: post
+date: 2017-01-07 23:10:00 +0000
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python,
   it might not be necessary.
 tags: python fandom

--- a/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
+++ b/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-01-14 16:09:00 +0000
 layout: post
-slug: experiments-with-ao3-and-python
 link: https://github.com/alexwlchan/ao3
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python,
   it might not be necessary.

--- a/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
+++ b/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-01-14 16:09:00 +0000
 layout: post
+date: 2017-01-14 16:09:00 +0000
 link: https://github.com/alexwlchan/ao3
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python,
   it might not be necessary.

--- a/src/_posts/2017/2017-02-08-backup-your-goodreads.md
+++ b/src/_posts/2017/2017-02-08-backup-your-goodreads.md
@@ -2,7 +2,6 @@
 date: 2017-02-08 20:41:00 +0000
 layout: post
 link: https://github.com/alexwlchan/backup-goodreads
-slug: backup-your-goodreads
 tags: python goodreads
 title: A script for backing up your Goodreads reviews
 ---

--- a/src/_posts/2017/2017-02-08-backup-your-goodreads.md
+++ b/src/_posts/2017/2017-02-08-backup-your-goodreads.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-02-08 20:41:00 +0000
 layout: post
+date: 2017-02-08 20:41:00 +0000
 link: https://github.com/alexwlchan/backup-goodreads
 tags: python goodreads
 title: A script for backing up your Goodreads reviews

--- a/src/_posts/2017/2017-02-11-backup-your-instapaper.md
+++ b/src/_posts/2017/2017-02-11-backup-your-instapaper.md
@@ -2,7 +2,6 @@
 date: 2017-02-11 12:00:00 +0000
 layout: post
 link: https://github.com/alexwlchan/backup-instapaper
-slug: backup-your-instapaper
 tags: python instapaper
 title: A script for backing up your Instapaper bookmarks
 ---

--- a/src/_posts/2017/2017-02-11-backup-your-instapaper.md
+++ b/src/_posts/2017/2017-02-11-backup-your-instapaper.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-02-11 12:00:00 +0000
 layout: post
+date: 2017-02-11 12:00:00 +0000
 link: https://github.com/alexwlchan/backup-instapaper
 tags: python instapaper
 title: A script for backing up your Instapaper bookmarks

--- a/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
+++ b/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-03-25 11:27:00 +0000
 layout: post
+date: 2017-03-25 11:27:00 +0000
 summary: I use Python-Markdown to render posts for my site. Here are a few examples
   of the extensions I'm using.
 tags: python markdown

--- a/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
+++ b/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-03-25 11:27:00 +0000
 layout: post
-slug: extensions-in-python-markdown
 summary: I use Python-Markdown to render posts for my site. Here are a few examples
   of the extensions I'm using.
 tags: python markdown

--- a/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
+++ b/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-04-04 17:46:00 +0000
 layout: post
+date: 2017-04-04 17:46:00 +0000
 summary: For accessibility and inclusion, AlterConf sets a high bar to beat.
 tags: alterconf conferences
 title: Accessibility at AlterConf

--- a/src/_posts/2017/2017-06-07-crossness-pumping-station.md
+++ b/src/_posts/2017/2017-06-07-crossness-pumping-station.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-06-07 20:50:00 +0000
 layout: post
-slug: crossness-pumping-station
 summary: Pictures from my recent visit to Crossness, a Victorian pumping station for London's sewers.
 title: A visit to the Crossness pumping station
 theme:

--- a/src/_posts/2017/2017-06-07-crossness-pumping-station.md
+++ b/src/_posts/2017/2017-06-07-crossness-pumping-station.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-06-07 20:50:00 +0000
 layout: post
+date: 2017-06-07 20:50:00 +0000
 summary: Pictures from my recent visit to Crossness, a Victorian pumping station for London's sewers.
 title: A visit to the Crossness pumping station
 theme:

--- a/src/_posts/2017/2017-07-18-listing-s3-keys.md
+++ b/src/_posts/2017/2017-07-18-listing-s3-keys.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-07-18 08:30:00 +0000
 layout: post
-slug: listing-s3-keys
 summary: A short Python function for getting a list of keys in an S3 bucket.
 tags: aws python
 title: Listing keys in an S3 bucket with Python

--- a/src/_posts/2017/2017-07-18-listing-s3-keys.md
+++ b/src/_posts/2017/2017-07-18-listing-s3-keys.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-07-18 08:30:00 +0000
 layout: post
+date: 2017-07-18 08:30:00 +0000
 summary: A short Python function for getting a list of keys in an S3 bucket.
 tags: aws python
 title: Listing keys in an S3 bucket with Python

--- a/src/_posts/2017/2017-07-18-soundcloud-backups.md
+++ b/src/_posts/2017/2017-07-18-soundcloud-backups.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-07-18 09:30:00 +0000
 layout: post
-slug: soundcloud-backups
 title: Backing up content from SoundCloud
 ---
 

--- a/src/_posts/2017/2017-07-18-soundcloud-backups.md
+++ b/src/_posts/2017/2017-07-18-soundcloud-backups.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-07-18 09:30:00 +0000
 layout: post
+date: 2017-07-18 09:30:00 +0000
 title: Backing up content from SoundCloud
 ---
 

--- a/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
+++ b/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-07-31 19:47:00 +0000
 layout: post
+date: 2017-07-31 19:47:00 +0000
 summary: A Rust utility for saving local copies of my full-page archives from Pinboard.
 tags: rust pinboard
 title: Backing up full-page archives from Pinboard

--- a/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
+++ b/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
@@ -1,7 +1,6 @@
 ---
 date: 2017-07-31 19:47:00 +0000
 layout: post
-slug: backing-up-pinboard-archives
 summary: A Rust utility for saving local copies of my full-page archives from Pinboard.
 tags: rust pinboard
 title: Backing up full-page archives from Pinboard

--- a/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
+++ b/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
@@ -2,7 +2,6 @@
 date: 2017-09-02 17:34:00 +0000
 layout: post
 link: https://github.com/alexwlchan/lazyreader
-slug: lazy-reading-in-python
 summary: I wrote a small Python module for lazy file reading, ideal for efficient
   batch processing.
 tags: python

--- a/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
+++ b/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
@@ -1,6 +1,6 @@
 ---
-date: 2017-09-02 17:34:00 +0000
 layout: post
+date: 2017-09-02 17:34:00 +0000
 link: https://github.com/alexwlchan/lazyreader
 summary: I wrote a small Python module for lazy file reading, ideal for efficient
   batch processing.

--- a/src/_posts/2017/2017-09-11-ode-to-docopt.md
+++ b/src/_posts/2017/2017-09-11-ode-to-docopt.md
@@ -1,10 +1,10 @@
 ---
+layout: post
 title: Ode to docopt
 summary: Why I love docopt as a tool for writing clean, simple command-line interfaces.
 tags: python slides
 category: slides
 date: 2017-09-11 12:01:13 +0100
-layout: post
 theme:
   color: 008000
   touch_icon: docopt

--- a/src/_posts/2017/2017-09-16-useful-git-commands.md
+++ b/src/_posts/2017/2017-09-16-useful-git-commands.md
@@ -1,9 +1,9 @@
 ---
+layout: post
 title: Some useful Git commands for CI
 summary: A couple of Git commands that I find useful in builds and CI.
 tags: git
 date: 2017-09-18 18:45:00 +0100
-layout: post
 ---
 
 I spend a lot of time writing build scripts for interacting with Git repos.

--- a/src/_posts/2017/2017-09-25-overengineering.md
+++ b/src/_posts/2017/2017-09-25-overengineering.md
@@ -1,7 +1,6 @@
 ---
 layout: post
 title: What happens when you overengineer a static site?
-slug: overengineering
 link: https://github.com/alexwlchan/alexwlchan.net
 tags: jekyll
 date: 2017-10-03 22:23:38 +0100

--- a/src/_posts/2017/2017-10-08-pronunciation-peeves.md
+++ b/src/_posts/2017/2017-10-08-pronunciation-peeves.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-08 19:08:16 +0000
 title: "NPR: Graduation Readers At MIT Go The Extra Mile To Pronounce Names Correctly"
 link: http://www.npr.org/2016/05/15/478114689/graduation-readers-at-mit-go-the-extra-mile-to-pronounce-names-correctly
 summary: Why I care about names being pronounced correctly, and appreciate MIT's efforts to get it right.

--- a/src/_posts/2017/2017-10-09-pip-tools.md
+++ b/src/_posts/2017/2017-10-09-pip-tools.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-09 08:11:03 +0000
 title: Using pip-tools to manage my Python dependencies
 tags: python docker make
 summary: How I use pip-tools to ensure my Python dependencies are pinned, precise, and as minimal as possible.

--- a/src/_posts/2017/2017-10-11-latex-underlines.md
+++ b/src/_posts/2017/2017-10-11-latex-underlines.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-11 22:09:25 +0000
 title: Four ways to underline text in LaTeX
 tags: latex typesetting
 summary: I'm very picky about the way underlines look, and have spent a lot of time trying to get the perfect underline in LaTeX.

--- a/src/_posts/2017/2017-10-17-control-centre.md
+++ b/src/_posts/2017/2017-10-17-control-centre.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-17 20:54:13 +0000
 title: "Control Centre: one step forward, two steps back"
 summary: I like aspects of Control Centre in iOS 11, but WiFi/Bluetooth and audio playback are both immensely frustrating.
 tags: ios frustrations

--- a/src/_posts/2017/2017-10-20-requests-hooks.md
+++ b/src/_posts/2017/2017-10-20-requests-hooks.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-20 17:11:59 +0000
 title: Using hooks for custom behaviour in requests
 tags: python
 summary: I often have code I want to run against every HTTP response (logging, error checking) --- event hooks give me a nice way to do that without repetition.

--- a/src/_posts/2017/2017-10-25-tweets-in-keynote.md
+++ b/src/_posts/2017/2017-10-25-tweets-in-keynote.md
@@ -2,7 +2,6 @@
 layout: post
 date: 2017-10-25 13:14:54 +0000
 title: Displaying tweets in Keynote
-slug: tweets-in-keynote
 tags: keynote
 summary: Slides for showing tweets that look like tweets on slides in Keynote and PowerPoint.
 theme:

--- a/src/_posts/2017/2017-10-25-tweets-in-keynote.md
+++ b/src/_posts/2017/2017-10-25-tweets-in-keynote.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-25 13:14:54 +0000
 title: Displaying tweets in Keynote
 slug: tweets-in-keynote
 tags: keynote

--- a/src/_posts/2017/2017-10-27-pyconuk-2017-resources.md
+++ b/src/_posts/2017/2017-10-27-pyconuk-2017-resources.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-27 08:25:34 +0000
 title: PyCon UK 2017 resources
 summary: Slides and links for my PyCon UK 2017 talks/workshops.
 ---

--- a/src/_posts/2017/2017-10-28-lightning-talks.md
+++ b/src/_posts/2017/2017-10-28-lightning-talks.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-10-28 10:20:29 +0000
 title: Lightning talks
 tags: conferences
 summary: Why I like the lottery system used to select lightning talks at PyCon UK this year.

--- a/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
+++ b/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-11-03 11:40:52 +0000
 title: Using privilege to improve inclusion
 summary: In the tech industry, how can we be more aware of our privilege, and use that to build inclusive cultures?
 tags: pyconuk slides

--- a/src/_posts/2017/2017-11-08-asking-about-gender.md
+++ b/src/_posts/2017/2017-11-08-asking-about-gender.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-11-08 22:27:28 +0000
 title: How I ask about gender
 summary: "If you're asking for someone's gender, a simple 'Female/Male' isn't good enough. Here's what I use instead."
 tags: gender

--- a/src/_posts/2017/2017-11-09-a-plumbers-guide-to-git.md
+++ b/src/_posts/2017/2017-11-09-a-plumbers-guide-to-git.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-11-09 18:18:05 +0000
 title: A plumber's guide to Git
 summary: How does Git work under the hood? How does it store information, and what's really behind a branch? Notes from a workshop at PyCon UK 2017.
 tags: pyconuk slides git

--- a/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
+++ b/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-11-22 11:50:19 +0000
 title: Downloading logs from Amazon CloudWatch
 tags: aws python
 summary: A detailed breakdown of how I wrote a Python script to download logs from CloudWatch.

--- a/src/_posts/2017/2017-11-27-pruning-git-branches.md
+++ b/src/_posts/2017/2017-11-27-pruning-git-branches.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-11-27 22:41:36 +0000
 title: Pruning old Git branches
 theme:
   minipost: true

--- a/src/_posts/2017/2017-12-11-armed-police.md
+++ b/src/_posts/2017/2017-12-11-armed-police.md
@@ -1,5 +1,6 @@
 ---
 layout: post
+date: 2017-12-11 12:19:24 +0000
 title: Armed police officers don't make me feel safer
 content_warning: discussion of guns, police violence, and images of armed police.
 summary: Why guns make me jumpy, how armed police don't reassure me, and why you need to be careful about the images you use in tweets.


### PR DESCRIPTION
One unexpected aspect of the new publishing system is that I’m writing more than I used to. Yay!

But the system worked too well – a couple of times, I’ve tried to post more than once in a day, and the publish-drafts plugin could only publish posts with per-day granularity. More than one post a day would cause bugs in the RSS feed.

This patch:

* Modifies the publish-draft plugin to insert a full date/time in the front matter, not just relying on the post filename to carry it for us
* Uses the Git commit history to add a full date/time to posts which didn’t already have it
* Converts all posts to have the same filename as their slug, then delete the slug field, which becomes redundant
* Does a bit of other front matter cleaning while I had the script handy