### PR TITLE
Make /all-posts/ the canonical page for the post archive

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -7,7 +7,12 @@
 
   <meta name="description" content="{{ page.summary | default: site.description }}">
 
+  {% if page.canonical_url %}
+  <link rel="canonical" href="{{ page.canonical_url | absolute_url }}">
+  {% else %}
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+  {% endif %}
+
   <link type="application/atom+xml" rel="alternate" href="{{ site.url }}/atom.xml">
 
   <!--

--- a/src/_plugins/all_posts_generator.rb
+++ b/src/_plugins/all_posts_generator.rb
@@ -98,6 +98,7 @@ module Jekyll
         "url" => File.join("/", "", year.to_s, month.to_s, "index.html"),
         "year" => @year,
         "display_month" => Date.new(year, month).strftime("%B %Y"),
+        "canonical_url" => "/all-posts/",
 
         # This causes the archive list to render dates "4 May", not "May 2020".
         "post_list_date_format" => "day_month",
@@ -154,6 +155,7 @@ module Jekyll
         "title" => "Posts from #{@year}",
         "posts" => @posts,
         "year" => @year,
+        "canonical_url" => "/all-posts/",
 
         # This causes the archive list to render dates "4 May", not "May 2020".
         "post_list_date_format" => "day_month",

--- a/src/all-posts-by-tag.md
+++ b/src/all-posts-by-tag.md
@@ -3,6 +3,7 @@ layout: page
 title: All posts by tag
 archive_variant: global
 post_list_date_format: month_year
+canonical_url: /all-posts/
 ---
 
 This is a list of every post on alexwlchan.net, organised by tag.

--- a/src/best-of.md
+++ b/src/best-of.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: My favourite posts
+canonical_url: /all-posts/
 ---
 
 This is a list of my favourite posts, sorted by date.


### PR DESCRIPTION
While searching in DuckDuckGo, I noticed that it's indexed the per-month and per-year archive pages, which are really specific views of the overall archive page.  They shouldn't be surfaced in search, only for people fiddling with URLs.

This patch uses <link rel="canonical"> to redirect search engines to the overall archive page, and away from the per-month/per-year pages.