### PR TITLE
Make the root of the repo be the root of the Jekyll build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN ./install_jekyll.sh
 # it from a Gem.
 COPY src/_plugins/publish_drafts.rb /usr/local/bundle/gems/jekyll-3.5.2/lib/jekyll/commands
 
+VOLUME ["/site"]
 WORKDIR /site
 
 ENTRYPOINT ["bundle", "exec", "jekyll"]

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean: .docker/build
 	docker rmi --force $(TESTS_IMAGE)
 
 build: .docker/build
-	docker run --volume $(SRC):/site $(BUILD_IMAGE) build
+	docker run --volume $(ROOT):/site $(BUILD_IMAGE) build
 
 stop:
 	@# Clean up old running containers

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ serve-debug: serve
 
 publish-drafts: .docker/build
 	docker run \
-		--volume $(ROOT):/repo \
+		--volume $(ROOT):/site \
 		--volume ~/.gitconfig:/root/.gitconfig \
 		--volume ~/.ssh:/root/.ssh \
 		--tty --rm $(BUILD_IMAGE) \
-		publish-drafts --source=/repo/src
+		publish-drafts
 
 publish: publish-drafts build
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ stop:
 serve: .docker/build stop
 	docker run \
 		--publish 5757:5757 \
-		--volume $(SRC):/site \
+		--volume $(ROOT):/site \
 		--name $(SERVE_CONTAINER) \
 		--hostname $(SERVE_CONTAINER) \
 		--tty --rm --detach $(BUILD_IMAGE) \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ RSYNC_DIR = /home/alexwlchan/sites/alexwlchan.net
 
 ROOT = $(shell git rev-parse --show-toplevel)
 SRC = $(ROOT)/src
+DST = $(ROOT)/_site
 TESTS = $(ROOT)/tests
 
 $(ROOT)/.docker/build: Dockerfile install_jekyll.sh install_specktre.sh Gemfile.lock src/_plugins/publish_drafts.rb
@@ -70,7 +71,7 @@ publish: publish-drafts build
 deploy: publish
 	docker run --rm --tty \
 		--volume ~/.ssh/id_rsa:/root/.ssh/id_rsa \
-		--volume $(ROOT)/src/_site:/data \
+		--volume $(DST):/data \
 		instrumentisto/rsync-ssh \
 		rsync \
 		--archive \
@@ -102,7 +103,7 @@ Gemfile.lock: Gemfile
 nginx-serve:
 	docker run --rm \
 		--volume $(ROOT)/infra/alexwlchan.net.nginx.conf:/etc/nginx/nginx.conf \
-		--volume $(ROOT)/src/_site:/usr/share/nginx/html \
+		--volume $(DST):/usr/share/nginx/html \
 		--publish 5858:80 \
 		--hostname alexwlchan \
 		--name alexwlchan \

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,9 @@ author: "Alex Chan"
 description: "Alex Chan's personal blog"
 url: "https://alexwlchan.net"
 
+source: src
+destination: _site
+
 social:
   github: "alexwlchan"
   twitter: "alexwlchan"

--- a/src/_plugins/static_file_generator.rb
+++ b/src/_plugins/static_file_generator.rb
@@ -1,9 +1,14 @@
 module Jekyll
   class StaticFileGenerator < Generator
     def generate(site)
-      system('mkdir -p _site'); # We may be called before _site exists.
+      src = site.config["source"]
+      dst = site.config["destination"]
+
+      # We may be called before the destination directory exists
+      system("mkdir -p #{dst}");
+
       site.keep_files.each { |dir|
-        if !system("rsync --archive --delete _#{dir}/ _site/#{dir}/")
+        if !system("rsync --archive --delete #{src}/_#{dir}/ #{dst}/#{dir}/")
           raise RuntimeError, "Error running the static file rsync for #{dir}!"
         end
       }

--- a/src/_plugins/theming.rb
+++ b/src/_plugins/theming.rb
@@ -1,9 +1,12 @@
-Jekyll::Hooks.register :posts, :post_render do |post|
-  if post["theme"] && post["theme"]["color"]
-    color = post["theme"]["color"]
-    create_scss_theme(color)
-    create_banner_image(color)
-  end
+Jekyll::Hooks.register :site, :post_read do |site|
+  src = site.config["source"]
+  site.posts.docs.each { |post|
+    if post["theme"] && post["theme"]["color"]
+      color = post["theme"]["color"]
+      create_scss_theme(src, color)
+      create_banner_image(src, color)
+    end
+  }
 end
 
 
@@ -11,8 +14,8 @@ end
 #
 # This will be picked up by the SCSS processor for the site, and cause
 # the creation of a CSS theme with this as the primary color.
-def create_scss_theme(color)
-  mainfile = "theme/style_#{color}.scss"
+def create_scss_theme(src, color)
+  mainfile = "#{src}/theme/style_#{color}.scss"
   if ! File.file?(mainfile)
     File.open(mainfile, 'w') { |file| file.write(<<-EOT
 ---
@@ -32,8 +35,8 @@ end
 #
 # This will be picked up by the rsync plugin, and used by the CSS theme
 # created above.
-def create_banner_image(color)
-  banner_file = "theme/specktre_#{color}.png"
+def create_banner_image(src, color)
+  banner_file = "#{src}/theme/specktre_#{color}.png"
   if ! File.file?(banner_file)
 
     puts("Building the banner file for #{color}")


### PR DESCRIPTION
This is a bit of probably overdue refactoring – rather than rooting Jekyll in `src`, now Jekyll can run from the root of the repo.

Nothing ground-breaking, but it flushes out a few hard-coded bits of config, and means I can start using Git metadata in Jekyll processes.

I've also moved the output from `src/_site` to `_site`, so input and output don't live in the same tree. 