### PR TITLE
Add a {% slide %} tag that requires alt text

### DIFF
--- a/src/_plugins/alexwlchan_base.rb
+++ b/src/_plugins/alexwlchan_base.rb
@@ -1,0 +1,31 @@
+module Alexwlchan
+  module Base
+    def initialize(tag_name, params_string, tokens)
+      super
+      bind_params(eval("{#{params_string}}"))
+    end
+
+    def markdown_converter
+      @context.registers[:site].find_converter_instance(::Jekyll::Converters::Markdown)
+    end
+  end
+
+  class Block < Liquid::Block
+    include Base
+
+    def render(context)
+      @context = context
+      @text = super
+      internal_render
+    end
+  end
+
+  class Tag < Liquid::Tag
+    include Base
+
+    def render(context)
+      @context = context
+      internal_render
+    end
+  end
+end

--- a/src/_plugins/slides.rb
+++ b/src/_plugins/slides.rb
@@ -1,3 +1,58 @@
+require_relative "alexwlchan_base"
+
+
+def render_slide(deck, slide, alt_text, caption_text)
+  path = get_slide_path(deck, slide)
+
+  md_content = caption_text.strip
+  caption = if md_content
+     "<figcaption>#{markdown_converter.convert(md_content)}</figcaption>"
+  else
+    ""
+  end
+
+<<-EOT
+<figure class="slide">
+<a href="#{path}"><img src="#{path}" alt="#{alt_text}" title="#{alt_text}"></a>
+#{caption}
+</figure>
+EOT
+end
+
+
+module Jekyll
+
+  module SlideBase
+    def bind_params(params)
+      @deck = params[:deck] or raise SyntaxError, "Error in tag 'better_slide', :deck parameter is required"
+      @slide = params[:slide] or raise SyntaxError, "Error in tag 'better_slide', :slide parameter is required"
+      @alt = params[:alt] or raise SyntaxError, "Error in tag 'better_slide', :alt parameter is required"
+    end
+  end
+
+  class BetterSlideBlock < Alexwlchan::Block
+    include SlideBase
+
+    def internal_render
+      render_slide(@deck, @slide, @alt, @text)
+    end
+  end
+
+  class BetterSlideTag < Alexwlchan::Tag
+    include SlideBase
+
+    def internal_render
+      render_slide(@deck, @slide, @alt, "")
+    end
+  end
+end
+
+
+Liquid::Template.register_tag("better_slide", Jekyll::BetterSlideBlock)
+Liquid::Template.register_tag("slide_image", Jekyll::BetterSlideTag)
+
+
+
 # This is a plugin for embedding slide images.
 #
 # Each image needs to be both an image, and a link to the fullsized image.

--- a/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
+++ b/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
@@ -56,15 +56,15 @@ You can read the slides and my notes on this page, or download the slides [as a 
 
 ## Slides and notes
 
-{% slide curbcut_monkigras 1 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 1, :alt => "Title slide." %}
 
 Hi, I'm Alex.
 I'm going to talk about the Curb Cut Effect, what it is, and how we might use it.
 
-{% slide_captioned curbcut_monkigras 2 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 2, :alt => "The Wellcome Collection building, lit up in purple." %}
   The Wellcome Collection building lit up in purple to mark [International Day of Persons with Disabilities](https://en.wikipedia.org/wiki/United_Nations%27_International_Day_of_Persons_with_Disabilities) in December 2018.
   Image credit: Wellcome Collection.
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 I'm a software developer at [Wellcome Collection][wc], a free museum and library on Euston Road.
 
@@ -74,10 +74,10 @@ Our current exhibition, [Living with Buildings][buildings], is all about the eff
 [wc]: https://wellcomecollection.org/
 [buildings]: https://wellcomecollection.org/exhibitions/Wk4sPSQAACcANwrX
 
-{% slide_captioned curbcut_monkigras 3 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 3, :alt => "A dropped kerb against a black background, with the caption “dropped kerb aka curb cut”." %}
   A dropped kerb around the back of UCL, near the Wellcome offices.
   Image credit: me!
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 I'm talking about those areas where the kerb dips to form a ramp -- giving a level, step-free path from the road to the pavement.
 In the UK, these are usually accompanied by a textured yellow surface (pictured).
@@ -87,10 +87,10 @@ The American spelling is mostly common, and that's what I'll use for the rest of
 
 [kerbs]: https://en.wikipedia.org/wiki/Curb_cut
 
-{% slide_captioned curbcut_monkigras 4 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 4, :alt => "A map, with circled areas “Kalamazoo” and “Battle Creek”." %}
   A map showing part of Michigan, highlighting Kalamazoo and Battle Creek.
   Image credit: original map [from the US Geological Survey](https://ngmdb.usgs.gov/img4/ht_icons/Browse/MI/MI_Grand%20Rapids_278737_1958_250000.jpg).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 One of the earliest examples of curb cuts was in [Kalamazoo, MI][kalamazoo].
 (Great name!)
@@ -113,10 +113,10 @@ He became well-known among other disabled veterans in and near Kalamazoo -- of w
 [kalamazoo]: https://en.wikipedia.org/wiki/Kalamazoo,_Michigan
 [battle_creek]: https://en.wikipedia.org/wiki/Battle_Creek,_Michigan
 
-{% slide_captioned curbcut_monkigras 5 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 5, :alt => "A black and white photo of a wheelchair standing at the edge of a raised curb." %}
   A wheelchair standing at an raised, inaccessible curb.
   Image from [an article by the Smithsonian](http://americanhistory.si.edu/blog/smashing-barriers-access-disability-activism-and-curb-cuts).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 Working closely with them, he became aware of the problems and challenges they faced.
 
@@ -124,10 +124,10 @@ One of those problems: Kalamazoo had tall curbs (up to 6 inches).
 This was a problem -- people would trip, injure themselves, damage prosthetic limbs, and for wheelchair users they're a total nightmare.
 Tall kerbs are inaccessible, and prevent people getting around, socialising, working and so on.
 
-{% slide_captioned curbcut_monkigras 6 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 6, :alt => "A black and white photo of a street, with somebody walking up a ramp with hand rails cut into the kerb." %}
   A ramp with hand rails on the streets of Kalamazoo.
   Image from [an article in Encore Magazine](http://www.encorekalamazoo.com/creating-curb-cuts).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 So in 1945, Jack Fisher took it upon himself to fix this, and petitioned the city commission for curb cuts and hand-rails.
 Ditching the step would make it easier for people to get around.
@@ -135,7 +135,7 @@ The city authorised their construction and ran a small pilot program, they were 
 
 Kalamazoo is one of the earliest examples of dropped kerbs, but the same story plays out in lots of other places -- curb cuts were installed in lots of places to make the streets more accessible for disabled people and wheelchair users.
 
-{% slide curbcut_monkigras 7 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 7, :alt => "Text slide, white text on purple. “Curb cuts make the roads more accessible for wheelchair users and disabled people, but they aren't the only people who benefit!”" %}
 
 So curb cuts make the roads more accessible for wheelchair users and disabled people.
 Yay!
@@ -153,13 +153,13 @@ And probably others.
 
 Wcould call this a "force multipler" or a "happy accident", but really this is the original example of the "Curb Cut Effect".
 
-{% slide curbcut_monkigras 8 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 8, :alt => "Text slide, white text on purple. “Making something better for disabled people can make it better for everyone.”" %}
 
 The Curb Cut Effect comes in many forms, but the way I think of it is:
 
 > Making something better for disabled people can make it better for everyone.
 
-{% slide curbcut_monkigras 9 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 9, :alt => "Text slide, white text on purple. “What it means for us: Designs that include disabled people are better designs for everybody.”" %}
 
 What this means for us, as people who build things:
 
@@ -169,13 +169,13 @@ And we reflect this is the words we use: it's why we don't talk about *handicapp
 We talk *universal design*.
 We talk about *good* design.
 
-{% slide curbcut_monkigras 8 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 8, :alt => "Text slide, white text on purple. “Making something better for disabled people can make it better for everyone.”" %}
 
 (Repeat the Curb Cut Effect.)
 
 Let's look at a few examples.
 
-{% slide curbcut_monkigras 10 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 10, :alt => "A black-and-white artwork of a woman sitting at a table. There’s a large machine with a keyboard on the table." %}
 
 One of the earliest examplse predates Kalamazoo by more than a century.
 
@@ -192,10 +192,10 @@ This was one of the earliest iterations of the typewriter.
 It made writing accessible to the blind, and the derivatives became the modern-day keyboard.
 A machine created to help one blind woman write love letters was the basis for a fundamental input device for modern computing.
 
-{% slide_captioned curbcut_monkigras 11 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 11, :alt => "A photo of a laptop with an email client open." %}
   Somebody using an email client on a laptop.
   Image credit: [rawpixel.com on Pexels](https://www.pexels.com/photo/person-using-macbook-pro-on-brown-wooden-desk-1061588/).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 Speaking of love letters… let's talk about email!
 
@@ -205,9 +205,9 @@ Sounds fake.)
 Email has become a ubiquitous part of modern comms, but where did it come from?
 Why was it invented?
 
-{% slide_captioned curbcut_monkigras 12 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 12, :alt => "A photo of a man in a suit (Vint Cerf), with a quote overlaid. “Because I’m hearing-impaired, emails are a tremendously valuable tool because of the precision that you get. I can read what’s typed as opposed to straining to hear what’s being said.”" %}
   A picture of Vinton Cerf, taken from [his Royal Society photo](https://commons.wikimedia.org/wiki/File:Dr_Vint_Cerf_ForMemRS.jpg) and overlaid with a quote [from a CNET article](https://www.cnet.com/news/internet-inventor-vint-cerf-accessibility-disability-deaf-hearing/).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 This is [Vinton Cerf](https://en.wikipedia.org/wiki/Vint_Cerf).
 He's often called the "Father of the Internet", did a lot of work on the early Internet (then-ARPANET) protocols, is a strong advocate for accessibility, and led the work on the first commercial email program.
@@ -226,9 +226,7 @@ Here's a quote [he gave to CNET](https://www.cnet.com/news/internet-inventor-vin
 
 Email started as a key technology for people who are deaf or have hearing loss -- or who are just separated by time and space.
 
-{% slide_captioned curbcut_monkigras 13 %}
-  A picture of Vinton Cerf, taken from [his Royal Society photo](https://commons.wikimedia.org/wiki/File:Dr_Vint_Cerf_ForMemRS.jpg) and overlaid with a quote [from a CNET article](https://www.cnet.com/news/internet-inventor-vint-cerf-accessibility-disability-deaf-hearing/).
-{% endslide_captioned %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 13, :alt => "A screenshot from Sesame Street, with four characters on screen and a caption “Now everyone can read it”." %}
 
 Sticking with hearing loss, let's talk about captions.
 
@@ -246,9 +244,9 @@ And even if you can hear the sound fine, you can still benefit from captions:
 *   Children learning to read
 *   Somebody learning a foreign language
 
-{% slide_captioned curbcut_monkigras 14 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 14, :alt => "A person with their hands on a special “stenographic” keyboard, looking up to hear someone talking." %}
   A photo of one of the captioners at PyCon UK 2017, by [Mark Hawkins](https://www.flickr.com/photos/152472562@N06/37914240642/in/album-72157666242746367/).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 And it helps with conferences too!
 
@@ -256,15 +254,15 @@ I'm being captioned right now -- literally as I speak!
 [Monki Gras has live captioning.]
 This is one of the captioners at PyCon UK, and our experience is that lots of people find it useful during talks, not just the deaf or hard-of-hearing -- maybe a word you couldn't hear, somebody's speaking with an accent, or you stopped to check twitter halfway through the session.
 
-{% slide_captioned curbcut_monkigras 15 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 15, :alt => "A printed page titled “Optical character recognition”, being scanned with a handheld OCR scanner with a red light." %}
   A photo of a handheld OCR scanner, from [Wikipedia](https://en.wikipedia.org/wiki/Optical_character_recognition).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 Let's look at another bit of early technology: [optical character recognition](https://en.wikipedia.org/wiki/Optical_character_recognition), or OCR.
 
-{% slide_captioned curbcut_monkigras 16 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 16, :alt => "A sepia drawing of a machine with a scanning frame and a pair of headphones on a cord." %}
   A scanned image of an optophone, taken from [Wikipedia](https://commons.wikimedia.org/wiki/File:Optophone_in_detail.jpg).
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 Early research into OCR was done to help the blind.
 
@@ -274,29 +272,29 @@ This was pioneering work for computer vision and text-to-speech synthesis.
 
 These have become widely-used technologies: for making textual versions of scanned documents, Google Books, even those smartphone apps that let you translate signs in a foreign language.
 
-{% slide_captioned curbcut_monkigras 17 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 17, :alt => "A room with a row of shelves, with the spines of some large books visible on the nearest shelves." %}
   A room full of grey shelves, with books visible on the nearest shelves.
   Image credit: Wellcome Collection.
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 And in fact, this is what we do at Wellcome Collection!
 
 For those unfamiliar with Wellcome: we have an archive about human health and medicine.
 This is one of our "data centres"...
 
-{% slide_captioned curbcut_monkigras 18 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 18, :alt => "A close-up photo of some shelves, with the spines of large and old books closest to the camera." %}
   Four shelves, each with a couple of large books on each shelf.
   Image credit: Wellcome Collection.
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 …using advanced container technology, like "shelves" and "books".
 
 Like many institutions, we're scanning our archives to make them more easily available, and then we use OCR to make them searchable.
 
-{% slide_captioned curbcut_monkigras 19 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 19, :alt => "A screenshot of an ebook viewer, with a page titled “Die Radioaktivität”." %}
   A page from [the notebooks of Marie Curie](https://wellcomelibrary.org/item/b28120991#?c=0&m=0&s=0&cv=6&z=-1.0491%2C0%2C3.0982%2C1.5908), with a search highlighting instances of the word "radioaktiv".
   Image credit: Wellcome Collection.
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 Here's one example of our books: a notebook from Marie Curie, freely available to browse online.
 (Which is preferable to the original, which is [slightly radioactive](https://blog.bir.org.uk/2015/09/02/the-radioactive-legacy-of-marie-curie/)!)
@@ -304,10 +302,10 @@ And using OCR, we can see that the word "radioaktiv" appears 730 times.
 
 This so cool, but it wouldn't exist without the pioneering work done into OCR to help blind people.
 
-{% slide_captioned curbcut_monkigras 20 %}
+{% better_slide :deck => "curbcut_monkigras", :slide => 20, :alt => "A purple door with a silver handle." %}
   A silver door handle set against a purple door, with raindrops on the door's surface.
   Image credit: [MabelAmber on Pixabay](https://pixabay.com/en/door-handle-doorknob-lock-door-3633943/), and recoloured by me.
-{% endslide_captioned %}
+{% endbetter_slide %}
 
 One final example, less high technology and more small convenience: door handles.
 
@@ -316,11 +314,11 @@ Compared to door knobs, handles provide a larger area to grip or rest your hand 
 But they also make it easier if your hands are full, or you're carrying things -- you can lean on the door with an elbow without dropping something.
 It just makes life a bit easier.
 
-{% slide curbcut_monkigras 8 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 8, :alt => "Text slide, white text on purple. “Making something better for disabled people can make it better for everyone.”" %}
 
 So those are just a few examples of the Curb Cut Effect.
 
-{% slide curbcut_monkigras 21 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 21, :alt => "Text slide, white text on purple. “It isn’t just about disability!”" %}
 
 And that's often where discussion of the Curb Cut Effect stops, which is a shame, because it isn't just about disability!
 
@@ -328,7 +326,7 @@ Although disabled people are the most visibly excluded, there are plenty of excl
 
 Let's look at one more example.
 
-{% slide curbcut_monkigras 22 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 22, :alt => "A photo with a blue sign “inclusive” and a trans and wheelchair icon, and a toilet visible in the room marked by the sign." %}
 
 In the last few years, there's been a big uptick in single stall, gender-neutral bathrooms.
 These are bathrooms that contain their own toilet and sink, maybe a shelf, all in a single private, enclosed space.
@@ -341,7 +339,7 @@ And this is great for them… but it helps lots of other people too.
 *   Men who need baby changing facilities
 *   Somebody having a period emergency and wants a bit of privacy
 
-{% slide curbcut_monkigras 23 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 23, :alt => "Text slide, white text on purple. “Making something better for people who are excluded or marginalised makes it better for everyone.”" %}
 
 So we can take the Curb Cut Effect, and make it stronger:
 
@@ -349,7 +347,7 @@ So we can take the Curb Cut Effect, and make it stronger:
 
 It's not just about disability.
 
-{% slide curbcut_monkigras 24 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 24, :alt => "Text slide, white text on purple. “These are good stories.”" %}
 
 So why am I telling you all this?
 Two reasons.
@@ -360,7 +358,7 @@ They're little love letters to inclusion, and a nice way to get people talking a
 It's been really fun to research this talk, and get to go to friends and say, "Hey, did you know this really cool story about the invention of the bendy straw?"
 (Talk to me in the break if you want to know this one.)
 
-{% slide curbcut_monkigras 25 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 25, :alt => "Text slide, white text on purple. “Things don’t happen because they’re ‘fair’ or ‘right’.”" %}
 
 There is a moe serious point.
 
@@ -369,7 +367,7 @@ I don't need to convince you -- you want to do it because it's the right thing t
 
 Unfortunately, things dopn't happen because they're "right" or "fair" (what a world that would be!).
 
-{% slide curbcut_monkigras 26 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 26, :alt => "Text slide, white text on purple. “We often have to justify the value of inclusion.”" %}
 
 We often have to justify the value of inclusion.
 (If you're at this conference, you might be the person who does this advocacy, who has to make the business case.)
@@ -379,7 +377,7 @@ How often have you heard questions like "Do we have to do this?  How many people
 And the Curb Cut Effect is a great tool to remember: it shows the value of inclusion.
 Spread the cost across a wide group, and changes to support inclusion suddenly seem much more attractive.
 
-{% slide curbcut_monkigras 27 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 27, :alt => "Text slide, white text on purple. “We can help one group without hurting another.”" %}
 
 It also serves to dispel a powerful myth.
 
@@ -391,7 +389,7 @@ The Curb Cut Effect shows us this is false: in fact, it shows us the opposite is
 Making the world a better place for a small number of people can make it better for a much wider number too.
 Yay!
 
-{% slide curbcut_monkigras 23 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 23, :alt => "Text slide, white text on purple. “Making something better for people who are excluded or marginalised makes it better for everyone.”" %}
 
 So let's bring this all together.
 
@@ -404,6 +402,6 @@ And of course, curb cuts!
 But there are many more -- go away and try to think of some, maybe even ones in your own work.
 Keep it in mind, see how you can apply it to the things you build, and remember it the next time you're asked to justify the value of inclusion.
 
-{% slide curbcut_monkigras 28 %}
+{% slide_image :deck => "curbcut_monkigras", :slide => 28, :alt => "Closing slide, with a reminder of the curb cut effect and a link to the slides." %}
 
 (Exit to rapturous applause.)


### PR DESCRIPTION
One of the things heavily flagged by [HTMLProofer](https://alexwlchan.net/2019/02/checking-jekyll-sites-with-htmlproofer/) is the number of images that don’t have alt text (which is almost all of them!).

I don’t use images very often, but a lot of them are slides. This adds a new slide plugin that gives a way to specify alt text for a slide, and errors if it’s not provided.

This cuts the number of HTMLProofer errors from 563 to 501.

Related: #144, #205.