### PR TITLE
Consolidate the 'talks' and 'slides' tags

### DIFF
--- a/src/_data/tag_aliases.yml
+++ b/src/_data/tag_aliases.yml
@@ -1,0 +1,2 @@
+slides:
+  - talks

--- a/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
+++ b/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
@@ -3,7 +3,7 @@ layout: post
 date: 2016-06-09 08:29:00 +0000
 link: /talks/hypothesis-intro/
 summary: Slides from my talk about property-based testing at CamPUG.
-tags: python talks
+tags: python slides
 title: Introduction to property-based testing
 ---
 

--- a/src/tags.md
+++ b/src/tags.md
@@ -20,6 +20,12 @@ title: Tags
 {% for tag in sorted_tags %}
 {% assign tag_name = tag[0] %}
 {% assign posts = tag[1] %}
+
+{% assign aliases = site.data["tag_aliases"][tag_name] %}
+{% for a in aliases %}
+<a id="tag__{{ a }}"></a>
+{% endfor %}
+
 <h3 id="tag__{{ tag_name }}">{{ tag_name }}</h3>
 <ul>
   {% for p in posts %}

--- a/tests/test_page_content.py
+++ b/tests/test_page_content.py
@@ -62,6 +62,9 @@ def test_pages_appear_correctly(hostname, path):
     # We don't include HTML tags in titles
     ('/2015/05/raft-algorithm/', '<title>The Secret Lives of Data'),
     ('/2018/03/a-plumbers-guide-to-git/', '<title>Notes on A Plumber'),
+
+    # Tag aliases are created correctly
+    ('/tags/', '<a id="tag__talks"></a>'),
 ])
 def test_text_appears_in_pages(hostname, path, text_in_page):
     resp = requests.get('http://%s/%s' % (hostname, path.lstrip('/')))


### PR DESCRIPTION
And implement tag aliases so anybody who saved the link to the old "talks" tag goes to the new "slides" tag instead.