### PR TITLE
Use `docker buildx` to publish multi-architecture images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export DOCKER_IMAGE_NAME = ghcr.io/alexwlchan/alexwlchan.net
-export DOCKER_IMAGE_VERSION = 36
+export DOCKER_IMAGE_VERSION = 37
 DOCKER_IMAGE = $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_VERSION)
 
 ROOT = $(shell git rev-parse --show-toplevel)

--- a/scripts/publish_docker_image.rb
+++ b/scripts/publish_docker_image.rb
@@ -8,8 +8,9 @@ existing_makefile = File.read('Makefile')
 
 new_image_tag = "#{image_name}:#{new_version}"
 
-system("docker build --tag #{new_image_tag} .")
-system("docker push #{new_image_tag}")
+system("docker buildx build --push \
+  --platform linux/amd64,linux/arm64 \
+  --tag #{new_image_tag} .")
 
 new_makefile = existing_makefile.sub(
   "DOCKER_IMAGE_VERSION = #{old_version}",


### PR DESCRIPTION
I'm now publishing linux/arm64 and linux/amd64 images, which should work on Intel and Apple Silicon Macs, respectively: see https://github.com/alexwlchan/alexwlchan.net/pkgs/container/alexwlchan.net/82198174?tag=37

I see a noticeable perf improvement to using a native image vs one in emulation, so this will be the approach for all new images.

Closes https://github.com/alexwlchan/alexwlchan.net/issues/584

