### PR TITLE
Fix the CSS cache busting

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -18,13 +18,13 @@
   <meta name="page-source-path" content="{{ page.path }}">
 
 {% if page.theme and page.theme.color %}
-  <link rel="stylesheet" href="/theme/style_{{ page.theme.color }}.css?{{ site.time | date:'%Y%m%d%U%H%N%S' }}">
+  <link rel="stylesheet" href="/theme/style_{{ page.theme.color }}.css?h={% css_fingerprint %}">
   <link rel="shortcut icon" type="image/png" href="/theme/favicon_{{ page.theme.color }}.png">
   <link rel="shortcut icon" type="image/x-icon" href="/theme/favicon_{{ page.theme.color }}.ico">
   <meta name="theme-color" content="#{{ page.theme.color }}">
 
 {% else %}
-  <link rel="stylesheet" href="/theme/style.css?{{ site.time | date:'%Y%m%d%U%H%N%S' }}">
+  <link rel="stylesheet" href="/theme/style.css?h={% css_fingerprint %}">
   <link rel="shortcut icon" type="image/x-icon" href="/theme/favicon.ico" sizes="32x32">
   <meta name="theme-color" content="#d01c11">
 {% endif %}

--- a/src/_plugins/css_fingerprint.rb
+++ b/src/_plugins/css_fingerprint.rb
@@ -1,0 +1,24 @@
+# This provides a "fingerprint" of my CSS files.
+#
+# Roughly speaking, it's a hash of all the Sass files that get smushed
+# together into a single CSS file.  This gets included in the link to
+# the CSS files, so clients can cache the CSS file until it changes.
+
+checksums = Dir.glob("src/_scss/*.scss").map { |f|
+  Digest::MD5.file(open f).hexdigest
+}
+
+fingerprint = Digest::MD5.new
+fingerprint.update checksums.join("")
+
+FINGERPRINT = fingerprint.hexdigest
+
+module Jekyll
+  class CssFingerPrintTag < Liquid::Tag
+    def render(context)
+      FINGERPRINT
+    end
+  end
+end
+
+Liquid::Template.register_tag("css_fingerprint", Jekyll::CssFingerPrintTag)


### PR DESCRIPTION
It turns out iOS 15 ignores query parameters that aren't a key/value pair, so my cache-busting isn't actually working.  This switches to a k/v pair and embeds the MD5 fingerprint in the URL, so it should only bust the cache when the CSS actually changes.