### PR TITLE
Use youtube-nocookie.com to reduce tracking from YouTube embeds

### DIFF
--- a/src/_plugins/youtube.rb
+++ b/src/_plugins/youtube.rb
@@ -55,7 +55,7 @@ module Jekyll
 <iframe class="youtube"
         id="youtube_#{@video_id}"
         width="560" height="315"
-        src="https://www.youtube.com/embed/#{@video_id}"
+        src="https://www.youtube-nocookie.com/embed/#{@video_id}"
         frameborder="0" allowfullscreen></iframe>
 EOT
     end


### PR DESCRIPTION
h/t Steve Troughton-Smith: https://twitter.com/stroughtonsmith/status/1276940666933821440

> Today's protip: swap all your YouTube embeds for "http://youtube-nocookie.com". You may not even know you have tracking on your site, and Safari in macOS 11 will make it very clear