### PR TITLE
Implement primitive cache busting for CSS

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,5 +1,3 @@
-<!-- TODO: Put in the metadata for Twitter cards and OpenGraph metadata -->
-
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -9,15 +9,15 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/atom.xml">
 
-  {% if page.theme and page.theme.color %}
-  <link rel="stylesheet" href="/theme/style_{{ page.theme.color }}.css">
+{% if page.theme and page.theme.color %}
+  <link rel="stylesheet" href="/theme/style_{{ page.theme.color }}.css?{{ site.time | date:'%Y%m%d%U%H%N%S' }}">
   <link rel="shortcut icon" type="image/png" href="/theme/favicon_{{ page.theme.color }}.png">
   <link rel="shortcut icon" type="image/x-icon" href="/theme/favicon_{{ page.theme.color }}.ico">
-  {% else %}
-  <link rel="stylesheet" href="/theme/style.css">
+{% else %}
+  <link rel="stylesheet" href="/theme/style.css?{{ site.time | date:'%Y%m%d%U%H%N%S' }}">
   <link rel="shortcut icon" type="image/png" href="/theme/favicon.png">
   <link rel="shortcut icon" type="image/x-icon" href="/theme/favicon.ico">
-  {% endif %}
+{% endif %}
 
   {% if page.theme and page.theme.touch_icon %}
   <link rel="apple-touch-icon" href="/theme/apple-touch-icon_{{ page.theme.touch_icon }}.png">

--- a/src/_scss/_settings.scss
+++ b/src/_scss/_settings.scss
@@ -12,7 +12,7 @@ $midtone-gray: #ccc;
 $default-font-size: 1em;
 $line-height:       1.45em;
 
-$meta-size: 0.85;
+$meta-size: 0.95;
 $meta-font-size:   $meta-size * $default-font-size;
 $meta-line-height: $meta-size * $line-height * 1.15;
 
@@ -20,7 +20,7 @@ $max-width:       750px !default;
 $default-padding: 20px !default;
 $big-font-size:   2em !default;
 
-$scaling-factor: 0.9;
+$scaling-factor: 0.95;
 $code-scaling-factor: $scaling-factor;
 
 $jekyll-red:    #d50000;


### PR DESCRIPTION
The problem: every time I change my CSS, it gets cached in CloudFlare and/or browsers, so changes don't show up until the cache expires.

The solution: modify the CSS links every time I rebuild the site (by adding a timestamp), so the cache gets purged.

The idea is taken from https://stackoverflow.com/q/9638122/1558022 – there are better implementations of asset pipelines that can bust the cache only when you need it; this was the simplest thing I could think to do with the current setup.