### PR TITLE
Add a sitemap + exclude robots from /analytics/

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem "jekyll", "~> 3.8"
 
 group :jekyll_plugins do
    gem "jekyll-paginate-v2", "~> 1.8"
+   gem "jekyll-sitemap", "~> 1.2"
 end
 
 gem "nokogiri", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    jekyll (3.8.4)
+    jekyll (3.8.5)
       addressable (~> 2.4)
       colorator (~> 1.0)
       em-websocket (~> 0.5)
@@ -47,6 +47,8 @@ GEM
       jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
+    jekyll-sitemap (1.2.0)
+      jekyll (~> 3.3)
     jekyll-watch (2.1.2)
       listen (~> 3.0)
     json (1.8.6)
@@ -109,6 +111,7 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 3.8)
   jekyll-paginate-v2 (~> 1.8)
+  jekyll-sitemap (~> 1.2)
   nokogiri (~> 1.8)
   redcarpet
   shell-executer (~> 1.0)

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,8 @@ redcarpet:
   extensions: ["footnotes", "smart"]
 
 plugins:
-  - jekyll-paginate-v2
+  - "jekyll-paginate-v2"
+  - "jekyll-sitemap"
 
 highlighter: "rouge"
 

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /analytics/


### PR DESCRIPTION
This fixes one of the big remaining 404s, and should hopefully stop robots contributing to any of my analytics logs.