### PR TITLE
Move the image used for builds into GitHub Container Registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ FROM ruby:3.1-slim
 
 LABEL maintainer "Alex Chan <alex@alexwlchan.net>"
 LABEL description "Build image for alexwlchan.net"
+LABEL org.opencontainers.image.source https://github.com/alexwlchan/alexwlchan.net
 
 COPY ./scripts/install_imagemagick7.sh .
 RUN ./install_imagemagick7.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-export DOCKER_IMAGE_NAME = greengloves/alexwlchan.net
-export DOCKER_IMAGE_VERSION = 35
+export DOCKER_IMAGE_NAME = ghcr.io/alexwlchan/alexwlchan.net
+export DOCKER_IMAGE_VERSION = 36
 DOCKER_IMAGE = $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION)
 
 ROOT = $(shell git rev-parse --show-toplevel)


### PR DESCRIPTION
Docker is doing… something with their free plan, I don't really know what? There's nothing keeping me on Docker Hub, so this publishes the image into GitHub Container Registry instead.

See https://github.com/docker/hub-feedback/issues/2314