### PR TITLE
Minify SVGs when they get copied from `src` to `_site`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@ build:
 	docker run --tty --rm \
 		--volume $(ROOT):$(ROOT) \
 		--workdir $(ROOT) \
-		$(DOCKER_IMAGE) build
+		$(DOCKER_IMAGE) build --trace
 	make lint
 
 build-drafts:
 	docker run --tty --rm \
 		--volume $(ROOT):$(ROOT) \
 		--workdir $(ROOT) \
-		$(DOCKER_IMAGE) build --drafts --trace
+		$(DOCKER_IMAGE) build --trace --drafts
 	make lint
 
 lint:


### PR DESCRIPTION
Close #290, but properly.

As a bonus, this will break the build if I put in an invalid SVG image.