### PR TITLE
Tweak the appearance of the "all posts" page

### DIFF
--- a/src/_includes/archive_list.html
+++ b/src/_includes/archive_list.html
@@ -1,7 +1,7 @@
 <table class="archive">
 {% for post in posts %}
 <tr class="archive__entry">
-  {% if page.archive_variant == "yearly" or page.archive_variant == "monthly" or page.archive_variant == "index" %}
+  {% if page.archive_variant == "yearly" or page.archive_variant == "monthly" or page.archive_variant == "index" or include.variant == "most_recent_10" %}
     <td class="archive__date">{{ post.date | date: "%-d %b" }}</td>
   {% else %}
     <td class="archive__date">{{ post.date | date: "%b %Y" }}</td>

--- a/src/_layouts/all_posts.html
+++ b/src/_layouts/all_posts.html
@@ -11,7 +11,9 @@ layout: page
 <h3>Most recent 10 posts</h3>
 
 {% assign posts = page.posts | slice: 0, 10 %}
-{% include archive_list.html %}
+{% include archive_list.html variant="most_recent_10" %}
+
+<div class="post__separator" aria-hidden="true">&#9670;</div>
 
 {% for group in page.grouped_posts %}
   {% assign grp_category = group[0] %}


### PR DESCRIPTION
* The most recent 10 posts use DD/MM dates (1 Sep, 2 Oct, 3 Nov) rather then MM/YY (Sep 2019, Oct 2019)
* There's a grey diamond between the most recent 10 and the category list