### PR TITLE
Generate the per-colour SCSS files at build time

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,9 @@ permalink: "/:year/:month/:title/"
 keep_files: [
   # Managed by rsync outside the main Jekyll process
   "files", "images", "slides",
+
+  # Managed by the theming plugin
+  "theme/style_*.css",
 ]
 
 # This is the file used by Netlify to define redirects and the custom

--- a/src/_plugins/theming.rb
+++ b/src/_plugins/theming.rb
@@ -1,22 +1,16 @@
 Jekyll::Hooks.register :site, :post_write do |site|
-  colors = site.posts.docs
+  colours = site.posts.docs
     .map { |post|
       (post["theme"] || {})["color"]
     }
     .reject{ |c| c.nil? }
     .uniq
 
-  create_scss_themes(site, colors)
+  create_scss_themes(site, colours)
 
-  # puts colors
-  #
-  # site.posts.docs.each { |post|
-  #   if post["theme"] && post["theme"]["color"]
-  #     color = post["theme"]["color"]
-  #     create_scss_theme(site, dst, color)
-  #     ensure_banner_image_exists(src, color)
-  #   end
-  # }
+  colours.each { |c|
+    ensure_banner_image_exists(src, c)
+  }
 end
 
 

--- a/src/_plugins/theming.rb
+++ b/src/_plugins/theming.rb
@@ -1,33 +1,50 @@
-Jekyll::Hooks.register :site, :post_read do |site|
-  src = site.config["source"]
-  site.posts.docs.each { |post|
-    if post["theme"] && post["theme"]["color"]
-      color = post["theme"]["color"]
-      create_scss_theme(src, color)
-      ensure_banner_image_exists(src, color)
-    end
-  }
+Jekyll::Hooks.register :site, :post_write do |site|
+  colors = site.posts.docs
+    .map { |post|
+      (post["theme"] || {})["color"]
+    }
+    .reject{ |c| c.nil? }
+    .uniq
+
+  create_scss_themes(site, colors)
+
+  # puts colors
+  #
+  # site.posts.docs.each { |post|
+  #   if post["theme"] && post["theme"]["color"]
+  #     color = post["theme"]["color"]
+  #     create_scss_theme(site, dst, color)
+  #     ensure_banner_image_exists(src, color)
+  #   end
+  # }
 end
 
 
-# Create an SCSS theme with this color as the $primary-color variable.
-#
-# This will be picked up by the SCSS processor for the site, and cause
-# the creation of a CSS theme with this as the primary color.
-def create_scss_theme(src, color)
-  mainfile = "#{src}/theme/style_#{color.gsub(/#/, '')}.scss"
-  if ! File.file?(mainfile)
-    File.open(mainfile, 'w') { |file| file.write(<<-EOT
----
----
+def get_newest_scss_include(site)
+  src = site.config["source"]
+  sass_dir = site.config["sass"]["sass_dir"]
+end
 
-$primary-color: #{color};
+
+def create_scss_themes(site, colours)
+  src = site.config["source"]
+  dst = site.config["destination"]
+  sass_dir = site.config["sass"]["sass_dir"]
+
+  converter = site.find_converter_instance(::Jekyll::Converters::Scss)
+
+  colours.map { |c|
+    out_file = "#{dst}/theme/style_#{c.gsub(/#/, '')}.css"
+
+    css = converter.convert(<<-EOT
+$primary-color: #{c};
 
 @import "_main.scss";
 EOT
-) }
-    puts(mainfile)
-  end
+)
+
+    File.open(out_file, 'w') { |f| f.write(css) }
+  }
 end
 
 

--- a/src/_posts/2018/2018-08-13-inclusive-conferences.md
+++ b/src/_posts/2018/2018-08-13-inclusive-conferences.md
@@ -14,7 +14,6 @@ index:
 {% update "2019-02-05" %}
 Thank you to everyone who's read, shared, or given feedback on this post.
 I've been thrilled by the number of people who've said they found it useful.
-
 I got a lot of suggestions for new ideas to add to the list, and I had some thoughts on how to make it more readable.
 So if you're interested, there's a new version at <https://alexwlchan.net/ideas-for-inclusive-events/>, and I'll be trying to keep that updated more frequently.
 Enjoy!

--- a/src/theme/style_008000.scss
+++ b/src/theme/style_008000.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #008000;
-
-@import "_main.scss";

--- a/src/theme/style_008921.scss
+++ b/src/theme/style_008921.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #008921;
-
-@import "_main.scss";

--- a/src/theme/style_0a9f9f.scss
+++ b/src/theme/style_0a9f9f.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #0a9f9f;
-
-@import "_main.scss";

--- a/src/theme/style_109a19.scss
+++ b/src/theme/style_109a19.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #109A19;
-
-@import "_main.scss";

--- a/src/theme/style_20883f.scss
+++ b/src/theme/style_20883f.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #20883F;
-
-@import "_main.scss";

--- a/src/theme/style_4b536e.scss
+++ b/src/theme/style_4b536e.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #4b536e;
-
-@import "_main.scss";

--- a/src/theme/style_531b93.scss
+++ b/src/theme/style_531b93.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #531b93;
-
-@import "_main.scss";

--- a/src/theme/style_624230.scss
+++ b/src/theme/style_624230.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #624230;
-
-@import "_main.scss";

--- a/src/theme/style_6c006c.scss
+++ b/src/theme/style_6c006c.scss
@@ -1,6 +1,0 @@
----
----
-
-$primary-color: #6c006c;
-
-@import "_main.scss";


### PR DESCRIPTION
Previously these files had to be generated and checked in, but they're automatically generated derivatives.  It's easier to generate them at build time and dump them straight in the `_site` directory than have them cluttering up `src`.

This is part of #508.