### PR TITLE
Refactor the tweet plugin to put the HTML in a Liquid template

### DIFF
--- a/src/_includes/tweet.html
+++ b/src/_includes/tweet.html
@@ -1,7 +1,3 @@
-TWEET TWEET TWEET
-
-{{ tweet_data }}
-
 {% assign tweet_id = tweet_data["id_str"] %}
 {% assign name = tweet_data["user"]["name"] %}
 {% assign screen_name = tweet_data["user"]["screen_name"] %}

--- a/src/_includes/tweet.html
+++ b/src/_includes/tweet.html
@@ -4,6 +4,7 @@
 
 <div class="tweet">
   <blockquote>
+
   {% if tweet_data["extended_entities"]["media"].size == 1 %}
 
     {% assign media = tweet_data["extended_entities"]["media"][0] %}
@@ -15,6 +16,7 @@
       </a>
     </div>
   {% endif %}
+
     <div class="header">
       <div class="author">
         <a class="link link_blend" href="https://twitter.com/{{ screen_name }}">

--- a/src/_includes/tweet.html
+++ b/src/_includes/tweet.html
@@ -11,19 +11,15 @@
 
     <div class="media">
       <a href="{{ expanded_url }}">
-        <img src=\"#{display_path(filename)}\">
+        <img src="{{ media | tweet_img_entity_url }}">
       </a>
     </div>
   {% endif %}
-    {{ tweet_data["extended_entities"]["media"].size }}
-
-
-    {{ tweet_data["extended_entities"]["media"] }}
     <div class="header">
       <div class="author">
         <a class="link link_blend" href="https://twitter.com/{{ screen_name }}">
           <span class="avatar">
-            <img src="#{display_avatar_path(avatar_url, screen_name)}" alt="Profile picture for @{{ screen_name }}">
+            <img src="{{ tweet_data | tweet_avatar_url }}" alt="Profile picture for @{{ screen_name }}">
           </span>
           <span class="name" title="{{ name }}">{{ name }}</span>
           <span class="screen_name" title="@{{ screen_name }}">@{{ screen_name }}</span>
@@ -31,9 +27,9 @@
       </div>
     </div>
     <div class="body">
-      <p class="text">#{text}</p>
+      <p class="text">{{ tweet_data | render_tweet_text }}</p>
       <div class="metadata">
-        <a class="link_blend" href="https://twitter.com/{{ screen_name }}/status/{{ tweet_id }}">#{timestamp}</a>
+        <a class="link_blend" href="https://twitter.com/{{ screen_name }}/status/{{ tweet_id }}">{{ tweet_data | render_date_created }}</a>
       </div>
     </div>
   </blockquote>

--- a/src/_includes/tweet.html
+++ b/src/_includes/tweet.html
@@ -1,0 +1,44 @@
+TWEET TWEET TWEET
+
+{{ tweet_data }}
+
+{% assign tweet_id = tweet_data["id_str"] %}
+{% assign name = tweet_data["user"]["name"] %}
+{% assign screen_name = tweet_data["user"]["screen_name"] %}
+
+<div class="tweet">
+  <blockquote>
+  {% if tweet_data["extended_entities"]["media"].size == 1 %}
+
+    {% assign media = tweet_data["extended_entities"]["media"][0] %}
+    {% assign expanded_url = media["expanded_url"] %}
+
+    <div class="media">
+      <a href="{{ expanded_url }}">
+        <img src=\"#{display_path(filename)}\">
+      </a>
+    </div>
+  {% endif %}
+    {{ tweet_data["extended_entities"]["media"].size }}
+
+
+    {{ tweet_data["extended_entities"]["media"] }}
+    <div class="header">
+      <div class="author">
+        <a class="link link_blend" href="https://twitter.com/{{ screen_name }}">
+          <span class="avatar">
+            <img src="#{display_avatar_path(avatar_url, screen_name)}" alt="Profile picture for @{{ screen_name }}">
+          </span>
+          <span class="name" title="{{ name }}">{{ name }}</span>
+          <span class="screen_name" title="@{{ screen_name }}">@{{ screen_name }}</span>
+        </a>
+      </div>
+    </div>
+    <div class="body">
+      <p class="text">#{text}</p>
+      <div class="metadata">
+        <a class="link_blend" href="https://twitter.com/{{ screen_name }}/status/{{ tweet_id }}">#{timestamp}</a>
+      </div>
+    </div>
+  </blockquote>
+</div>

--- a/src/_plugins/twitter.rb
+++ b/src/_plugins/twitter.rb
@@ -73,7 +73,7 @@ module Jekyll
     def download_media(tweet)
       # TODO: Add support for rendering tweets that contain more than
       # one media entity.
-      raise "Too many media entities" unless tweet.media.count <= 1
+      raise "Too many media entities" unless tweet.media.count == 1 || tweet.media.count == 3
 
       tweet.media.each { |m|
 
@@ -187,30 +187,36 @@ EOD
 
       text = text.strip
 
-      tweet_html = <<-EOT
-<div class="tweet">
-  <blockquote>#{media_div}
-    <div class="header">
-      <div class="author">
-        <a class="link link_blend" href="https://twitter.com/#{screen_name}">
-          <span class="avatar">
-            <img src="#{display_avatar_path(avatar_url, screen_name)}" alt="Profile picture for @#{screen_name}">
-          </span>
-          <span class="name" title="#{name}">#{name}</span>
-          <span class="screen_name" title="@#{screen_name}">@#{screen_name}</span>
-        </a>
-      </div>
-    </div>
-    <div class="body">
-      <p class="text">#{text}</p>
-      <div class="metadata">
-        <a class="link_blend" href="https://twitter.com/#{screen_name}/status/#{@tweet_id}">#{timestamp}</a>
-      </div>
-    </div>
-  </blockquote>
-</div>
-EOT
-      tweet_html.lines.map { |line| line.strip }.join("")
+      markdown_converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+      tpl = Liquid::Template.parse(File.open("src/_includes/tweet.html").read)
+      tpl.render!("tweet_data" => tweet_data)
+      # markdown_converter.convert("{% include tweet.html %}")
+#
+#       tweet_html = <<-EOT
+# {% include tweet.html %}
+# <div class="tweet">
+#   <blockquote>#{media_div}
+#     <div class="header">
+#       <div class="author">
+#         <a class="link link_blend" href="https://twitter.com/#{screen_name}">
+#           <span class="avatar">
+#             <img src="#{display_avatar_path(avatar_url, screen_name)}" alt="Profile picture for @#{screen_name}">
+#           </span>
+#           <span class="name" title="#{name}">#{name}</span>
+#           <span class="screen_name" title="@#{screen_name}">@#{screen_name}</span>
+#         </a>
+#       </div>
+#     </div>
+#     <div class="body">
+#       <p class="text">#{text}</p>
+#       <div class="metadata">
+#         <a class="link_blend" href="https://twitter.com/#{screen_name}/status/#{@tweet_id}">#{timestamp}</a>
+#       </div>
+#     </div>
+#   </blockquote>
+# </div>
+# EOT
+      # tweet_html.lines.map { |line| line.strip }.join("")
     end
   end
 end

--- a/src/_plugins/twitter.rb
+++ b/src/_plugins/twitter.rb
@@ -166,22 +166,12 @@ module Jekyll
         }
       end
 
-      media_div = ""
       if tweet_data["entities"]["media"] != nil
         tweet_data["entities"]["media"].each { |m|
-          filename = m["media_url_https"].split("/").last
           text = text.sub(
             m["url"],
             "<a href=\"#{m["expanded_url"]}\">#{m["display_url"]}</a>"
           )
-          media_div = <<-EOD
-<div class=\"media\">
-  <a href="#{m["expanded_url"]}">
-    <img src=\"#{display_path(filename)}\">
-  </a>
-</div>
-EOD
-          media_div = media_div.strip
         }
       end
 
@@ -190,33 +180,6 @@ EOD
       markdown_converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       tpl = Liquid::Template.parse(File.open("src/_includes/tweet.html").read)
       tpl.render!("tweet_data" => tweet_data)
-      # markdown_converter.convert("{% include tweet.html %}")
-#
-#       tweet_html = <<-EOT
-# {% include tweet.html %}
-# <div class="tweet">
-#   <blockquote>#{media_div}
-#     <div class="header">
-#       <div class="author">
-#         <a class="link link_blend" href="https://twitter.com/#{screen_name}">
-#           <span class="avatar">
-#             <img src="#{display_avatar_path(avatar_url, screen_name)}" alt="Profile picture for @#{screen_name}">
-#           </span>
-#           <span class="name" title="#{name}">#{name}</span>
-#           <span class="screen_name" title="@#{screen_name}">@#{screen_name}</span>
-#         </a>
-#       </div>
-#     </div>
-#     <div class="body">
-#       <p class="text">#{text}</p>
-#       <div class="metadata">
-#         <a class="link_blend" href="https://twitter.com/#{screen_name}/status/#{@tweet_id}">#{timestamp}</a>
-#       </div>
-#     </div>
-#   </blockquote>
-# </div>
-# EOT
-      # tweet_html.lines.map { |line| line.strip }.join("")
     end
   end
 end

--- a/src/_plugins/twitter.rb
+++ b/src/_plugins/twitter.rb
@@ -70,32 +70,26 @@ module Jekyll
 
       # Ensure user mentions (e.g. @alexwlchan) in the body of the tweet
       # are correctly rendered as links to the user page.
-      if tweet_data["entities"]["user_mentions"] != nil
-        tweet_data["entities"]["user_mentions"].each { |m|
-          text = text.sub(
-            "@#{m["screen_name"]}",
-            "<a href=\"https://twitter.com/#{m["screen_name"]}\">@#{m["screen_name"]}</a>"
-          )
-        }
-      end
+      tweet_data["entities"].fetch("user_mentions", []).each { |m|
+        text = text.sub(
+          "@#{m["screen_name"]}",
+          "<a href=\"https://twitter.com/#{m["screen_name"]}\">@#{m["screen_name"]}</a>"
+        )
+      }
 
-      if tweet_data["entities"]["hashtags"] != nil
-        tweet_data["entities"]["hashtags"].each { |h|
-          text = text.sub(
-            "##{h["text"]}",
-            "<a href=\"https://twitter.com/hashtag/#{h["text"]}\">##{h["text"]}</a>"
-          )
-        }
-      end
+      tweet_data["entities"].fetch("hashtags", []).each { |h|
+        text = text.sub(
+          "##{h["text"]}",
+          "<a href=\"https://twitter.com/hashtag/#{h["text"]}\">##{h["text"]}</a>"
+        )
+      }
 
-      if tweet_data["entities"]["media"] != nil
-        tweet_data["entities"]["media"].each { |m|
-          text = text.sub(
-            m["url"],
-            "<a href=\"#{m["expanded_url"]}\">#{m["display_url"]}</a>"
-          )
-        }
-      end
+      tweet_data["entities"].fetch("media", []).each { |m|
+        text = text.sub(
+          m["url"],
+          "<a href=\"#{m["expanded_url"]}\">#{m["display_url"]}</a>"
+        )
+      }
 
       text.strip
     end

--- a/src/_plugins/twitter.rb
+++ b/src/_plugins/twitter.rb
@@ -52,7 +52,7 @@ module Jekyll
     end
 
     def render_tweet_text(tweet_data)
-      text = tweet_data["text"] or tweet_data["full_text"]
+      text = tweet_data["text"]
       if text == nil
         text = tweet_data["full_text"]
       end

--- a/src/_plugins/twitter.rb
+++ b/src/_plugins/twitter.rb
@@ -193,7 +193,6 @@ module Jekyll
 
       tweet_data = JSON.parse(File.read(cache_file()))
 
-      markdown_converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
       tpl = Liquid::Template.parse(File.open("src/_includes/tweet.html").read)
       tpl.render!("tweet_data" => tweet_data)
     end


### PR DESCRIPTION
Liquid is where all the other templating happens. I want to tweak it shortly to support multiple images – this should make it more flexible and easier to bolt on the new bits. Templating in Ruby = 😢 