### PR TITLE
Convert to using YAML lists for tags

### DIFF
--- a/front-matter.json
+++ b/front-matter.json
@@ -29,7 +29,8 @@
         },
         "tags": {
             "description": "A space-separated list of tags for this page or post.",
-            "type": "string"
+            "type": "array",
+            "items": {"type": "string"}
         },
         "link": {
             "description": "An external page that this page should link to, like a link blog. This is used on the HTML version of the page, and where clicking on the RSS feed entry will take the reader.",

--- a/src/_posts/2012/2012-12-30-hypercritical.md
+++ b/src/_posts/2012/2012-12-30-hypercritical.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2012-12-30 00:07:00 +0000
 summary: My thoughts on the ending of Hypercritical, a podcast by John Siracusa.
-tags: podcasts
+tags:
+  - podcasts
 title: Hypercritical
 ---
 

--- a/src/_posts/2013/2013-01-10-zero.md
+++ b/src/_posts/2013/2013-01-10-zero.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2013-01-10 00:41:00 +0000
 summary: An essay about the number zero that I wrote for school.
-tags: maths
+tags:
+  - maths
 title: Zero
 ---
 

--- a/src/_posts/2013/2013-02-13-darwin.md
+++ b/src/_posts/2013/2013-02-13-darwin.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2013-02-13 10:33:00 +0000
 summary: Looking at whether Darwin ever missed out on birthday cake for pancakes
-tags: datetime-shenanigans maths
+tags:
+  - datetime-shenanigans
+  - maths
 title: Darwin, pancakes and birthdays
 ---
 

--- a/src/_posts/2013/2013-03-06-candybar.md
+++ b/src/_posts/2013/2013-03-06-candybar.md
@@ -3,7 +3,8 @@ layout: post
 date: 2013-03-06 23:46:00 +0000
 summary: Some recommendations for alternative icon sets to use with the Mac theming
   app Candybar.
-tags: macos
+tags:
+  - macos
 title: Candybar and icon recommendations
 ---
 

--- a/src/_posts/2013/2013-03-30-timezone-bug.md
+++ b/src/_posts/2013/2013-03-30-timezone-bug.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2013-03-30 19:57:00 +0000
 summary: A strange bug with OS X's timezone handling
-tags: dates os-x
+tags:
+  - dates
+  - os-x
 title: Strange clock bug in OS X
 index:
   exclude: true

--- a/src/_posts/2013/2013-03-31-pinboard-backups.md
+++ b/src/_posts/2013/2013-03-31-pinboard-backups.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2013-03-31 11:13:00 +0000
 summary: A script for automatically backing up bookmarks from Pinboard
-tags: pinboard python
+tags:
+  - pinboard
+  - python
 title: Automatic Pinboard backups
 ---
 

--- a/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
+++ b/src/_posts/2013/2013-05-11-rss-podcasts-tumblr.md
@@ -3,7 +3,9 @@ layout: post
 date: 2013-05-11 12:26:00 +0000
 summary: A barely advertised feature of Tumblr that lets you get an RSS feed of external
   audio posts.
-tags: podcasts tumblr
+tags:
+  - podcasts
+  - tumblr
 title: Podcast feeds on Tumblr
 ---
 

--- a/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
+++ b/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2013-08-06 09:52:00 +0000
-tags: tumblr python
+tags:
+  - tumblr
+  - python
 title: Finding untagged posts on Tumblr
 ---
 

--- a/src/_posts/2013/2013-08-20-google-maps.md
+++ b/src/_posts/2013/2013-08-20-google-maps.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2013-08-20 10:47:00 +0000
 summary: A bookmarklet to hide some of the UI chrome in the new design of Google Maps.
-tags: javascript
+tags:
+  - javascript
 title: Cleaning up Google Maps
 ---
 

--- a/src/_posts/2013/2013-11-13-textmate-quick-look.md
+++ b/src/_posts/2013/2013-11-13-textmate-quick-look.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2013-11-13 08:16:00 +0000
 summary: Disabling the Quick Look plugin that comes in the TextMate 2 alpha.
-tags: textmate os-x
+tags:
+  - textmate
+  - os-x
 title: TextMate 2 and Quick Look
 index:
   exclude: true

--- a/src/_posts/2014/2014-04-20-veil.md
+++ b/src/_posts/2014/2014-04-20-veil.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-04-20 09:58:00 +0000
-tags: harry-potter
+tags:
+  - harry-potter
 title: Pulling back the veil
 ---
 

--- a/src/_posts/2014/2014-05-12-part-ii-advice.md
+++ b/src/_posts/2014/2014-05-12-part-ii-advice.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2014-05-12 15:53:00 +0000
 summary: Some suggestions for second year Cambridge maths students looking for workover the summer.
-tags: maths cambridge
+tags:
+  - maths
+  - cambridge
 title: Brief advice for Part II
 index:
   exclude: true

--- a/src/_posts/2014/2014-05-14-part-ia-exams.md
+++ b/src/_posts/2014/2014-05-14-part-ia-exams.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2014-05-14 21:10:00 +0000
 summary: Some advice for IA Mathmos sitting Tripos
-tags: cambridge maths
+tags:
+  - cambridge
+  - maths
 title: Some Part IA exam advice
 ---
 

--- a/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
+++ b/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-06-13 07:50:00 +0000
-tags: tumblr
+tags:
+  - tumblr
 title: Finding untagged posts on Tumblr, redux
 ---
 

--- a/src/_posts/2014/2014-06-23-instapaper-urls.md
+++ b/src/_posts/2014/2014-06-23-instapaper-urls.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2014-06-23 13:04:00 +0000
-tags: instapaper applescript
+tags:
+  - instapaper
+  - applescript
 title: Catching instapaper:// URLs from ReadKit
 index:
   exclude: true

--- a/src/_posts/2014/2014-06-29-skeletor.md
+++ b/src/_posts/2014/2014-06-29-skeletor.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-06-29 10:11:00 +0000
-tags: skeletor
+tags:
+  - skeletor
 title: Skeletor!
 ---
 

--- a/src/_posts/2014/2014-07-11-latex-alpha.md
+++ b/src/_posts/2014/2014-07-11-latex-alpha.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2014-07-11 07:43:00 +0000
-tags: latex wolfram-alpha
+tags:
+  - latex
+  - wolfram-alpha
 title: Getting plaintext LaTeX from Wolfram Alpha
 colors:
   index_light: "#f35716"

--- a/src/_posts/2014/2014-07-18-overcast.md
+++ b/src/_posts/2014/2014-07-18-overcast.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2014-07-18 02:39:00 +0000
 summary: Some thoughts on Marco Arment's new podcast player, Overcast.
-tags: podcasts
+tags:
+  - podcasts
 title: Thoughts on Overcast
 ---
 

--- a/src/_posts/2014/2014-08-28-alfred-screenshots.md
+++ b/src/_posts/2014/2014-08-28-alfred-screenshots.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2014-08-28 00:32:00 +0000
-tags: alfred applescript
+tags:
+  - alfred
+  - applescript
 title: A quick Alfred workflow for opening recent screenshots
 ---
 

--- a/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
+++ b/src/_posts/2014/2014-08-29-textexpander-amazon-affiliates.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-08-29 22:06:00 +0000
-tags: textexpander
+tags:
+  - textexpander
 title: A TextExpander snippet for Amazon affiliate links
 ---
 

--- a/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
+++ b/src/_posts/2014/2014-08-31-untagged-tumblr-updates.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-08-31 12:12:00 +0000
-tags: tumblr
+tags:
+  - tumblr
 title: Updates to my site for finding untagged Tumblr posts
 ---
 

--- a/src/_posts/2014/2014-09-05-new-standing-desk.md
+++ b/src/_posts/2014/2014-09-05-new-standing-desk.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2014-09-05 19:14:00 +0000
 summary: A standing desk that I built solely from IKEA parts.
-tags: personal
+tags:
+  - personal
 title: My new standing desk
 ---
 

--- a/src/_posts/2014/2014-09-14-404-pages.md
+++ b/src/_posts/2014/2014-09-14-404-pages.md
@@ -1,7 +1,10 @@
 ---
 layout: post
 date: 2014-09-14 00:13:00 +0000
-tags: python:pelican python blogging-about-blogging
+tags:
+  - python:pelican
+  - python
+  - blogging-about-blogging
 title: Playing with 404 pages
 ---
 

--- a/src/_posts/2014/2014-10-01-notes-on-tumblr.md
+++ b/src/_posts/2014/2014-10-01-notes-on-tumblr.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-10-01 18:34:00 +0000
-tags: tumblr
+tags:
+  - tumblr
 title: Notes on Tumblr
 ---
 

--- a/src/_posts/2014/2014-10-28-virtualfish.md
+++ b/src/_posts/2014/2014-10-28-virtualfish.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2014-10-28 20:06:00 +0000
-tags: fish-shell shell-scripting
+tags:
+  - fish-shell
+  - shell-scripting
 title: '"Missing argument at index 2" in fish'
 index:
   exclude: true

--- a/src/_posts/2014/2014-11-02-ranged-strings.md
+++ b/src/_posts/2014/2014-11-02-ranged-strings.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-11-02 16:19:00 +0000
-tags: python
+tags:
+  - python
 title: Unpacking sets and ranges from a single string
 ---
 

--- a/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
+++ b/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2014-12-06 22:42:00 +0000
 link: http://gouwens.net/skeletors-all-the-way-down
-tags: skeletor
+tags:
+  - skeletor
 title: Skeletors All the Way Down
 ---
 

--- a/src/_posts/2014/2014-12-10-acronyms.md
+++ b/src/_posts/2014/2014-12-10-acronyms.md
@@ -1,7 +1,8 @@
 ---
 layout: post
 date: 2014-12-10 08:12:00 +0000
-tags: python
+tags:
+  - python
 title: Acronyms
 ---
 

--- a/src/_posts/2014/2014-12-28-imessage-export.md
+++ b/src/_posts/2014/2014-12-28-imessage-export.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2014-12-28 13:00:00 +0000
 link: https://github.com/alexwlchan/imessage-archive
-tags: macos python macos:imessage
+tags:
+  - macos
+  - python
+  - macos:imessage
 title: A script for exporting from iMessage
 index:
   exclude: true

--- a/src/_posts/2014/2014-12-29-pelican-linkposts.md
+++ b/src/_posts/2014/2014-12-29-pelican-linkposts.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2014-12-29 08:26:00 +0000
-tags: pelican python
+tags:
+  - pelican
+  - python
 title: RSS linkposts in Pelican
 index:
   exclude: true

--- a/src/_posts/2015/2015-01-06-bbfc-podcast.md
+++ b/src/_posts/2015/2015-01-06-bbfc-podcast.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-01-06 21:22:00 +0000
 link: http://www.empireonline.com/news/story.asp?NID=37746
-tags: podcasts
+tags:
+  - podcasts
 title: Empire's BBFC Ratings Podcast Special
 
 index:

--- a/src/_posts/2015/2015-01-16-govuk.md
+++ b/src/_posts/2015/2015-01-16-govuk.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-01-16 20:55:00 +0000
 link: https://www.gov.uk/register-to-vote
-tags: politics
+tags:
+  - politics
 title: "Register to vote \u2013 GOV.UK"
 
 index:

--- a/src/_posts/2015/2015-02-09-swift-let.md
+++ b/src/_posts/2015/2015-02-09-swift-let.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-02-09 21:09:00 +0000
 link: https://developer.apple.com/swift/blog/?id=22
-tags: swift
+tags:
+  - swift
 title: Swift 1.2 improves the "let" keyword, and other improvements
 index:
   exclude: true

--- a/src/_posts/2015/2015-02-12-lists.md
+++ b/src/_posts/2015/2015-02-12-lists.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-02-12 12:00:00 +0000
 summary: A bookmarklet to add checkboxes to lists in the browser.
-tags: javascript
+tags:
+  - javascript
 title: Adding checkboxes to lists
 ---
 

--- a/src/_posts/2015/2015-02-22-1password.md
+++ b/src/_posts/2015/2015-02-22-1password.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-02-22 12:00:00 +0000
 title: Tidying up my 1Password
-tags: infosec
+tags:
+  - infosec
 ---
 
 I've been creating online accounts for years, and saving them in 1Password, but everything was a bit scattered. I'd never stopped to organise or tidy up my database. I also had a lot of weak or duplicate passwords that I'd never changed.

--- a/src/_posts/2015/2015-02-22-flask-notes.md
+++ b/src/_posts/2015/2015-02-22-flask-notes.md
@@ -2,7 +2,8 @@
 date: 2015-02-22 08:00:00 +0000
 layout: post
 link: https://charlesleifer.com/blog/saturday-morning-hack-a-little-note-taking-app-with-flask/
-tags: python
+tags:
+  - python
 title: A Flask app for taking notes
 index:
   exclude: true

--- a/src/_posts/2015/2015-03-05-python-firewall.md
+++ b/src/_posts/2015/2015-03-05-python-firewall.md
@@ -2,7 +2,9 @@
 date: 2015-03-05 08:24:00 +0000
 layout: post
 link: http://stackoverflow.com/q/19688841/1558022
-tags: python os-x
+tags:
+  - python
+  - os-x
 title: Adding Python to the OS X firewall
 index:
   exclude: true

--- a/src/_posts/2015/2015-03-07-pygmentizr.md
+++ b/src/_posts/2015/2015-03-07-pygmentizr.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2015-03-07 10:44:00 +0000
 summary: A web app for applying syntax highlighting to code using the Pygments library.
-tags: python python:pygments
+tags:
+  - python
+  - python:pygments
 title: Pygmentizr
 ---
 

--- a/src/_posts/2015/2015-03-29-exam-advice.md
+++ b/src/_posts/2015/2015-03-29-exam-advice.md
@@ -3,7 +3,8 @@ layout: post
 date: 2015-03-29 13:30:00 +0000
 link: http://alexwlchan.net/exams
 summary: Some advice for students sitting technical exams
-tags: maths
+tags:
+  - maths
 title: Some exam advice
 ---
 

--- a/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
+++ b/src/_posts/2015/2015-05-16-one-step-paste-simulator.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-05-16 11:51:00 +0000
 summary: How to paste text directly from OS X into the iOS Simulator.
-tags: os-x
+tags:
+  - os-x
 title: One-step paste in the iOS Simulator
 index:
   exclude: true

--- a/src/_posts/2015/2015-05-17-nvalt-and-marked.md
+++ b/src/_posts/2015/2015-05-17-nvalt-and-marked.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-05-17 20:16:00 +0000
 summary: A Python script that takes a note from nvALT and opens it in Marked.
-tags: python
+tags:
+  - python
 title: Previewing notes from nvALT in Marked
 index:
   exclude: true

--- a/src/_posts/2015/2015-05-26-github-contributions.md
+++ b/src/_posts/2015/2015-05-26-github-contributions.md
@@ -3,7 +3,8 @@ layout: post
 date: 2015-05-26 19:13:00 +0000
 summary: I made a clone of GitHub's Contributions graph to use as a motivational tool.
 title: Cloning GitHub's Contributions chart
-tags: github
+tags:
+  - github
 colors:
   index_light: "#4a35a5"
   index_dark:  "#79d9e9"

--- a/src/_posts/2015/2015-06-02-git-info-exclude.md
+++ b/src/_posts/2015/2015-06-02-git-info-exclude.md
@@ -2,7 +2,8 @@
 date: 2015-06-02 18:09:00 +0000
 layout: post
 summary: Another way to ignore untracked files in Git.
-tags: git
+tags:
+  - git
 title: 'Useful Git features: a per-clone exclude file (.git/info/exclude)'
 ---
 

--- a/src/_posts/2015/2015-06-22-safer-file-copying.md
+++ b/src/_posts/2015/2015-06-22-safer-file-copying.md
@@ -2,7 +2,8 @@
 date: 2015-06-22 23:20:00 +0000
 layout: post
 summary: A Python script for non-destructive file copying/moving.
-tags: python
+tags:
+  - python
 title: Safer file copying in Python
 ---
 

--- a/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
+++ b/src/_posts/2015/2015-06-29-persistent-ipython-notebooks.md
@@ -3,7 +3,10 @@ date: 2015-06-29 17:55:00 +0000
 layout: post
 summary: Configuring an IPython notebook server that is always running and easily
   accessible in Windows.
-tags: python windows python:ipython
+tags:
+  - python
+  - windows
+  - python:ipython
 title: Persistent IPython notebooks in Windows
 ---
 

--- a/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
+++ b/src/_posts/2015/2015-07-27-exit-traps-in-bash.md
@@ -2,7 +2,8 @@
 date: 2015-07-27 20:36:00 +0000
 layout: post
 link: http://redsymbol.net/articles/bash-exit-traps/
-tags: shell-scripting
+tags:
+  - shell-scripting
 title: 'Useful Bash features: exit traps'
 ---
 

--- a/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
+++ b/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
@@ -3,7 +3,8 @@ layout: post
 date: 2015-08-19 22:55:00 +0000
 link: http://finduntaggedtumblrposts.com
 summary: A new version of my site for finding untagged Tumblr posts.
-tags: tumblr
+tags:
+  - tumblr
 title: Finding even more untagged posts on Tumblr
 ---
 

--- a/src/_posts/2015/2015-09-06-effective-python.md
+++ b/src/_posts/2015/2015-09-06-effective-python.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2015-09-06 18:42:00 +0000
 summary: A review of Effective Python, by Brett Slatkin.
-tags: python books
+tags:
+  - python
+  - books
 title: 'Review: Effective Python'
 ---
 

--- a/src/_posts/2015/2015-09-16-http2-by-stealth.md
+++ b/src/_posts/2015/2015-09-16-http2-by-stealth.md
@@ -3,7 +3,9 @@ layout: post
 date: 2015-09-16 20:59:00 +0000
 summary: Apple has quietly adopted HTTP/2 in iOS 9 and El Capitan, and (almost) nobody
   noticed.
-tags: os-x http-2
+tags:
+  - os-x
+  - http-2
 title: Apple quietly adopts HTTP/2
 index:
   exclude: true

--- a/src/_posts/2015/2015-09-20-spotlight-suggestions.md
+++ b/src/_posts/2015/2015-09-20-spotlight-suggestions.md
@@ -3,7 +3,8 @@ layout: post
 date: 2015-09-20 09:32:00 +0000
 summary: In iOS 9, you can turn off the News in Spotlight by toggling Spotlight Suggestions.
   But what else does this disable?
-tags: ios
+tags:
+  - ios
 title: "What does \u201CSpotlight Suggestions\u201D turn off?"
 index:
   exclude: true

--- a/src/_posts/2015/2015-10-12-getting-started-testing.md
+++ b/src/_posts/2015/2015-10-12-getting-started-testing.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-10-12 08:23:00 +0000
 link: https://www.youtube.com/watch?v=FxSsnHeWQBY
-tags: python
+tags:
+  - python
 title: Getting Started Testing, by Ned Batchelder
 
 index:

--- a/src/_posts/2015/2015-11-02-quick-shell-docker.md
+++ b/src/_posts/2015/2015-11-02-quick-shell-docker.md
@@ -2,7 +2,9 @@
 date: 2015-11-02 22:07:00 +0000
 layout: post
 summary: A Bash function for quickly getting shell access to Docker containers.
-tags: docker shell-scripting
+tags:
+  - docker
+  - shell-scripting
 title: Quick shell access for Docker containers
 ---
 

--- a/src/_posts/2015/2015-11-03-bbc-micro-bit.md
+++ b/src/_posts/2015/2015-11-03-bbc-micro-bit.md
@@ -3,7 +3,8 @@ date: 2015-11-03 22:12:00 +0000
 layout: post
 summary: Playing with a tiny computer that runs Python.
 link: http://www.bbc.co.uk/programmes/articles/4hVG2Br1W1LKCmw8nSm9WnQ/introducing-the-bbc-micro-bit
-tags: python
+tags:
+  - python
 title: Python and the BBC micro:bit
 colors:
   index_light: "#18ab6d"

--- a/src/_posts/2015/2015-11-13-beyond-pep8.md
+++ b/src/_posts/2015/2015-11-13-beyond-pep8.md
@@ -4,7 +4,8 @@ index:
   exclude: true
 layout: post
 link: https://www.youtube.com/watch?v=wf-BqAjZb8M
-tags: python
+tags:
+  - python
 title: 'Beyond PEP 8: Best practices for beautiful intelligible code'
 ---
 

--- a/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
+++ b/src/_posts/2015/2015-11-15-export-urls-from-safari-reading-list.md
@@ -2,7 +2,9 @@
 date: 2015-11-15 21:50:00 +0000
 layout: post
 summary: A Python script for getting a list of URLs from Safari Reading List.
-tags: macos macos:safari
+tags:
+  - macos
+  - macos:safari
 title: Export a list of URLs from Safari Reading List
 ---
 

--- a/src/_posts/2015/2015-11-30-backups-and-docker.md
+++ b/src/_posts/2015/2015-11-30-backups-and-docker.md
@@ -3,7 +3,8 @@ layout: post
 date: 2015-11-30 22:39:00 +0000
 summary: The Docker folder on your computer can quickly fill up space. Don't forget
   to exclude it from backups.
-tags: docker
+tags:
+  - docker
 title: Backups and Docker
 ---
 

--- a/src/_posts/2015/2015-12-10-simpler-syndication.md
+++ b/src/_posts/2015/2015-12-10-simpler-syndication.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2015-12-10 08:15:00 +0000
 link: http://leancrew.com/all-this/2015/11/simpler-syndication/
-tags: python
+tags:
+  - python
 title: Simpler syndication, by Dr. Drang
 index:
   exclude: true

--- a/src/_posts/2015/2015-12-13-pretty-print.md
+++ b/src/_posts/2015/2015-12-13-pretty-print.md
@@ -1,7 +1,9 @@
 ---
 date: 2015-12-13 17:15:00 +0000
 layout: post
-tags: shell-scripting macos
+tags:
+  - shell-scripting
+  - macos
 title: Pretty printing JSON and XML in the shell
 ---
 

--- a/src/_posts/2016/2016-01-20-skeletor-2015.md
+++ b/src/_posts/2016/2016-01-20-skeletor-2015.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-01-20 19:38:00 +0000
 link: /skeletor
 summary: Updating the Skeletor clip loop chart for the 2015 Clip Show.
-tags: skeletor
+tags:
+  - skeletor
 title: The Skeletor clip loop, 2015 edition
 ---
 

--- a/src/_posts/2016/2016-01-25-harry-potter-ipod.md
+++ b/src/_posts/2016/2016-01-25-harry-potter-ipod.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2016-01-25 17:22:00 +0000
 link: http://www.512pixels.net/blog/2016/1/the-harry-potter-collectors-ipod
-tags: ipod harry-potter
+tags:
+  - ipod
+  - harry-potter
 title: The Harry Potter Collector's iPod
 summary: A rare and unusual iPod variant I'd never heard of before.
 ---

--- a/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
+++ b/src/_posts/2016/2016-02-09-saved-by-the-prompt.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2016-02-09 12:49:00 +0000
 summary: It turns out that an SSH client on your iPhone can be really handy.
-tags: ios
+tags:
+  - ios
 title: Saved by the Prompt
 index:
   exclude: true

--- a/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
+++ b/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
@@ -3,7 +3,10 @@ layout: post
 date: 2016-02-24 08:16:00 +0000
 summary: "I have some TextExpander snippets that I use to cut out words I don\u2019\
   t want to write."
-tags: textexpander writethedocs inclusion
+tags:
+  - textexpander
+  - writethedocs
+  - inclusion
 title: How I use TextExpander to curb my language
 ---
 

--- a/src/_posts/2016/2016-03-08-backup-paranoia.md
+++ b/src/_posts/2016/2016-03-08-backup-paranoia.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-03-08 08:52:00 +0000
 title: Backup paranoia
 summary: Running a backup is good protection against data loss, but it's not perfect.  I take extra measures to ensure I have really safe backups.
-tags: backups
+tags:
+  - backups
 index:
   exclude: true
 ---

--- a/src/_posts/2016/2016-03-27-exclusive-create-python.md
+++ b/src/_posts/2016/2016-03-27-exclusive-create-python.md
@@ -3,7 +3,8 @@ date: 2016-03-27 10:33:00 +0000
 layout: post
 summary: If you want to create a file, but only if it doesn't already exist, Python
   3 has a helpful new file mode `x`.
-tags: python
+tags:
+  - python
 title: Exclusively create a file in Python 3
 ---
 

--- a/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
+++ b/src/_posts/2016/2016-03-29-itunes-images-with-alfred.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-03-29 07:56:00 +0000
 summary: Using Alfred and a Python script to retrieve artwork from the iTunes, App
   and Mac App Stores.
-tags: alfred python
+tags:
+  - alfred
+  - python
 title: Get images from the iTunes/App/Mac App Stores with Alfred
 colors:
   index_light: "#333333"

--- a/src/_posts/2016/2016-04-08-regexes-are-code.md
+++ b/src/_posts/2016/2016-04-08-regexes-are-code.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-04-08 13:03:00 +0000
 summary: Regexes have a reputation for being unreadable monsters, but it doesn't have
   to be that way.
-tags: regex
+tags:
+  - regex
 title: Treat regular expressions as code, not magic
 
 colors:

--- a/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
+++ b/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-04-16 14:32:00 +0000
 summary: "I\u2019ve adapted my bookmarklet for tidying up Google Maps to hide the\
   \ YouTube search bar."
-tags: javascript
+tags:
+  - javascript
 title: Hiding the YouTube search bar
 index:
   exclude: true

--- a/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
+++ b/src/_posts/2016/2016-05-01-os-x-hates-textmate.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-05-01 19:55:00 +0000
 title: "\u201CThe document could not be saved\u201D"
 summary: "Debugging a strange interaction between TextMate and OS X\u2019s security system."
-tags: os-x textmate
+tags:
+  - os-x
+  - textmate
 index:
   exclude: true
 ---

--- a/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf.md
+++ b/src/_posts/2016/2016-05-05-safely-deleting-a-file-called-rf.md
@@ -2,7 +2,9 @@
 date: 2016-05-05 21:03:00 +0000
 summary: If for some reason you create a file called `-rf *`, it’s possible to delete it safely. But really, don’t create it in the first place.
 layout: post
-tags: shell-scripting code-crimes
+tags:
+  - shell-scripting
+  - code-crimes
 title: Safely deleting a file called ‘-rf *’
 ---
 

--- a/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
+++ b/src/_posts/2016/2016-05-10-python-smtplib-and-fastmail.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-05-10 12:41:00 +0000
 title: A Python smtplib wrapper for FastMail
 summary: A quick python-smtplib wrapper for sending emails through FastMail.
-tags: python fastmail
+tags:
+  - python
+  - fastmail
 ---
 
 Sometimes I want to send email from a Python script on my Mac.

--- a/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
+++ b/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-05-16 21:02:00 +0000
 summary: A Python script for finding 404 errors in my Apache web logs - and by extension,
   broken pages.
-tags: python apache
+tags:
+  - python
+  - apache
 title: Finding 404s and broken pages in my Apache logs
 ---
 

--- a/src/_posts/2016/2016-06-07-hypothesis-intro.md
+++ b/src/_posts/2016/2016-06-07-hypothesis-intro.md
@@ -1,7 +1,9 @@
 ---
 layout: post
 date: 2016-06-07 12:00:00 +0000
-tags: python python:hypothesis
+tags:
+  - python
+  - python:hypothesis
 title: Introduction to property-based testing
 summary: Testing with randomly generated examples can be a good way to uncover bugs in your code.
 ---

--- a/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
+++ b/src/_posts/2016/2016-06-09-introduction-to-property-based-testing.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-06-09 08:29:00 +0000
 link: /2016/hypothesis-intro/
 summary: Slides from my talk about property-based testing at CamPUG.
-tags: python slides
+tags:
+  - python
+  - slides
 title: Introduction to property-based testing
 index:
   exclude: true

--- a/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
+++ b/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
@@ -3,7 +3,10 @@ layout: post
 date: 2016-06-16 08:50:00 +0000
 summary: A Python script I wrote that let me sends web pages from my Mac and my iPhone
   to my Kindle.
-tags: python kindle ebooks
+tags:
+  - python
+  - kindle
+  - ebooks
 title: Reading web pages on my Kindle
 ---
 

--- a/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
+++ b/src/_posts/2016/2016-07-04-clearing-disk-space-on-os-x.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-07-04 07:42:00 +0000
 summary: "A few tools and utilities I\u2019ve been using to help clear disk space\
   \ on my Mac."
-tags: macos
+tags:
+  - macos
 title: Clearing disk space on OS X
 ---
 

--- a/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
+++ b/src/_posts/2016/2016-07-28-chasing-redirects-and-url-shorteners.md
@@ -2,7 +2,8 @@
 date: 2016-07-28 21:03:00 +0000
 layout: post
 summary: A quick Python function to follow a redirect to its eventual conclusion.
-tags: python
+tags:
+  - python
 title: 'Python snippets: Chasing redirects and URL shorteners'
 ---
 

--- a/src/_posts/2016/2016-08-07-clean-up-directories.md
+++ b/src/_posts/2016/2016-08-07-clean-up-directories.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-08-07 22:46:00 +0000
 title: 'Python snippets: Cleaning up empty/nearly empty directories'
 summary: A pair of Python scripts I've been using to clean up my mess of directories.
-tags: python
+tags:
+  - python
 ---
 
 Last month, I wrote about [some tools]({% post_url 2016/2016-07-04-clearing-disk-space-on-os-x %}) I'd been using to clear disk space on my Mac.

--- a/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
+++ b/src/_posts/2016/2016-08-19-is-a-url-from-tumblr.md
@@ -1,7 +1,9 @@
 ---
 date: 2016-08-19 23:34:00 +0000
 layout: post
-tags: tumblr python
+tags:
+  - tumblr
+  - python
 title: 'Python snippets: Is a URL from a Tumblr post?'
 index:
   exclude: true

--- a/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
+++ b/src/_posts/2016/2016-08-31-dealing-with-query-strings.md
@@ -1,7 +1,8 @@
 ---
 date: 2016-08-31 20:05:00 +0000
 layout: post
-tags: python
+tags:
+  - python
 title: 'Python snippet: dealing with query strings in URLs'
 index:
   exclude: true

--- a/src/_posts/2016/2016-09-14-pyconuk2016.md
+++ b/src/_posts/2016/2016-09-14-pyconuk2016.md
@@ -2,7 +2,11 @@
 layout: post
 date: 2016-09-14
 title: An introduction to property-based testing and Hypothesis
-tags: talks property-based-testing software-testing python:hypothesis
+tags:
+  - talks
+  - property-based-testing
+  - software-testing
+  - python:hypothesis
 index:
   exclude: true
 ---

--- a/src/_posts/2016/2016-09-17-speech-to-text.md
+++ b/src/_posts/2016/2016-09-17-speech-to-text.md
@@ -3,7 +3,11 @@ layout: post
 date: 2016-09-17 22:08:00 +0000
 summary: Live captioning of conference talks was an unexpected bonus at this year's
   PyCon UK.
-tags: pyconuk conferences inclusion accessibility
+tags:
+  - pyconuk
+  - conferences
+  - inclusion
+  - accessibility
 title: Live captioning at conferences
 colors:
   index_light: "#141213"

--- a/src/_posts/2016/2016-09-19-silence-is-golden.md
+++ b/src/_posts/2016/2016-09-19-silence-is-golden.md
@@ -3,7 +3,10 @@ layout: post
 date: 2016-09-19 10:17:00 +0000
 title: Silence is golden
 summary: PyCon had a dedicated quiet room for people to get some downtime, and I think it's a great idea.
-tags: pyconuk conferences inclusion
+tags:
+  - pyconuk
+  - conferences
+  - inclusion
 ---
 
 As I write this, it's the last day of [PyCon UK](http://2016.pyconuk.org/).

--- a/src/_posts/2016/2016-09-23-please-use-aspell.md
+++ b/src/_posts/2016/2016-09-23-please-use-aspell.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2016-09-23 07:40:00 +0000
 title: aspell, a command-line spell checker
-tags: writethedocs
+tags:
+  - writethedocs
 colors:
   index_light: "#022833"
   index_dark:  "#a7b3b4"

--- a/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
+++ b/src/_posts/2016/2016-10-01-a-shell-alias-for-tallying.md
@@ -1,7 +1,8 @@
 ---
 date: 2016-10-01 21:23:00 +0000
 layout: post
-tags: shell-scripting
+tags:
+  - shell-scripting
 title: A shell alias for tallying data
 summary: A way to count records on the command-line.
 ---

--- a/src/_posts/2016/2016-10-08-why-i-use-pytest.md
+++ b/src/_posts/2016/2016-10-08-why-i-use-pytest.md
@@ -2,7 +2,9 @@
 date: 2016-10-08 18:31:00 +0000
 layout: post
 summary: Why py.test is my unit test framework of choice in Python.
-tags: python python:pytest
+tags:
+  - python
+  - python:pytest
 title: Why I use py.test
 ---
 

--- a/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
+++ b/src/_posts/2016/2016-10-21-tiling-the-plane-with-pillow.md
@@ -3,7 +3,11 @@ layout: post
 date: 2016-10-21 12:18:00 +0000
 summary: Using the Python Imaging Library to draw regular tilings of squares, triangles
   and hexagons.
-tags: python maths python:pillow drawing-things
+tags:
+  - python
+  - maths
+  - python:pillow
+  - drawing-things
 title: Tiling the plane with Pillow
 colors:
   index_light: "#444444"

--- a/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
+++ b/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
@@ -3,7 +3,11 @@ layout: post
 date: 2016-10-22 21:03:00 +0000
 title: Creating low contrast wallpapers with Pillow
 summary: "Take a regular tiling of the plane, apply a random colouring, and voila: a unique wallpaper, courtesy of the Python Imaging Library."
-tags: python python:pillow drawing-things generative-art
+tags:
+  - python
+  - python:pillow
+  - drawing-things
+  - generative-art
 colors:
   index_light: "#98291d"
   index_dark:  "#ffd20b"

--- a/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
+++ b/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
@@ -3,7 +3,9 @@ layout: post
 date:       2016-10-30 09:12:00 +0000
 layout:     post
 summary:    A brief introduction to asexuality, what it means, and why it matters.
-tags:       personal asexuality
+tags:
+  - personal
+  - asexuality
 title:      The A stands for Asexual
 index:
   exclude: true

--- a/src/_posts/2016/2016-11-16-you-should-use-keyring.md
+++ b/src/_posts/2016/2016-11-16-you-should-use-keyring.md
@@ -3,7 +3,10 @@ date: 2016-11-16 07:48:00 +0000
 layout: post
 summary: If you need to store passwords in a Python application, use the keyring module
   to keep them safe.
-tags: python infosec python:keyring
+tags:
+  - python
+  - infosec
+  - python:keyring
 title: Use keyring to store your credentials
 ---
 

--- a/src/_posts/2016/2016-11-30-low-tech-productivity.md
+++ b/src/_posts/2016/2016-11-30-low-tech-productivity.md
@@ -3,7 +3,8 @@ layout: post
 date: 2016-11-30 19:07:00 +0000
 summary: A few suggestions for "low tech devices" that aid in the process of generating
   ideas.
-tags: productivity
+tags:
+  - productivity
 title: Some low-tech ways to get more ideas
 ---
 

--- a/src/_posts/2016/2016-12-01-strings-are-terrible.md
+++ b/src/_posts/2016/2016-12-01-strings-are-terrible.md
@@ -3,7 +3,10 @@ layout: post
 date: 2016-12-01 07:43:00 +0000
 title: Another example of why strings are terrible
 summary: "Pop quiz: if I lowercase a string, does it still have the same length as the original string?"
-tags: unicode python:hypothesis python
+tags:
+  - unicode
+  - python:hypothesis
+  - python
 ---
 
 Here's a programming assumption I used to make, that until today I'd never really thought about: *changing the case of a string won't change its length*.

--- a/src/_posts/2016/2016-12-28-slack-history.md
+++ b/src/_posts/2016/2016-12-28-slack-history.md
@@ -3,7 +3,9 @@ layout: post
 date: 2016-12-28 10:29:00 +0000
 title: A tool for backing up your message history from Slack
 link: https://pypi.org/project/slack-history/
-tags: python slack
+tags:
+  - python
+  - slack
 index:
   exclude: true
 ---

--- a/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
+++ b/src/_posts/2017/2017-01-07-scrape-logged-in-ao3.md
@@ -2,7 +2,9 @@
 date: 2017-01-07 23:10:00 +0000
 layout: post
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python, it might not be necessary.
-tags: python ao3
+tags:
+  - python
+  - ao3
 title: Experiments with AO3 and Python
 ---
 

--- a/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
+++ b/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
@@ -4,7 +4,9 @@ layout: post
 link: https://github.com/alexwlchan/ao3
 summary: AO3 doesn't have an official API for scraping data - but with a bit of Python,
   it might not be necessary.
-tags: python ao3
+tags:
+  - python
+  - ao3
 title: A Python interface to AO3
 ---
 

--- a/src/_posts/2017/2017-02-08-backup-your-goodreads.md
+++ b/src/_posts/2017/2017-02-08-backup-your-goodreads.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2017-02-08 20:41:00 +0000
 link: https://github.com/alexwlchan/backup-goodreads
-tags: python goodreads
+tags:
+  - python
+  - goodreads
 title: A script for backing up your Goodreads reviews
 ---
 

--- a/src/_posts/2017/2017-02-11-backup-your-instapaper.md
+++ b/src/_posts/2017/2017-02-11-backup-your-instapaper.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2017-02-11 12:00:00 +0000
 link: https://github.com/alexwlchan/backup-instapaper
-tags: python instapaper
+tags:
+  - python
+  - instapaper
 title: A script for backing up your Instapaper bookmarks
 ---
 

--- a/src/_posts/2017/2017-03-08-qcon2017.md
+++ b/src/_posts/2017/2017-03-08-qcon2017.md
@@ -2,7 +2,11 @@
 layout: post
 date: 2017-03-08
 title: Property based testing in practice
-tags: talks property-based-testing software-testing python:hypothesis
+tags:
+  - talks
+  - property-based-testing
+  - software-testing
+  - python:hypothesis
 index:
   exclude: true
 ---

--- a/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
+++ b/src/_posts/2017/2017-03-25-extensions-in-python-markdown.md
@@ -5,7 +5,9 @@ index:
 layout: post
 summary: I use Python-Markdown to render posts for my site. Here are a few examples
   of the extensions I'm using.
-tags: python markdown
+tags:
+  - python
+  - markdown
 title: A few examples of extensions in Python-Markdown
 ---
 

--- a/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
+++ b/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
@@ -2,7 +2,11 @@
 layout: post
 date: 2017-04-04 17:46:00 +0000
 summary: For accessibility and inclusion, AlterConf sets a high bar to beat.
-tags: alterconf conferences accessibility inclusion
+tags:
+  - alterconf
+  - conferences
+  - accessibility
+  - inclusion
 title: Accessibility at AlterConf
 ---
 

--- a/src/_posts/2017/2017-06-07-crossness-pumping-station.md
+++ b/src/_posts/2017/2017-06-07-crossness-pumping-station.md
@@ -3,7 +3,10 @@ layout: post
 date: 2017-06-07 20:50:00 +0000
 summary: Pictures from my recent visit to Crossness, a Victorian pumping station for London's sewers.
 title: A visit to the Crossness pumping station
-tags: photography history london
+tags:
+  - photography
+  - history
+  - london
 colors:
   css_light: "#2b5750"
   css_dark:  "#5da898"

--- a/src/_posts/2017/2017-07-18-listing-s3-keys.md
+++ b/src/_posts/2017/2017-07-18-listing-s3-keys.md
@@ -2,7 +2,10 @@
 date: 2017-07-18 08:30:00 +0000
 layout: post
 summary: A short Python function for getting a list of keys in an S3 bucket.
-tags: aws python amazon-s3
+tags:
+  - aws
+  - python
+  - amazon-s3
 title: Listing keys in an S3 bucket with Python
 ---
 

--- a/src/_posts/2017/2017-07-18-soundcloud-backups.md
+++ b/src/_posts/2017/2017-07-18-soundcloud-backups.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2017-07-18 09:30:00 +0000
 title: Backing up content from SoundCloud
-tags: soundcloud
+tags:
+  - soundcloud
 ---
 
 In the last week or so, SoundCloud have been [looking pretty fragile][layoffs].

--- a/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
+++ b/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2017-07-31 19:47:00 +0000
 summary: A Rust utility for saving local copies of my full-page archives from Pinboard.
-tags: rust pinboard
+tags:
+  - rust
+  - pinboard
 title: Backing up full-page archives from Pinboard
 ---
 

--- a/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
+++ b/src/_posts/2017/2017-09-02-lazy-reading-in-python.md
@@ -4,7 +4,8 @@ layout: post
 link: https://github.com/alexwlchan/lazyreader
 summary: I wrote a small Python module for lazy file reading, ideal for efficient
   batch processing.
-tags: python
+tags:
+  - python
 title: A Python module for lazy reading of file objects
 ---
 

--- a/src/_posts/2017/2017-09-11-ode-to-docopt.md
+++ b/src/_posts/2017/2017-09-11-ode-to-docopt.md
@@ -2,7 +2,10 @@
 layout: post
 title: Ode to docopt
 summary: Why I love docopt as a tool for writing clean, simple command-line interfaces.
-tags: python python:docopt talks
+tags:
+  - python
+  - python:docopt
+  - talks
 date: 2017-09-11 12:01:13 +0100
 colors:
   css_light: "#008000"

--- a/src/_posts/2017/2017-09-16-useful-git-commands.md
+++ b/src/_posts/2017/2017-09-16-useful-git-commands.md
@@ -2,7 +2,9 @@
 date: 2017-09-18 18:45:00 +0100
 layout: post
 summary: A couple of Git commands that I find useful in builds and CI.
-tags: git builds-and-ci
+tags:
+  - git
+  - builds-and-ci
 title: Some useful Git commands for CI
 ---
 

--- a/src/_posts/2017/2017-10-03-overengineering.md
+++ b/src/_posts/2017/2017-10-03-overengineering.md
@@ -2,7 +2,8 @@
 layout: post
 title: What happens when you overengineer a static site?
 link: https://github.com/alexwlchan/alexwlchan.net
-tags: jekyll
+tags:
+  - jekyll
 date: 2017-10-03 22:23:38 +0100
 summary: I switched back to Jekyll, and posted all the source code for my blog on GitHub.
 index:

--- a/src/_posts/2017/2017-10-09-pip-tools.md
+++ b/src/_posts/2017/2017-10-09-pip-tools.md
@@ -3,7 +3,10 @@ date: 2017-10-09 08:11:03 +0000
 layout: post
 summary: How I use pip-tools to ensure my Python dependencies are pinned, precise,
   and as minimal as possible.
-tags: python docker make
+tags:
+  - python
+  - docker
+  - make
 title: Using pip-tools to manage my Python dependencies
 ---
 

--- a/src/_posts/2017/2017-10-11-latex-underlines.md
+++ b/src/_posts/2017/2017-10-11-latex-underlines.md
@@ -4,7 +4,9 @@ date: 2017-10-11 22:09:25 +0000
 date_updated: 2018-11-13 20:54:44 +0000
 summary: I'm very picky about the way underlines look, and have spent a lot of time
   trying to get the perfect underline in LaTeX.
-tags: latex typesetting
+tags:
+  - latex
+  - typesetting
 title: Four ways to underline text in LaTeX
 ---
 

--- a/src/_posts/2017/2017-10-17-control-centre.md
+++ b/src/_posts/2017/2017-10-17-control-centre.md
@@ -3,7 +3,9 @@ layout: post
 date: 2017-10-17 20:54:13 +0000
 title: "Control Centre: one step forward, two steps back"
 summary: I like aspects of Control Centre in iOS 11, but WiFi/Bluetooth and audio playback are both immensely frustrating.
-tags: ios frustrations
+tags:
+  - ios
+  - frustrations
 index:
   exclude: true
 ---

--- a/src/_posts/2017/2017-10-20-requests-hooks.md
+++ b/src/_posts/2017/2017-10-20-requests-hooks.md
@@ -3,7 +3,9 @@ date: 2017-10-20 17:11:59 +0000
 layout: post
 summary: I often have code I want to run against every HTTP response (logging, error
   checking) --- event hooks give me a nice way to do that without repetition.
-tags: python python:requests
+tags:
+  - python
+  - python:requests
 title: Using hooks for custom behaviour in requests
 colors:
   index_light: "#79451e"

--- a/src/_posts/2017/2017-10-25-tweets-in-keynote.md
+++ b/src/_posts/2017/2017-10-25-tweets-in-keynote.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2017-10-25 13:14:54 +0000
 title: Displaying tweets in Keynote
-tags: keynote twitter
+tags:
+  - keynote
+  - twitter
 summary: Slides for showing tweets that look like tweets on slides in Keynote and PowerPoint.
 colors:
   index_light: "#3F6989"

--- a/src/_posts/2017/2017-10-28-lightning-talks.md
+++ b/src/_posts/2017/2017-10-28-lightning-talks.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2017-10-28 10:20:29 +0000
 title: Lightning talks
-tags: conferences pyconuk
+tags:
+  - conferences
+  - pyconuk
 summary: Why I like the lottery system used to select lightning talks at PyCon UK this year.
 colors:
   index_light: "#174346"

--- a/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
+++ b/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
@@ -3,7 +3,9 @@ layout: post
 date: 2017-11-03 11:40:52 +0000
 title: Using privilege to improve inclusion
 summary: In the tech industry, how can we be more aware of our privilege, and use that to build inclusive cultures?
-tags: talks inclusion
+tags:
+  - talks
+  - inclusion
 colors:
   css_light:   "#076e6e"
   css_dark:    "#0dcece"

--- a/src/_posts/2017/2017-11-08-asking-about-gender.md
+++ b/src/_posts/2017/2017-11-08-asking-about-gender.md
@@ -3,7 +3,8 @@ layout: post
 date: 2017-11-08 22:27:28 +0000
 title: How I ask about gender
 summary: "If you're asking for someone's gender, a simple 'Female/Male' isn't good enough. Here's what I use instead."
-tags: gender
+tags:
+  - gender
 index:
   exclude: true
 ---

--- a/src/_posts/2017/2017-11-09-a-plumbers-guide-to-git.md
+++ b/src/_posts/2017/2017-11-09-a-plumbers-guide-to-git.md
@@ -2,7 +2,9 @@
 date: 2017-11-09 18:18:05 +0000
 layout: post
 summary: How does Git work under the hood? How does it store information, and what's really behind a branch?
-tags: workshops git
+tags:
+  - workshops
+  - git
 title: A plumber's guide to Git
 colors:
   index_light: "#d32a1d"

--- a/src/_posts/2017/2017-11-20-dont-tap-the-mic.md
+++ b/src/_posts/2017/2017-11-20-dont-tap-the-mic.md
@@ -7,7 +7,8 @@ date: 2017-11-20 08:00
 colors:
   index_light: "#4a403a"
   index_dark:  "#d5d6d5"
-tags: conferences
+tags:
+  - conferences
 ---
 
 When I was in college, I did a bit of work in the college theatre as a backstage technician.

--- a/src/_posts/2017/2017-11-20-five-years-of-witch.md
+++ b/src/_posts/2017/2017-11-20-five-years-of-witch.md
@@ -1,6 +1,9 @@
 ---
 layout: post
-tags: tnmoc history computing
+tags:
+  - tnmoc
+  - history
+  - computing
 title: My favourite WITCH story
 summary: As the WITCH computer celebrates five years since its reboot at TNMoC, a fun story of how it was left to run at Christmas.
 colors:

--- a/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
+++ b/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
@@ -3,7 +3,10 @@ date: 2017-11-22 11:50:19 +0000
 layout: post
 summary: A detailed breakdown of how I wrote a Python script to download logs from
   CloudWatch.
-tags: aws python amazon-cloudwatch
+tags:
+  - aws
+  - python
+  - amazon-cloudwatch
 title: Downloading logs from Amazon CloudWatch
 ---
 

--- a/src/_posts/2017/2017-11-27-pruning-git-branches.md
+++ b/src/_posts/2017/2017-11-27-pruning-git-branches.md
@@ -3,7 +3,8 @@ date: 2017-11-27 22:41:36 +0000
 layout: post
 summary: 'Two commands for managing Git branches: one for deleting branches which
   have already been merged, one for deleting branches which were deleted on a remote.'
-tags: git
+tags:
+  - git
 title: Pruning old Git branches
 ---
 

--- a/src/_posts/2017/2017-12-11-armed-police.md
+++ b/src/_posts/2017/2017-12-11-armed-police.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2017-12-11 12:19:24 +0000
 title: Armed police officers don't make me feel safer
-tags: politics
+tags:
+  - politics
 summary: Why guns make me jumpy, how armed police don't reassure me, and why you need to be careful about the images you use in tweets.
 index:
   exclude: true

--- a/src/_posts/2017/2017-12-18-building-your-repo.md
+++ b/src/_posts/2017/2017-12-18-building-your-repo.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2017-12-18 08:40:30 +0000
 title: Your repo should be easy to build, and how
-tags: make docker builds-and-ci
+tags:
+  - make
+  - docker
+  - builds-and-ci
 summary: Making your repo easy to clone and build is very important. This post explains why, and how I'm using Make and Docker to achieve that goal.
 ---
 

--- a/src/_posts/2018/2018-01-18-ips-for-documentation.md
+++ b/src/_posts/2018/2018-01-18-ips-for-documentation.md
@@ -3,7 +3,8 @@ layout: post
 title: IP and DNS addresses for documentation
 date: 2018-01-18 23:26:28 +0000
 summary: If you're writing technical docs and need placeholder IP addresses or DNS hostnames, there are some special values just for you!
-tags: documentation
+tags:
+  - documentation
 ---
 
 If you're writing documentation that includes IP addresses, you may want to check out [RFC 5737][rfc5737] and [RFC 3849][rfc3849], which specify IPv4 and IPv6 addresses for use in documentation.

--- a/src/_posts/2018/2018-01-20-listing-s3-keys-redux.md
+++ b/src/_posts/2018/2018-01-20-listing-s3-keys-redux.md
@@ -2,7 +2,10 @@
 date: 2018-01-20 20:25:33 +0000
 layout: post
 summary: Python functions for getting a list of keys and objects in an S3 bucket.
-tags: aws python amazon-s3
+tags:
+  - aws
+  - python
+  - amazon-s3
 title: Listing keys in an S3 bucket with Python, redux
 ---
 

--- a/src/_posts/2018/2018-01-25-downloading-sqs-queues.md
+++ b/src/_posts/2018/2018-01-25-downloading-sqs-queues.md
@@ -3,7 +3,10 @@ date: 2018-01-25 21:56:15 +0000
 layout: post
 summary: Code for saving every message from an SQS queue, and then saving the messages
   to a file, or resending them to another queue.
-tags: aws python amazon-sqs
+tags:
+  - aws
+  - python
+  - amazon-sqs
 title: Getting every message in an SQS queue
 ---
 

--- a/src/_posts/2018/2018-02-24-working-from-home.md
+++ b/src/_posts/2018/2018-02-24-working-from-home.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-02-24 06:51:45 +0000
 title: A working from home experiment
-tags: personal work
+tags:
+  - personal
+  - work
 summary: I've recently started working from home for one day a week. In this post I explain why I made the change, some of the benefits and risks, and why I think it's worth trying.
 index:
   exclude: true

--- a/src/_posts/2018/2018-03-01-overnight-bag.md
+++ b/src/_posts/2018/2018-03-01-overnight-bag.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2018-03-01 19:05:00 +0000
 title: Keep an overnight bag in the office
-tags: work
+tags:
+  - work
 summary: Although hopefully never needed, I think it's worth keeping an overnight bag in your workplace.
 ---
 

--- a/src/_posts/2018/2018-03-02-continuous-releases.md
+++ b/src/_posts/2018/2018-03-02-continuous-releases.md
@@ -3,7 +3,9 @@ layout: post
 date: 2018-03-02 08:04:05 +0000
 link: https://hypothesis.works/articles/continuous-releases/
 title: The Hypothesis continuous release process
-tags: builds-and-ci python:hypothesis
+tags:
+  - builds-and-ci
+  - python:hypothesis
 summary: How we do continuous releases of hypothesis-python, and why.
 colors:
   index_light: "#006dad"

--- a/src/_posts/2018/2018-03-13-a-plumbers-guide-to-git.md
+++ b/src/_posts/2018/2018-03-13-a-plumbers-guide-to-git.md
@@ -5,7 +5,9 @@ link: https://alexwlchan.net/a-plumbers-guide-to-git/
 summary: Git is a fundamental part of many modern developer workflows -- but how does
   it really work under the hood?  In this workshop, we'll learn about the internals
   of Git.
-tags: git workshops
+tags:
+  - git
+  - workshops
 title: Notes on <em>A Plumber's Guide to Git</em>
 ---
 

--- a/src/_posts/2018/2018-04-17-24-hours.md
+++ b/src/_posts/2018/2018-04-17-24-hours.md
@@ -2,7 +2,9 @@
 title: 24 hours or bust
 layout: post
 date: 2018-04-17 16:32:42 +0000
-tags: productivity personal
+tags:
+  - productivity
+  - personal
 summary: I've started deleting all my Instapaper items if they're more than a day old, and I'm much happier for it.
 index:
   exclude: true

--- a/src/_posts/2018/2018-04-18-anti-social-media.md
+++ b/src/_posts/2018/2018-04-18-anti-social-media.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-04-18 12:00:33 +0000
 title: (Anti) Social Media
-tags: talks trust-and-safety
+tags:
+  - talks
+  - trust-and-safety
 summary: Slides and notes for a talk about online harassment, and why you should always design with an abusive ex in mind.
 ---
 

--- a/src/_posts/2018/2018-04-27-s3-shortcuts.md
+++ b/src/_posts/2018/2018-04-27-s3-shortcuts.md
@@ -3,7 +3,9 @@ date: 2018-04-27 06:43:25 +0000
 layout: post
 summary: Two shell functions for editing and inspecting S3 objects as if they were
   local files.
-tags: aws amazon-s3
+tags:
+  - aws
+  - amazon-s3
 title: Two shortcuts for using S3 in the shell
 ---
 

--- a/src/_posts/2018/2018-05-04-beware-logged-errors.md
+++ b/src/_posts/2018/2018-05-04-beware-logged-errors.md
@@ -3,7 +3,10 @@ date: 2018-05-04 08:28:01 +0000
 layout: post
 summary: If you use Python's subprocess module, be careful you don't leak sensitive
   information in your error logs.
-tags: python infosec python:subprocess
+tags:
+  - python
+  - infosec
+  - python:subprocess
 title: Beware of logged errors from subprocess
 ---
 

--- a/src/_posts/2018/2018-05-14-google-duplex.md
+++ b/src/_posts/2018/2018-05-14-google-duplex.md
@@ -3,7 +3,10 @@ layout: post
 date: 2018-05-14 06:15:08 +0000
 title: A brief thought on Google Duplex
 summary: I think Duplex could be a great tool for accessibility, even if that's not what it was pitched as.
-tags: accessibility ableism inclusion
+tags:
+  - accessibility
+  - ableism
+  - inclusion
 ---
 
 Last week was Google I/O, and there was a lot of discussion around one of their keynote demos: Google Duplex.

--- a/src/_posts/2018/2018-05-26-ascii-bar-charts.md
+++ b/src/_posts/2018/2018-05-26-ascii-bar-charts.md
@@ -3,7 +3,9 @@ layout: post
 date: 2018-05-26 18:57:07 +0000
 date_updated: 2018-06-02 13:03:03 +0100
 summary: A Python snippets for drawing bar charts in command-line applications.
-tags: terminal-tricks python
+tags:
+  - terminal-tricks
+  - python
 title: Drawing ASCII bar charts
 colors:
   index_light: "#000000"

--- a/src/_posts/2018/2018-07-01-imac-accessory.md
+++ b/src/_posts/2018/2018-07-01-imac-accessory.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-07-01 20:12:48 +0000
 title: My favourite iMac accessory
-tags: imac hardware
+tags:
+  - imac
+  - hardware
 summary: Adding a USB extension cable to my iMac makes a world of difference.
 colors:
   index_light: "#857f71"

--- a/src/_posts/2018/2018-07-15-travel-instructions.md
+++ b/src/_posts/2018/2018-07-15-travel-instructions.md
@@ -3,7 +3,8 @@ layout: post
 date: 2018-07-15 08:48:25 +0000
 title: A tip for travel instructions
 summary: Lots of people use smartphones for mapping, so consider that when writing travel advice.
-tags: misc
+tags:
+  - misc
 index:
   exclude: true
 ---

--- a/src/_posts/2018/2018-07-19-leaking-my-ssh-keys.md
+++ b/src/_posts/2018/2018-07-19-leaking-my-ssh-keys.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2018-07-19 07:38:10 +0000
 title: A robot leaked my SSH keys
-tags: github builds-and-ci infosec
+tags:
+  - github
+  - builds-and-ci
+  - infosec
 summary: A cautionary tale of a daft incident where I leaked a set of SSH keys to GitHub.
 ---
 

--- a/src/_posts/2018/2018-07-28-icloud-calendars.md
+++ b/src/_posts/2018/2018-07-28-icloud-calendars.md
@@ -3,7 +3,9 @@ layout: post
 date: 2018-07-28 10:04:42 +0000
 title: Moving my calendars from iCloud to FastMail
 summary: I recently discovered that iCloud was deleting my old calendar entries, so I switched to FastMail.
-tags: icloud fastmail
+tags:
+  - icloud
+  - fastmail
 ---
 
 I used to manage my calendar with iCloud. I have basic needs, and it seemed like a good fit – until I discovered the following [unexpected restriction](https://support.apple.com/en-au/HT204055#calendars):

--- a/src/_posts/2018/2018-08-02-selective-sudo-on-travis.md
+++ b/src/_posts/2018/2018-08-02-selective-sudo-on-travis.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-08-02 07:31:35 +0000
 title: Selective sudo on Travis
-tags: travis build-automation
+tags:
+  - travis
+  - build-automation
 summary: I recently learnt how to set up Travis with a mixture of VMs and containers – not just all of one or the other.
 index:
   exclude: true

--- a/src/_posts/2018/2018-08-05-do-not-distract-while-driving.md
+++ b/src/_posts/2018/2018-08-05-do-not-distract-while-driving.md
@@ -3,7 +3,9 @@ layout: post
 date: 2018-08-05 22:15:55 +0000
 title: Do Not Distract while driving
 summary: I've been using Apple Maps for a lot of navigation recently, and run into screens which seem dangerously distracting.
-tags: ui-design ios
+tags:
+  - ui-design
+  - ios
 index:
   exclude: true
 ---

--- a/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
+++ b/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
@@ -3,7 +3,10 @@ layout: post
 date: 2018-08-07 15:48:53 +0000
 title: Finding slow builds in Travis
 summary: A Python snippet for using the Travis CI API to track build times.
-tags: travis python builds-and-ci
+tags:
+  - travis
+  - python
+  - builds-and-ci
 ---
 
 For a while, I've been whinging on Twitter about Scala compile times -- mostly driven by the ever-increasing length of the Travis builds at work.

--- a/src/_posts/2018/2018-08-13-inclusive-conferences.md
+++ b/src/_posts/2018/2018-08-13-inclusive-conferences.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-08-13 08:16:20 +0000
 title: Ideas for inclusive conferences and events
-tags: conferences inclusion
+tags:
+  - conferences
+  - inclusion
 date_updated: 2019-02-05 08:25:14 +0000
 summary: A collection of ideas and suggestions for running conferences which are more inclusive and accessible. Based on my experiences at AlterConf, PyCon UK, and similar events.
 colors:

--- a/src/_posts/2018/2018-08-20-no-more-tumblr-redirects.md
+++ b/src/_posts/2018/2018-08-20-no-more-tumblr-redirects.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2018-08-20 07:17:19 +0000
 title: Avoiding the automatic redirect on Tumblr posts
-tags: tumblr
+tags:
+  - tumblr
 summary: I see an intermittent 303 Redirect when trying to navigate to a Tumblr 'permalink'; changing the User-Agent seems to fix it.
 ---
 

--- a/src/_posts/2018/2018-08-25-parallel-scan-scanamo.md
+++ b/src/_posts/2018/2018-08-25-parallel-scan-scanamo.md
@@ -3,7 +3,10 @@ date: 2018-08-25 08:20:24 +0000
 layout: post
 summary: Prototype code for running a parallel scan against a DynamoDB table, and
   using Scanamo to serialise rows as Scala case classes.
-tags: aws scala amazon-dynamodb
+tags:
+  - aws
+  - scala
+  - amazon-dynamodb
 title: Implementing parallel scan in DynamoDB with Scanamo
 colors:
   index_light: "#2E27AD"

--- a/src/_posts/2018/2018-08-26-maps-for-pyconuk.md
+++ b/src/_posts/2018/2018-08-26-maps-for-pyconuk.md
@@ -3,7 +3,9 @@ layout: post
 date: 2018-08-26 07:10:28 +0000
 title: Making the venue maps for PyCon UK
 summary: A quick braindump of my thoughts from drawing some venue maps for PyCon UK.
-tags: pyconuk graphic-design
+tags:
+  - pyconuk
+  - graphic-design
 colors:
   index_light: "#336EAF"
   index_dark:  "#fac126"

--- a/src/_posts/2018/2018-09-05-error-logging-in-lambdas.md
+++ b/src/_posts/2018/2018-09-05-error-logging-in-lambdas.md
@@ -3,7 +3,10 @@ date: 2018-09-05 20:11:59 +0000
 layout: post
 summary: A snippet to make it a bit easier to debug errors in AWS Lambda functions
   written in Python.
-tags: aws python aws-lambda
+tags:
+  - aws
+  - python
+  - aws-lambda
 title: A basic error logger for Python Lambdas
 ---
 

--- a/src/_posts/2018/2018-09-13-pyconuk-2018.md
+++ b/src/_posts/2018/2018-09-13-pyconuk-2018.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2018-09-13 16:53:55 +0000
 title: PyCon UK 2018
-tags: pyconuk
+tags:
+  - pyconuk
 summary: "It's almost time for this year's PyCon UK. What I'm doing, where to find me, how to have fun."
 index:
   exclude: true

--- a/src/_posts/2018/2018-09-17-lessons-in-signage.md
+++ b/src/_posts/2018/2018-09-17-lessons-in-signage.md
@@ -3,7 +3,10 @@ layout: post
 date: 2018-09-17 17:21:17 +0000
 title: Signs of the time
 summary: A few lessons I learned while doing the signage for this year's PyCon UK.
-tags: pyconuk conferences graphic-design
+tags:
+  - pyconuk
+  - conferences
+  - graphic-design
 ---
 
 One of the changes at this year's PyCon UK was that I printed a bunch of signs for the venue.

--- a/src/_posts/2018/2018-09-22-suspicious-minds.md
+++ b/src/_posts/2018/2018-09-22-suspicious-minds.md
@@ -3,7 +3,10 @@ layout: post
 date: 2018-09-22 17:07:59 +0000
 title: Building trust in an age of suspicious minds
 summary: Notes and slides from my PyCon UK 2018 keynote. In a world where people are less and less trusting, how can we take steps to make ourselves more trustable?
-tags: pyconuk talks systems-thinking
+tags:
+  - pyconuk
+  - talks
+  - systems-thinking
 colors:
   index_light: "#8b5023"
   index_dark:  "#f6d05b"

--- a/src/_posts/2018/2018-09-24-assume-worst-intent.md
+++ b/src/_posts/2018/2018-09-24-assume-worst-intent.md
@@ -2,7 +2,12 @@
 layout: post
 date: 2018-09-24 06:56:21 +0000
 title: Assume worst intent (designing against the abusive ex)
-tags: pyconuk talks community-management inclusion trust-and-safety
+tags:
+  - pyconuk
+  - talks
+  - community-management
+  - inclusion
+  - trust-and-safety
 summary: How do we design services and platforms to reduce the risk of harassment and abuse from other users?
 colors:
   index_light: "#531b93"

--- a/src/_posts/2018/2018-10-11-gender-recognition-act.md
+++ b/src/_posts/2018/2018-10-11-gender-recognition-act.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-10-11 07:32:20 +0000
 title: Open consultation on the Gender Recognition Act
-tags: gender uk-politics
+tags:
+  - gender
+  - uk-politics
 summary: The Government has launched a consultation on the Gender Recognition Act 2004, and it's an opportunity to improve rights and legal recognition for trans/non-binary people.
 link: https://www.gov.uk/government/consultations/reform-of-the-gender-recognition-act-2004
 index:

--- a/src/_posts/2018/2018-10-22-finatra-404.md
+++ b/src/_posts/2018/2018-10-22-finatra-404.md
@@ -3,7 +3,10 @@ date: 2018-10-22 20:04:40 +0000
 layout: post
 summary: A snippet for returning a custom 404 response in a Finatra app when somebody
   requests a missing page.
-tags: scala:finatra scala web-development
+tags:
+  - scala:finatra
+  - scala
+  - web-development
 title: Custom 404 responses in Finatra
 ---
 

--- a/src/_posts/2018/2018-10-28-horstmann-electric-7.md
+++ b/src/_posts/2018/2018-10-28-horstmann-electric-7.md
@@ -3,7 +3,8 @@ layout: post
 date: 2018-10-28 14:12:26 +0000
 title: How to set the clock on a Horstmann Electronic 7 water heater
 summary: Instructions for setting the time of day on my boiler clock.
-tags: domestic
+tags:
+  - domestic
 index:
   exclude: true
 ---

--- a/src/_posts/2018/2018-10-29-unscrupulous-time-travel.md
+++ b/src/_posts/2018/2018-10-29-unscrupulous-time-travel.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2018-10-29 07:48:12 +0000
 title: How do you hide a coin for 400 years?
-tags: misc time-travel
+tags:
+  - misc
+  - time-travel
 summary: Late night musings on an unscrupulous time traveller who wants to cheat at archeology.
 index:
   exclude: true

--- a/src/_posts/2018/2018-11-02-finding-unsubscribed-sns-topics.md
+++ b/src/_posts/2018/2018-11-02-finding-unsubscribed-sns-topics.md
@@ -3,7 +3,10 @@ date: 2018-11-02 10:42:04 +0000
 layout: post
 summary: I'm trying out Go, and I wrote a tool to help me find SNS topics that don't
   have any subscriptions.
-tags: golang aws amazon-sns
+tags:
+  - golang
+  - aws
+  - amazon-sns
 title: Finding SNS topics without any subscriptions
 ---
 

--- a/src/_posts/2018/2018-11-08-aberdulais-waterfall.md
+++ b/src/_posts/2018/2018-11-08-aberdulais-waterfall.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2018-11-08 12:37:19 +0000
 title: My visit to the Aberdulais Falls
-tags: personal wales photography
+tags:
+  - personal
+  - wales
+  - photography
 summary: Pictures from my trip to the waterfalls and former tin plating works at Aberdulais.
 colors:
   index_light: "#74844e"

--- a/src/_posts/2018/2018-11-13-book-recommendations.md
+++ b/src/_posts/2018/2018-11-13-book-recommendations.md
@@ -3,7 +3,8 @@ layout: post
 date: 2018-11-13 10:44:40 +0000
 title: Keeping track of my book recommendations
 summary: The three lists I use to manage my book recommendations.
-tags: books
+tags:
+  - books
 ---
 
 I have a text file where I write down every book recommendation I receive.

--- a/src/_posts/2018/2018-12-05-backing-up-tumblr.md
+++ b/src/_posts/2018/2018-12-05-backing-up-tumblr.md
@@ -3,7 +3,8 @@ layout: post
 date: 2018-12-05 21:17:14 +0000
 title: A script for backing up Tumblr posts and likes
 summary: Since Tumblr users are going on a mass deletion spree (helped by the Tumblr staff), some scripts to save content before it's too late.
-tags: tumblr
+tags:
+  - tumblr
 link: https://github.com/alexwlchan/backup_tumblr
 ---
 

--- a/src/_posts/2018/2018-12-13-getting-credentials-for-an-assumed-iam-role.md
+++ b/src/_posts/2018/2018-12-13-getting-credentials-for-an-assumed-iam-role.md
@@ -3,7 +3,10 @@ date: 2018-12-13 08:57:16 +0000
 layout: post
 summary: A script that creates temporary credentials for an assumed IAM role, and
   stores them in ~/.aws/credentials.
-tags: python aws aws-iam
+tags:
+  - python
+  - aws
+  - aws-iam
 title: Getting credentials for an assumed IAM Role
 ---
 

--- a/src/_posts/2018/2018-12-23-iterating-in-fixed-size-chunks.md
+++ b/src/_posts/2018/2018-12-23-iterating-in-fixed-size-chunks.md
@@ -3,7 +3,8 @@ date: 2018-12-23 22:39:38 +0000
 layout: post
 summary: A snippet for iterating over an arbitrary iterable in chunks, and returning
   a smaller chunk if the boundaries don't line up.
-tags: python
+tags:
+  - python
 title: Iterating in fixed-size chunks in Python
 ---
 

--- a/src/_posts/2018/2018-12-27-reading-a-utf8-encoded-csv.md
+++ b/src/_posts/2018/2018-12-27-reading-a-utf8-encoded-csv.md
@@ -3,7 +3,9 @@ date: 2018-12-27 17:38:55 +0000
 layout: post
 summary: Some notes on trying to do this in a way that supports both Python 2 and
   3, and the frustration of doing so.
-tags: python unicode
+tags:
+  - python
+  - unicode
 title: Notes on reading a UTF-8 encoded CSV in Python
 ---
 

--- a/src/_posts/2019/2019-01-16-paul-rothe-and-sons.md
+++ b/src/_posts/2019/2019-01-16-paul-rothe-and-sons.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-01-16 08:54:08 +0000
 title: "A delightful store for speciality spreads: Paul Rothe & Sons"
 summary: Tucked away on Marylebone Lane, just before Christmas I found a lovely deli with an amazing selection of jams.
-tags: london
+tags:
+  - london
 link: https://munchies.vice.com/en_uk/article/j5bbyg/the-118-year-old-deli-where-no-sandwich-is-too-weird
 index:
   exclude: true

--- a/src/_posts/2019/2019-01-21-oyster-tracking.md
+++ b/src/_posts/2019/2019-01-21-oyster-tracking.md
@@ -2,7 +2,8 @@
 layout: post
 title: "Thoughts on privacy and Oyster cards"
 date: 2019-01-21 08:29:00 +0000
-tags: privacy
+tags:
+  - privacy
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-01-22-sunlight.md
+++ b/src/_posts/2019/2019-01-22-sunlight.md
@@ -2,7 +2,9 @@
 layout: post
 title: "How much sunlight affects my mood levels"
 date: 2019-01-22 21:39:49 +0000
-tags: health personal
+tags:
+  - health
+  - personal
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-01-28-notes-from-you-got-this.md
+++ b/src/_posts/2019/2019-01-28-notes-from-you-got-this.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-01-28 13:42:06 +0000
 title: Notes from <em>You Got This</em> 2019
 summary: Notes from the inaugural 'You Got This' conference, a conference about creating a healthy and sustainable work life.
-tags: conferences
+tags:
+  - conferences
 colors:
   index_light: "#640b0f"
   index_dark:  "#e1f0f6"

--- a/src/_posts/2019/2019-01-29-debugging-a-stuck-terraform-plan.md
+++ b/src/_posts/2019/2019-01-29-debugging-a-stuck-terraform-plan.md
@@ -3,7 +3,9 @@ date: 2019-01-29 16:07:28 +0000
 layout: post
 summary: If a 'terraform plan' hangs, adding 'max_retries = 1' can sometimes expose
   the issue.
-tags: terraform aws
+tags:
+  - terraform
+  - aws
 title: Debugging a stuck Terraform plan
 index:
   exclude: true

--- a/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
+++ b/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-01-31 10:03:33 +0000
 title: "Monki Gras 2019: The Curb Cut Effect"
 summary: Slides and notes for my talk 'The Curb Cut Effect'. Making something better for disabled people can make it better for everybody.
-tags: talks accessibility
+tags:
+  - talks
+  - accessibility
 colors:
   css_light: "#531b93"
   css_dark:  "#b7a2d7"

--- a/src/_posts/2019/2019-02-05-inclusive-events-redux.md
+++ b/src/_posts/2019/2019-02-05-inclusive-events-redux.md
@@ -4,7 +4,9 @@ date: 2019-02-05 09:04:11 +0000
 title: More advice on running inclusive and welcoming events
 link: https://alexwlchan.net/ideas-for-inclusive-events/
 summary: An updated version of my list of ideas for running inclusive and welcoming events.
-tags: conferences inclusion
+tags:
+  - conferences
+  - inclusion
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-02-09-working-with-large-s3-objects.md
+++ b/src/_posts/2019/2019-02-09-working-with-large-s3-objects.md
@@ -3,7 +3,10 @@ layout: post
 date: 2019-02-09 18:09:32 +0000
 summary: Code for processing large objects in S3 without downloading the whole thing
   first, using file-like objects in Python.
-tags: python aws amazon-s3
+tags:
+  - python
+  - aws
+  - amazon-s3
 title: Working with really large objects in S3
 ---
 

--- a/src/_posts/2019/2019-02-26-checking-jekyll-sites-with-htmlproofer.md
+++ b/src/_posts/2019/2019-02-26-checking-jekyll-sites-with-htmlproofer.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2019-02-26 20:27:45 +0000
 title: "Checking Jekyll sites with HTMLProofer"
-tags: jekyll accessibility blogging-about-blogging
+tags:
+  - jekyll
+  - accessibility
+  - blogging-about-blogging
 ---
 
 Here's a quick change I've just made to my Jekyll setup: I've added HTML linting with [HTMLProofer][html_proofer].

--- a/src/_posts/2019/2019-03-03-atomic-cross-filesystem-moves-in-python.md
+++ b/src/_posts/2019/2019-03-03-atomic-cross-filesystem-moves-in-python.md
@@ -3,7 +3,8 @@ date: 2019-03-03 23:48:31 +0000
 layout: post
 summary: Explaining some code for moving files around in a way that's atomic and works
   across filesystem boundaries.
-tags: python
+tags:
+  - python
 title: Atomic, cross-filesystem moves in Python
 ---
 

--- a/src/_posts/2019/2019-03-11-finding-the-latest-screenshot-in-macos-mojave.md
+++ b/src/_posts/2019/2019-03-11-finding-the-latest-screenshot-in-macos-mojave.md
@@ -1,7 +1,10 @@
 ---
 date: 2019-03-11 20:31:17 +0000
 layout: post
-tags: macos shell-scripting screenshots
+tags:
+  - macos
+  - shell-scripting
+  - screenshots
 title: Finding the latest screenshot in macOS Mojave
 ---
 

--- a/src/_posts/2019/2019-03-15-forth-bridge.md
+++ b/src/_posts/2019/2019-03-15-forth-bridge.md
@@ -3,7 +3,10 @@ layout: post
 date: 2019-03-15 22:02:51 +0000
 title: "A day out to the Forth Bridge"
 summary: "Photographs from a trip to North Queensferry to see the Forth Bridge, the Forth Road Bridge, and an unexpected light tower."
-tags: personal scotland photography
+tags:
+  - personal
+  - scotland
+  - photography
 colors:
   index_light: "#3063a4"
   index_dark:  "#629de4"

--- a/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
+++ b/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-03-25 21:15:36 +0000
 title: Creating a GitHub Action to auto-merge pull requests
 summary: Saving myself the trouble of clicking that pesky "merge" button.
-tags: builds-and-ci github
+tags:
+  - builds-and-ci
+  - github
 colors:
   index_light: "#1b1e21"
   index_dark:  "#e6f2fb"

--- a/src/_posts/2019/2019-04-11-getting-a-transcript-of-a-talk-from-youtube.md
+++ b/src/_posts/2019/2019-04-11-getting-a-transcript-of-a-talk-from-youtube.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-04-11 07:00:43 +0000
 title: Getting a transcript of a talk from YouTube
 summary: Using the auto-generated captions from a YouTube video as a starting point for a complete transcript.
-tags: youtube
+tags:
+  - youtube
 colors:
   index_light: "#3164ce"
   index_dark:  "#dbe3e9"

--- a/src/_posts/2019/2019-04-23-some-tips-for-conferences.md
+++ b/src/_posts/2019/2019-04-23-some-tips-for-conferences.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2019-04-23 09:27:31 +0000
 title: Some tips for conferences
-tags: conferences
+tags:
+  - conferences
 ---
 
 My first tech conference was PyCon UK, back in September 2016.

--- a/src/_posts/2019/2019-04-28-reversing-a-tco-url-to-the-original-tweet.md
+++ b/src/_posts/2019/2019-04-28-reversing-a-tco-url-to-the-original-tweet.md
@@ -4,7 +4,8 @@ layout: post
 summary: Twitter uses t.co to shorten links in tweets, so I wrote some Python to take
   a t.co URL and find the original tweet.
 title: Reversing a t.co URL to the original tweet
-tags: twitter
+tags:
+  - twitter
 colors:
   index_light: "#273d5d"
   index_dark:  "#5fa0c1"

--- a/src/_posts/2019/2019-05-01-finding-unused-variables-in-a-terraform-module.md
+++ b/src/_posts/2019/2019-05-01-finding-unused-variables-in-a-terraform-module.md
@@ -2,7 +2,8 @@
 date: 2019-05-01 20:59:07 +0000
 layout: post
 title: Finding unused variables in a Terraform module
-tags: terraform
+tags:
+  - terraform
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-05-13-creating-a-locking-service-in-a-scala-type-class.md
+++ b/src/_posts/2019/2019-05-13-creating-a-locking-service-in-a-scala-type-class.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2019-05-13 10:17:13 +0000
 summary: Breaking down some tricky code that allows us to lock over concurrent operations.
-tags: scala
+tags:
+  - scala
 title: Creating a locking service in a Scala type class
 colors:
   index_light: "#276b44"

--- a/src/_posts/2019/2019-05-15-falsehoods-programmers-believe-about-unix-time.md
+++ b/src/_posts/2019/2019-05-15-falsehoods-programmers-believe-about-unix-time.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-05-15 06:39:00 +0000
 title: Falsehoods programmers believe about Unix time
 summary: It's not quite the number of seconds since 1 January 1970.
-tags: datetime-shenanigans
+tags:
+  - datetime-shenanigans
 colors:
   index_light: "#8f743d"
   index_dark:  "#c5a96e"

--- a/src/_posts/2019/2019-05-24-first-thoughts-on-trans-inclusion.md
+++ b/src/_posts/2019/2019-05-24-first-thoughts-on-trans-inclusion.md
@@ -3,7 +3,10 @@ layout: post
 date: 2019-05-24 07:29:44 +0000
 title: Questions to ask when writing a trans inclusion policy
 summary: Notes on common themes and ideas in a variety of trans inclusion policies, as we start thinking about writing a policy at Wellcome.
-tags: gender work inclusion
+tags:
+  - gender
+  - work
+  - inclusion
 ---
 
 A fortnight ago, I tweeted a question:

--- a/src/_posts/2019/2019-06-04-cycle-tracking-isn-t-just-for-women.md
+++ b/src/_posts/2019/2019-06-04-cycle-tracking-isn-t-just-for-women.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-06-04 22:51:19 +0000
 title: Hey Apple, cycle tracking isn't just for women
 summary: At WWDC, I was disappointed to see Apple pitch period tracking exclusively towards women, and not in a more gender-inclusive way.
-tags: gender inclusion
+tags:
+  - gender
+  - inclusion
 ---
 
 One of the announcements at WWDC on Monday was new cycle tracking features in Apple's Health app.

--- a/src/_posts/2019/2019-06-04-getting-cover-images-from-mobi-ebooks.md
+++ b/src/_posts/2019/2019-06-04-getting-cover-images-from-mobi-ebooks.md
@@ -3,7 +3,8 @@ date: 2019-06-04 19:43:14 +0000
 layout: post
 link: https://github.com/alexwlchan/get-mobi-cover-image
 title: A script for getting cover images from mobi ebooks
-tags: ebooks
+tags:
+  - ebooks
 ---
 
 As part of a recent project, I've been writing code to get thumbnails for a bunch of different file formats.

--- a/src/_posts/2019/2019-06-09-acorn-on-the-command-line.md
+++ b/src/_posts/2019/2019-06-09-acorn-on-the-command-line.md
@@ -3,7 +3,10 @@ layout: post
 date: 2019-06-09 10:36:43 +0000
 title: Converting Acorn images on the command-line
 summary: I wrote some AppleScript to help me do batch conversion of Acorn images into formats like PNG and JPEG.
-tags: applescript acorn images
+tags:
+  - applescript
+  - acorn
+  - images
 ---
 
 I've just finished creating some images for a new post, and I drew them all in the macOS image editor [Acorn].

--- a/src/_posts/2019/2019-06-12-reading-a-chinese-dictionary.md
+++ b/src/_posts/2019/2019-06-12-reading-a-chinese-dictionary.md
@@ -6,7 +6,8 @@ summary: Although paper dictionaries are mostly a thing of the past, knowing how
 colors:
   index_light: "#131313"
   index_dark:  "#c4c4c4"
-tags: languages
+tags:
+  - languages
 ---
 
 <style>

--- a/src/_posts/2019/2019-06-15-a-jekyll-filter-for-obfuscating-email-addresses.md
+++ b/src/_posts/2019/2019-06-15-a-jekyll-filter-for-obfuscating-email-addresses.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-06-15 21:49:44 +0000
 title: A Jekyll filter for obfuscating email addresses
 summary: The original Markdown implementation would do randomised hex/decimal encoding to help obscure email addresses, and I do the same in Jekyll.
-tags: jekyll blogging-about-blogging
+tags:
+  - jekyll
+  - blogging-about-blogging
 ---
 
 Like many people, I use [Markdown] to write a lot of text.

--- a/src/_posts/2019/2019-06-18-regenerating.md
+++ b/src/_posts/2019/2019-06-18-regenerating.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-06-18 12:48:49 +0000
 title: An inescapable conclusion
 summary: After months of introspection and soul-searching, I've had some big realisations about my identity.
-tags: personal gender
+tags:
+  - personal
+  - gender
 colors:
   index_light: "#0a5b8a"
   index_dark:  "#54b8f2"

--- a/src/_posts/2019/2019-07-01-ten-braille-facts.md
+++ b/src/_posts/2019/2019-07-01-ten-braille-facts.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-07-01 07:51:11 +0000
 title: Ten braille facts / ⠼⠁⠚⠀⠃⠗⠁⠊⠇⠇⠑⠀⠋⠁⠉⠞⠎
 summary: Where does braille come from? How was braille originally written? What can you write in braille today? And more.
-tags: languages accessibility
+tags:
+  - languages
+  - accessibility
 colors:
   index_light: "#514d45"
   index_dark:  "#b3b5b0"

--- a/src/_posts/2019/2019-07-03-listing-s3-keys.md
+++ b/src/_posts/2019/2019-07-03-listing-s3-keys.md
@@ -3,7 +3,10 @@ date: 2019-07-03 19:33:55 +0000
 layout: post
 summary: Python functions for getting a list of keys and objects in an S3 bucket.
 title: Listing even more keys in an S3 bucket with Python
-tags: python amazon-s3 aws
+tags:
+  - python
+  - amazon-s3
+  - aws
 ---
 
 Two years ago, I wrote a Python function for [listing keys in an S3 bucket]({% post_url 2017/2017-07-18-listing-s3-keys %}).

--- a/src/_posts/2019/2019-07-18-section-28.md
+++ b/src/_posts/2019/2019-07-18-section-28.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-07-18 07:53:44 +0000
 title: Section 28, and LGBTQ+ people in UK schools
 summary: A not-so-well-known UK law that forbid the teaching of anything about LGBTQ+ people for 15 years.
-tags: politics
+tags:
+  - politics
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-07-29-finding-divisors-with-python.md
+++ b/src/_posts/2019/2019-07-29-finding-divisors-with-python.md
@@ -4,7 +4,9 @@ layout: post
 summary: Using unique prime factorisations and itertools to find all the divisors
   of a number.
 title: Finding divisors of a number with Python
-tags: python maths
+tags:
+  - python
+  - maths
 ---
 
 Here's a problem I was trying to solve recently: given an integer *n*, what are all the divisors of *n*?

--- a/src/_posts/2019/2019-08-19-finding-tint-colours-with-k-means.md
+++ b/src/_posts/2019/2019-08-19-finding-tint-colours-with-k-means.md
@@ -4,7 +4,11 @@ date: 2019-08-19 09:40:52 +0000
 summary: I want to display text next to an image that looks visually similar to the
   image, so I need to extract a tint colour.
 title: Getting a tint colour from an image with Python and <em>k</em>-means
-tags: python images python:pillow colour
+tags:
+  - python
+  - images
+  - python:pillow
+  - colour
 colors:
   index_light: "#4A653A"
   index_dark:  "#70a15a"

--- a/src/_posts/2019/2019-09-05-unpacking-compressed-archives-in-scala.md
+++ b/src/_posts/2019/2019-09-05-unpacking-compressed-archives-in-scala.md
@@ -4,7 +4,8 @@ layout: post
 summary: Code to turn an InputStream into an Iterator of entries from a tar.gz file
   or similar compressed archive in Java/Scala.
 title: Iterating over the entries of a compressed archive (tar.gz) in Scala
-tags: scala
+tags:
+  - scala
 ---
 
 Six months ago, I wrote a post about [working with large S3 objects in Python][s3_python].

--- a/src/_posts/2019/2019-09-12-streaming-large-s3-objects.md
+++ b/src/_posts/2019/2019-09-12-streaming-large-s3-objects.md
@@ -3,7 +3,10 @@ date: 2019-09-12 19:53:53 +0000
 layout: post
 summary: Reliably reading a large object by stitching together multiple GetObject requests into a single Java InputStream.
 title: Streaming large objects from S3 with ranged GET requests
-tags: aws amazon-s3 scala
+tags:
+  - aws
+  - amazon-s3
+  - scala
 ---
 
 In [my last post]({% post_url 2019/2019-09-05-unpacking-compressed-archives-in-scala %}), I talked about how to take a Java `InputStream` for a tar.gz file, and get an iterator of `(ArchiveEntry, InputStream)`.

--- a/src/_posts/2019/2019-09-23-triangular-coordinates-in-svg.md
+++ b/src/_posts/2019/2019-09-23-triangular-coordinates-in-svg.md
@@ -7,7 +7,9 @@ title: Drawing with triangular coordinates in SVG
 colors:
   index_light: "#000000"
   index_dark:  "#b6beb3"
-tags: svg drawing-things
+tags:
+  - svg
+  - drawing-things
 ---
 
 If you've been paying close attention to my recent posts, you might have noticed that I've started to use [SVG images][svg] for some of my diagrams.

--- a/src/_posts/2019/2019-09-28-github-code-search-with-de-duplication.md
+++ b/src/_posts/2019/2019-09-28-github-code-search-with-de-duplication.md
@@ -3,7 +3,8 @@ date: 2019-09-28 19:26:39 +0000
 layout: post
 link: https://github.com/alexwlchan/github-code-search
 title: 'Experiment: GitHub code search with de-duplication'
-tags: github
+tags:
+  - github
 ---
 
 When I'm trying to learn a new library or function, I often [search for code that uses it on GitHub](https://help.github.com/en/articles/searching-code).

--- a/src/_posts/2019/2019-10-06-rough-edges-of-filecmp.md
+++ b/src/_posts/2019/2019-10-06-rough-edges-of-filecmp.md
@@ -3,7 +3,8 @@ date: 2019-10-06 17:32:56 +0000
 layout: post
 summary: The filecmp module has a confusing API, and it just caught me out.
 title: The rough edges of filecmp
-tags: python
+tags:
+  - python
 ---
 
 I've been cleaning up some old files recently, and as part of that I'm using the [filecmp module](https://docs.python.org/3/library/filecmp.html) to find duplicates.

--- a/src/_posts/2019/2019-10-11-religious-holidays.md
+++ b/src/_posts/2019/2019-10-11-religious-holidays.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2019-10-11 20:34:14 +0000
 title: Adding religious holidays to my calendar
-tags: inclusion religion
+tags:
+  - inclusion
+  - religion
 ---
 
 I made a small tweak to my calendar recently, so it shows me religious holidays -- or at least, Christian, Jewish and Muslim holidays:

--- a/src/_posts/2019/2019-10-14-sans-io-programming.md
+++ b/src/_posts/2019/2019-10-14-sans-io-programming.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-10-14 17:33:09 +0000
 title: "Sans I/O programming: what, why and how (PyCon UK talk)"
 summary: Code that pushes I/O to the boundary is simpler, easier to reuse and easier to test.
-tags: pyconuk programming
+tags:
+  - pyconuk
+  - programming
 colors:
   css_light: "#008921"
   css_dark:  "#54c552"

--- a/src/_posts/2019/2019-10-16-adventures-with-concurrent-futures.md
+++ b/src/_posts/2019/2019-10-16-adventures-with-concurrent-futures.md
@@ -4,7 +4,8 @@ date: 2019-10-16 21:24:21 +0000
 title: Adventures in Python with concurrent.futures
 summary: Some examples of how I've been using concurrent.futures to speed up my batch scripting in Python.
 date_updated: 2020-05-02 20:29:25 +0100
-tags: python
+tags:
+  - python
 ---
 
 I use a lot of Python for scripting, and in particular to perform repetitive tasks.

--- a/src/_posts/2019/2019-10-22-digital-preservation-at-wellcome-collection.md
+++ b/src/_posts/2019/2019-10-22-digital-preservation-at-wellcome-collection.md
@@ -4,7 +4,9 @@ date: 2019-10-22 22:00:14 +0000
 title: Digital preservation at Wellcome Collection
 summary: Slides from a presentation about our processes, practices, and tools.
 link: https://stacks.wellcomecollection.org/digital-preservation-at-wellcome-3f86b423047
-tags: wellcome-collection digital-preservation
+tags:
+  - wellcome-collection
+  - digital-preservation
 colors:
   index_light: "#837252"
   index_dark:  "#efeee3"

--- a/src/_posts/2019/2019-11-06-aws-costs-graph.md
+++ b/src/_posts/2019/2019-11-06-aws-costs-graph.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-11-06 07:54:27 +0000
 title: An AWS costs graph that works for me
 summary: How I get a Cost Explorer graph for the last 30 days of spending, broken down by service.
-tags: aws aws-billing
+tags:
+  - aws
+  - aws-billing
 ---
 
 If you use AWS, it's always a good idea to keep an eye on your costs.

--- a/src/_posts/2019/2019-11-08-fixing-terraform-module-sources.md
+++ b/src/_posts/2019/2019-11-08-fixing-terraform-module-sources.md
@@ -3,7 +3,8 @@ layout: post
 date: 2019-11-08 08:29:51 +0000
 title: "Preparing for Terraform 0.12: fixing module sources"
 summary: I wanted a quick way to find Terraform modules that had values that would break in 0.12. I used a Python script to do it.
-tags: terraform
+tags:
+  - terraform
 index:
   exclude: true
 ---

--- a/src/_posts/2019/2019-11-17-saving-a-copy-of-a-tweet-by-typing-twurl.md
+++ b/src/_posts/2019/2019-11-17-saving-a-copy-of-a-tweet-by-typing-twurl.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2019-11-17 11:38:06 +0000
 title: Saving a copy of a tweet by typing ;twurl
-tags: twitter python
+tags:
+  - twitter
+  - python
 ---
 
 For years, I've been using a [Keyboard Maestro][km] snippet for getting the front URL from my running web browser.

--- a/src/_posts/2019/2019-11-27-my-scanning-setup.md
+++ b/src/_posts/2019/2019-11-27-my-scanning-setup.md
@@ -3,7 +3,10 @@ layout: post
 date: 2019-11-27 12:43:44 +0000
 title: How I scan and organise my paperwork
 summary: My procedure for scanning paper, and organising the scanned PDFs with keyword tagging.
-tags: personal productivity digital-preservation
+tags:
+  - personal
+  - productivity
+  - digital-preservation
 colors:
   index_light: "#302d2b"
   index_dark:  "#c2904f"

--- a/src/_posts/2019/2019-12-02-november-scripts.md
+++ b/src/_posts/2019/2019-12-02-november-scripts.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2019-12-02 23:21:41 +0000
 title: "November 2019 scripts: downloading podcasts, retrying flaky errors, Azure and AWS"
-tags: python aws
+tags:
+  - python
+  - aws
 ---
 
 I do a lot of automation, and I write plenty of scripts.

--- a/src/_posts/2019/2019-12-06-spreadsheet-functions.md
+++ b/src/_posts/2019/2019-12-06-spreadsheet-functions.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2019-12-06 09:02:20 +0000
 title: "Some useful spreadsheet functions: FORMULATEXT, MATCH, CONCATENATE and INDIRECT"
-tags: spreadsheets
+tags:
+  - spreadsheets
 ---
 
 I've been doing some work in spreadsheets recently, and I stumbled upon a couple of functions that let me do some neat things.

--- a/src/_posts/2019/2019-12-11-yaml-impossible.md
+++ b/src/_posts/2019/2019-12-11-yaml-impossible.md
@@ -3,7 +3,9 @@ layout: post
 date: 2019-12-11 08:52:40 +0000
 title: This YAML file will self-destruct in five seconds!
 summary: YAML allows you to execute arbitrary code in a parser, even if you really really shouldn't.
-tags: python code-crimes
+tags:
+  - python
+  - code-crimes
 
 colors:
   index_light: "#527ab2"

--- a/src/_posts/2020/2020-01-04-finding-the-bottlenecks-in-an-ecs-cluster.md
+++ b/src/_posts/2020/2020-01-04-finding-the-bottlenecks-in-an-ecs-cluster.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2020-01-04 10:03:53 +0000
 title: Finding the CPU and memory bottlenecks in an ECS cluster
-tags: aws amazon-ecs
+tags:
+  - aws
+  - amazon-ecs
 ---
 
 At work, we use Amazon's EC2 Container Service (ECS) to run some of our applications.

--- a/src/_posts/2020/2020-01-16-pride-valknuts.md
+++ b/src/_posts/2020/2020-01-16-pride-valknuts.md
@@ -4,7 +4,12 @@ date: 2020-01-16 22:56:51 +0000
 title: Generating pride-themed Norse valknuts with Python 🌈
 summary: A web app to generate mashups of Norse valknuts and Pride flags.
 link: https://rainbow-valknuts.glitch.me/
-tags: python glitch generative-art fun-stuff drawing-things
+tags:
+  - python
+  - glitch
+  - generative-art
+  - fun-stuff
+  - drawing-things
 colors:
   index_light: "#e31b85"
   index_dark:  "#c8c8c8"

--- a/src/_posts/2020/2020-01-19-tex-dockerfile.md
+++ b/src/_posts/2020/2020-01-19-tex-dockerfile.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-01-19 10:32:58 +0000
 title: A Docker image to run LaTeX
 link: https://github.com/alexwlchan/tex-dockerfile
-tags: latex docker
+tags:
+  - latex
+  - docker
 ---
 
 These days, I do less and less writing that needs to be printed, but when I do, my tool of choice is still LaTeX.

--- a/src/_posts/2020/2020-01-22-deletion-canary.md
+++ b/src/_posts/2020/2020-01-22-deletion-canary.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-01-22 08:23:50 +0000
 title: "A deletion canary: testing your S3 bucket permissions"
 summary: If you've tried to disable deletions in your S3 buckets, how do you know they're working?
-tags: aws amazon-s3
+tags:
+  - aws
+  - amazon-s3
 colors:
   index_light: "#7b674a"
   index_dark:  "#e1b234"

--- a/src/_posts/2020/2020-01-22-uk-stations-map.md
+++ b/src/_posts/2020/2020-01-22-uk-stations-map.md
@@ -4,7 +4,10 @@ date: 2020-01-22 07:50:23 +0000
 title: An interactive map of British railway stations 🚂
 summary: A map I use to plot which railway stations I've visited.
 link: https://uk-stations-map.glitch.me/
-tags: glitch trains fun-stuff
+tags:
+  - glitch
+  - trains
+  - fun-stuff
 colors:
   index_light: "#0b9e00"
   index_dark:  "#0b9e00"

--- a/src/_posts/2020/2020-01-29-excluding-lots-of-folders-in-backblaze.md
+++ b/src/_posts/2020/2020-01-29-excluding-lots-of-folders-in-backblaze.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-01-29 09:44:49 +0000
 title: Excluding lots of folders in Backblaze
 summary: Backblaze lets you say “back up everything except these folders”. How do you tell it you have lots of folders you want it to ignore?
-tags: macos backblaze
+tags:
+  - macos
+  - backblaze
 ---
 
 One of the services I rely on is [Backblaze].

--- a/src/_posts/2020/2020-02-06-archival-storage-service.md
+++ b/src/_posts/2020/2020-02-06-archival-storage-service.md
@@ -7,7 +7,9 @@ link: https://stacks.wellcomecollection.org/building-wellcome-collections-new-ar
 colors:
   index_light: "#223395"
   index_dark:  "#5c90f0"
-tags: digital-preservation wellcome-collection
+tags:
+  - digital-preservation
+  - wellcome-collection
 ---
 
 Yesterday, I posted an article about the new cloud storage service I've been helping to build at Wellcome.

--- a/src/_posts/2020/2020-02-18-versioning-a-bagit-bag.md
+++ b/src/_posts/2020/2020-02-18-versioning-a-bagit-bag.md
@@ -4,7 +4,9 @@ date: 2020-02-18 08:09:36 +0000
 title: Storing multiple, human-readable versions of BagIt bags
 summary: How we use the fetch.txt file in a bag to track multiple copies of an object in our digital archive.
 link: https://stacks.wellcomecollection.org/how-we-store-multiple-versions-of-bagit-bags-e68499815184
-tags: digital-preservation wellcome-collection
+tags:
+  - digital-preservation
+  - wellcome-collection
 colors:
   index_light: "#1d78b9"
   index_dark:  "#bdddf6"

--- a/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
+++ b/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
@@ -2,7 +2,12 @@
 layout: post
 date: 2020-02-23 20:58:34 +0000
 title: Adjusting the dominant colour of an image
-tags: acorn python images colour drawing-things
+tags:
+  - acorn
+  - python
+  - images
+  - colour
+  - drawing-things
 summary: Adjusting the hue to get different colour variants of the same image.
 ---
 

--- a/src/_posts/2020/2020-02-25-a-remote-controlled-oven-is-a-safety-nightmare.md
+++ b/src/_posts/2020/2020-02-25-a-remote-controlled-oven-is-a-safety-nightmare.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-02-25 12:13:12 +0000
 title: A remote-controlled oven is a safety nightmare
 summary: We should always think about how a malicious user might misuse the things we build. What could they do with a remote-controlled oven?
-tags: security
+tags:
+  - security
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-03-02-finding-the-size-of-your-s3-buckets.md
+++ b/src/_posts/2020/2020-03-02-finding-the-size-of-your-s3-buckets.md
@@ -4,7 +4,9 @@ date: 2020-03-02 07:48:10 +0000
 title: Finding the size and cost of each of your S3 buckets
 summary: A Python script that tells you how many objects and how many bytes there are in each of your S3 buckets.
 link: https://github.com/alexwlchan/s3_summary_spreadsheet_script
-tags: aws amazon-s3
+tags:
+  - aws
+  - amazon-s3
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-03-04-adding-non-breaking-spaces-with-jekyll.md
+++ b/src/_posts/2020/2020-03-04-adding-non-breaking-spaces-with-jekyll.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-03-04 09:42:35 +0000
 title: A Jekyll filter for adding non-breaking spaces
 summary: A way to avoid awkward line breaks in the middle of phrases.
-tags: jekyll blogging-about-blogging
+tags:
+  - jekyll
+  - blogging-about-blogging
 ---
 
 I've been using [Jekyll] to build this blog for about two and a half years.

--- a/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
+++ b/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-03-08 10:13:19 +0000
 title: Creating striped flag wallpapers with Pillow
-tags: python drawing-things python:pillow
+tags:
+  - python
+  - drawing-things
+  - python:pillow
 ---
 
 <style>

--- a/src/_posts/2020/2020-03-14-sick-leave.md
+++ b/src/_posts/2020/2020-03-14-sick-leave.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-03-14 09:27:10 +0000
 title: Sick leave while working from home
 summary: It's okay to take sick leave if you're working from home.
-tags: work
+tags:
+  - work
 ---
 
 In the current pandemic, many of us are about to start working from home full-time.

--- a/src/_posts/2020/2020-03-15-rich-enough-to-make-bad-choices.md
+++ b/src/_posts/2020/2020-03-15-rich-enough-to-make-bad-choices.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-03-15 08:30:18 +0000
 title: Rich enough to make bad choices
 summary: If you're rich, not only can you invest in good boots, you can also invest in experimental boot-making startups.
-tags: inclusion
+tags:
+  - inclusion
 colors:
   index_light: "#16282d"
   index_dark:  "#c98a6c"

--- a/src/_posts/2020/2020-03-25-inclusion-cant-be-an-afterthought.md
+++ b/src/_posts/2020/2020-03-25-inclusion-cant-be-an-afterthought.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-03-25 13:03:10 +0000
 title: Inclusion can't be an afterthought
 summary: Notes from a talk about inclusion in design and unconscious bias.
-tags: inclusion talks open-life-science
+tags:
+  - inclusion
+  - talks
+  - open-life-science
 colors:
   css_light: "#20883f"
   css_dark:  "#2fc65d"

--- a/src/_posts/2020/2020-04-05-storing-language-vocabulary-as-a-graph.md
+++ b/src/_posts/2020/2020-04-05-storing-language-vocabulary-as-a-graph.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-04-05 08:09:36 +0000
 title: Storing language vocabulary as a graph
 summary: Experimenting with a way to store words and phrases that highlights the connections between them.
-tags: languages python graph-theory
+tags:
+  - languages
+  - python
+  - graph-theory
 colors:
   index_light: "#946800"
   index_dark:  "#ffb300"

--- a/src/_posts/2020/2020-04-12-downloading-files-with-python.md
+++ b/src/_posts/2020/2020-04-12-downloading-files-with-python.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-04-12 14:27:01 +0000
 title: A snippet for downloading files with Python
-tags: python
+tags:
+  - python
 ---
 
 Back in February, I wrote about the [new storage service][storage] I've been helping to build at Wellcome.

--- a/src/_posts/2020/2020-04-16-adventures-in-embodiment.md
+++ b/src/_posts/2020/2020-04-16-adventures-in-embodiment.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-04-16 11:50:48 +0000
 title: Adventures in euphoria and embodiment
 summary: We all have bodies, and I've been trying to become more self-aware and connected with mine.
-tags: personal gender
+tags:
+  - personal
+  - gender
 ---
 
 If you've follow me on Twitter, you might have seen some vague tweets about embodiment recently.

--- a/src/_posts/2020/2020-04-17-getting-word-count-stats-for-my-blog.md
+++ b/src/_posts/2020/2020-04-17-getting-word-count-stats-for-my-blog.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-04-17 20:23:19 +0000
 title: Getting word count stats for my blog
 link: https://alexwlchan.net/stats/
-tags: jekyll blogging-about-blogging
+tags:
+  - jekyll
+  - blogging-about-blogging
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-04-18-survivors-guilt.md
+++ b/src/_posts/2020/2020-04-18-survivors-guilt.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-04-18 07:02:18 +0000
 title: Look out for survivor's guilt
-tags: pandemic
+tags:
+  - pandemic
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-04-19-comparing-json-in-scala.md
+++ b/src/_posts/2020/2020-04-19-comparing-json-in-scala.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-04-19 12:43:43 +0000
 title: Comparing JSON strings when testing in Scala
 summary: There are lots of ways to format JSON. How do you know if two JSON strings have the same data, just differently formatted?
-tags: scala
+tags:
+  - scala
 ---
 
 For my day job, I write APIs that return JSON responses.

--- a/src/_posts/2020/2020-04-19-complex-failures.md
+++ b/src/_posts/2020/2020-04-19-complex-failures.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-04-19 18:32:48 +0000
 title: Complex systems have complex failures
 summary: When a complex system fails, it's usually a combination of problems, not a single person's mistake.
-tags: systems-thinking
+tags:
+  - systems-thinking
 ---
 
 As the pandemic gets worse, I see a lot of people blaming China for everything.

--- a/src/_posts/2020/2020-04-22-thinking-about-gender.md
+++ b/src/_posts/2020/2020-04-22-thinking-about-gender.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-04-22 18:19:40 +0000
 title: Thinking about your gender
 summary: Cis people are allowed to think about their gender too.
-tags: gender
+tags:
+  - gender
 ---
 
 Here's a take I see fairly regularly in online trans discourse: _"If you think a lot about your gender, you're trans"_.

--- a/src/_posts/2020/2020-04-26-exploring-an-unknown-sql-server.md
+++ b/src/_posts/2020/2020-04-26-exploring-an-unknown-sql-server.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-04-26 17:53:53 +0000
 title: Exploring an unknown SQL server
 summary: You're handed a SQL server which has some data, but you don't know anything about the schema. What do you do?
-tags: programming mysql
+tags:
+  - programming
+  - mysql
 ---
 
 I've been helping to decommission an old application at work recently, and part of that process was verifying we'd got all the important data out.

--- a/src/_posts/2020/2020-04-27-using-dynamodb-as-a-calculator.md
+++ b/src/_posts/2020/2020-04-27-using-dynamodb-as-a-calculator.md
@@ -3,7 +3,11 @@ layout: post
 date: 2020-04-27 09:23:04 +0000
 title: Using DynamoDB as a calculator
 summary: Taking advantage of Amazon's least-loved compute platform.
-tags: aws amazon-dynamodb python code-crimes
+tags:
+  - aws
+  - amazon-dynamodb
+  - python
+  - code-crimes
 colors:
   index_light: "#234371"
   index_dark:  "#56abdf"

--- a/src/_posts/2020/2020-05-01-illustrating-lifecycle-transitions-in-amazon-s3.md
+++ b/src/_posts/2020/2020-05-01-illustrating-lifecycle-transitions-in-amazon-s3.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-05-01 15:56:04 +0000
 title: Illustrating lifecycle transitions in Amazon S3
 summary: A picture speaks a thousand words, which is why I always have pen and paper to hand.
-tags: aws amazon-s3 drawing-things
+tags:
+  - aws
+  - amazon-s3
+  - drawing-things
 colors:
   index_light: "#118f63"
   index_dark:  "#09c385"

--- a/src/_posts/2020/2020-05-02-give-your-audience-time-to-react.md
+++ b/src/_posts/2020/2020-05-02-give-your-audience-time-to-react.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-05-02 06:01:43 +0000
 title: Give your audience time to react
 summary: Rehearsing a presentation only tells you the minimum length of time you'll take. If you're speaking to a time limit, remember to leave some slack.
-tags: public-speaking
+tags:
+  - public-speaking
 ---
 
 One of the most common bits of advice in public speaking is to rehearse, rehearse, rehearse.

--- a/src/_posts/2020/2020-05-02-how-long-is-my-data.md
+++ b/src/_posts/2020/2020-05-02-how-long-is-my-data.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-05-02 08:07:18 +0000
 title: How long is my data? 💾
 link: https://howlongismydata.glitch.me/
-tags: digital-preservation glitch fun-stuff
+tags:
+  - digital-preservation
+  - glitch
+  - fun-stuff
 summary: A fun app to calculate the size of your data in terms of floppy disks.
 colors:
   index_light: "#ff47ff"

--- a/src/_posts/2020/2020-05-10-make-it-safe-to-admit-mistakes.md
+++ b/src/_posts/2020/2020-05-10-make-it-safe-to-admit-mistakes.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-05-10 09:11:55 +0000
 title: Make it safe to admit mistakes
 summary: You can't stop people making mistakes, but you can make it more likely that they'll admit their next mistake to you.
-tags: interpersonal-skills
+tags:
+  - interpersonal-skills
 ---
 
 Most software developers have stories about how they broke their production environment.

--- a/src/_posts/2020/2020-05-11-the-friends-i-lost-along-the-way.md
+++ b/src/_posts/2020/2020-05-11-the-friends-i-lost-along-the-way.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-05-11 18:30:07 +0000
 title: The friends I lost along the way
-tags: personal
+tags:
+  - personal
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
+++ b/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-05-12 06:57:53 +0000
 title: Taking tuple unpacking to terrible places
 summary: I want to assign a bunch of variables to True, but I don't know how many there are. Reflection to the rescue!
-tags: python code-crimes
+tags:
+  - python
+  - code-crimes
 ---
 
 A week ago, I posted [a snippet of code on Twitter](https://twitter.com/alexwlchan/status/1258147811851460608) that has upset people:

--- a/src/_posts/2020/2020-05-14-letter-to-my-mp-about-liz-truss-and-medical-treatment-for-trans-youth.md
+++ b/src/_posts/2020/2020-05-14-letter-to-my-mp-about-liz-truss-and-medical-treatment-for-trans-youth.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2020-05-14 21:21:55 +0000
 title: Letter to my MP about Liz Truss and medical treatment for trans youth
-tags: politics gender
+tags:
+  - politics
+  - gender
 ---
 
 About three weeks ago, Liz Truss gave a speech [to the Women and Equalities Select Committee](https://www.gov.uk/government/speeches/minister-for-women-and-equalities-liz-truss-sets-out-priorities-to-women-and-equalities-select-committee), which included discussion of the Gender Recognition Act, and potentially restricting access to medical care for trans youth:

--- a/src/_posts/2020/2020-05-15-downloading-the-ao3-fics-that-i-ve-saved-in-pinboard.md
+++ b/src/_posts/2020/2020-05-15-downloading-the-ao3-fics-that-i-ve-saved-in-pinboard.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-05-15 18:59:26 +0000
 title: Downloading the AO3 fics that I've saved in Pinboard
 summary: A script that downloads the nicely formatted AO3 downloads for everything I've saved in Pinboard.
-tags: python pinboard ao3
+tags:
+  - python
+  - pinboard
+  - ao3
 ---
 
 A couple of days ago, I tweeted about one of my scripts:

--- a/src/_posts/2020/2020-05-16-moving-messages-between-sqs-queues.md
+++ b/src/_posts/2020/2020-05-16-moving-messages-between-sqs-queues.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-05-16 09:43:00 +0000
 title: Moving messages between SQS queues
 summary: You can send messages to a DLQ if they fail processing. What if you fix the bug, and you want to resend the failed messages?
-tags: aws amazon-sqs
+tags:
+  - aws
+  - amazon-sqs
 ---
 
 At work, we make heavy use of [Amazon SQS](https://en.wikipedia.org/wiki/Amazon_Simple_Queue_Service) for message queues.

--- a/src/_posts/2020/2020-05-17-sachsenhausen.md
+++ b/src/_posts/2020/2020-05-17-sachsenhausen.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-05-17 13:13:12 +0000
 title: The Sachsenhausen concentration camp
 summary: Feeling the weight of death in a former concentration camp.
-tags: history
+tags:
+  - history
 ---
 
 *Content warning: Nazis, Holocaust, murder, graphic descriptions of death.*

--- a/src/_posts/2020/2020-05-24-human-friendly-dates-in-javascript.md
+++ b/src/_posts/2020/2020-05-24-human-friendly-dates-in-javascript.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-05-24 11:08:57 +0000
 title: Showing human-friendly dates in JavaScript
 summary: What's a nicer way to show a date than an ISO 8601 timestamp?
-tags: javascript datetime-shenanigans web-development
+tags:
+  - javascript
+  - datetime-shenanigans
+  - web-development
 ---
 
 At work, we have an API for tracking the state of ingests in [our digital archive].

--- a/src/_posts/2020/2020-05-27-getting-every-item-from-a-dynamodb-table-with-python.md
+++ b/src/_posts/2020/2020-05-27-getting-every-item-from-a-dynamodb-table-with-python.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-05-27 09:26:13 +0000
 title: Getting every item from a DynamoDB table with Python
 summary: A Python function that generates every item in a DynamoDB table.
-tags: aws amazon-dynamodb python
+tags:
+  - aws
+  - amazon-dynamodb
+  - python
 ---
 
 At work, we use [DynamoDB] as our primary database.

--- a/src/_posts/2020/2020-06-06-finding-the-months-between-two-dates-in-python.md
+++ b/src/_posts/2020/2020-06-06-finding-the-months-between-two-dates-in-python.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2020-06-06 06:38:11 +0000
 title: Finding the months between two dates in Python
-tags: python datetime-shenanigans
+tags:
+  - python
+  - datetime-shenanigans
 ---
 
 Here's a function extracted from a recent project that I'm likely to reuse elsewhere: finding all the months between two dates in Python.

--- a/src/_posts/2020/2020-06-15-always-read-your-contract.md
+++ b/src/_posts/2020/2020-06-15-always-read-your-contract.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-06-15 20:49:45 +0000
 title: Always read your contracts
 link: https://twitter.com/alexwlchan/status/1271339259509825536
-tags: personal
+tags:
+  - personal
 index:
   exclude: true
 ---

--- a/src/_posts/2020/2020-06-15-archive-monocultures-considered-harmful.md
+++ b/src/_posts/2020/2020-06-15-archive-monocultures-considered-harmful.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-06-15 06:57:51 +0000
 title: Archive monocultures considered harmful
 summary: We are better off when the same topic is represented in multiple, different archives.
-tags: digital-preservation
+tags:
+  - digital-preservation
 ---
 
 *Note: like everything on this blog, this is my personal opinion. I'm not speaking for Wellcome Collection or anybody else who works there.*

--- a/src/_posts/2020/2020-06-20-large-things-living-in-cold-places.md
+++ b/src/_posts/2020/2020-06-20-large-things-living-in-cold-places.md
@@ -2,7 +2,11 @@
 layout: post
 date: 2020-06-20 08:36:39 +0000
 title: Large things living in cold places
-tags: digital-preservation wellcome-collection aws amazon-s3
+tags:
+  - digital-preservation
+  - wellcome-collection
+  - aws
+  - amazon-s3
 summary: Using cold storage tiers to reduce the cost of storing Wellcome's digital collections in the cloud.
 link: https://stacks.wellcomecollection.org/large-things-living-in-cold-places-66cbc3603e14
 colors:

--- a/src/_posts/2020/2020-06-21-fat-shaming-in-the-good-place.md
+++ b/src/_posts/2020/2020-06-21-fat-shaming-in-the-good-place.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-06-21 10:44:13 +0000
 title: Fat shaming in <em>The Good Place</em>
 summary: How many good person points do you lose for making a joke about somebody's weight?
-tags: the-good-place tv
+tags:
+  - the-good-place
+  - tv
 colors:
   index_light: "#653415"
   index_dark:  "#f1ba62"

--- a/src/_posts/2020/2020-06-24-using-applescript-to-open-a-url-in-private-browsing-in-safari.md
+++ b/src/_posts/2020/2020-06-24-using-applescript-to-open-a-url-in-private-browsing-in-safari.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-06-24 20:02:44 +0000
 title: Using AppleScript to open a URL in Private Browsing in Safari
-tags: applescript macos macos:safari
+tags:
+  - applescript
+  - macos
+  - macos:safari
 
 ---
 

--- a/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
+++ b/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-07-06 21:31:32 +0000
 title: Changing the accent colour of ICNS icons
 summary: Playing with macOS ICNS image files to create colourful new icons.
-tags: macos colour fun-stuff
+tags:
+  - macos
+  - colour
+  - fun-stuff
 ---
 
 One of my key tools is [nvALT], a notetaking app for macOS.

--- a/src/_posts/2020/2020-07-12-how-to-do-parallel-downloads-with-youtube-dl.md
+++ b/src/_posts/2020/2020-07-12-how-to-do-parallel-downloads-with-youtube-dl.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2020-07-12 07:34:45 +0000
 title: How to do parallel downloads with youtube-dl
-tags: shell-scripting youtube
+tags:
+  - shell-scripting
+  - youtube
 ---
 
 I'm a regular user of [youtube-dl](http://ytdl-org.github.io/youtube-dl/), a command-line program for downloading videos from YouTube (and other sites).

--- a/src/_posts/2020/2020-07-13-what-does-d-match-in-a-regex.md
+++ b/src/_posts/2020/2020-07-13-what-does-d-match-in-a-regex.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-07-13 22:20:06 +0000
 title: What does \d match in a regex?
-tags: regex
+tags:
+  - regex
 summary: It's more complicated than I thought.
 colors:
   index_light: "#6d5537"

--- a/src/_posts/2020/2020-07-20-running-concurrent-try-functions-in-scala.md
+++ b/src/_posts/2020/2020-07-20-running-concurrent-try-functions-in-scala.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-07-20 09:06:38 +0000
 title: Running concurrent Try functions in Scala
 summary: If you have a function that returns Try[_], how do you call it more than once at the same time?
-tags: scala
+tags:
+  - scala
 ---
 
 Suppose you have a Scala function that returns `Try[_]`.

--- a/src/_posts/2020/2020-07-22-why-do-programming-languages-have-a-main-function.md
+++ b/src/_posts/2020/2020-07-22-why-do-programming-languages-have-a-main-function.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-07-22 14:18:15 +0000
 title: Why do programming languages have a main() function?
 summary: Lots of programming languages have a function called main() where code starts executing. Where does this come from?
-tags: programming history
+tags:
+  - programming
+  - history
 ---
 
 <style>

--- a/src/_posts/2020/2020-07-26-getting-a-markdown-link-to-a-window-in-safari.md
+++ b/src/_posts/2020/2020-07-26-getting-a-markdown-link-to-a-window-in-safari.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-07-26 17:31:36 +0000
 title: Getting a Markdown link to a window in Safari
-tags: macos applescript macos:safari
+tags:
+  - macos
+  - applescript
+  - macos:safari
 ---
 
 Here's an AppleScript I wrote today, which gets a Markdown-formatted link to whatever's in my frontmost Safari window:

--- a/src/_posts/2020/2020-08-06-using-fuzzy-string-matching-to-find-duplicate-tags.md
+++ b/src/_posts/2020/2020-08-06-using-fuzzy-string-matching-to-find-duplicate-tags.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-08-06 11:14:20 +0000
 title: Using fuzzy string matching to find duplicate tags
-tags: python
+tags:
+  - python
 ---
 
 I'm a big fan of [keyword tagging](https://en.wikipedia.org/wiki/Tag_(metadata)) as a way to organise my digital data.

--- a/src/_posts/2020/2020-08-18-s3-keys-are-not-file-paths.md
+++ b/src/_posts/2020/2020-08-18-s3-keys-are-not-file-paths.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-08-18 15:19:20 +0000
 title: S3 keys are not file paths
 summary: Although an S3 key looks a lot like a file path, they aren't always the same, and the distinction can trip you up.
-tags: amazon-s3 aws path-problems
+tags:
+  - amazon-s3
+  - aws
+  - path-problems
 ---
 
 If you look at an S3 bucket, you could be forgiven for thinking it behaves like a hierarchical filesystem, with everything organised as files and folders.

--- a/src/_posts/2020/2020-08-20-s3-prefixes-are-not-directories.md
+++ b/src/_posts/2020/2020-08-20-s3-prefixes-are-not-directories.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-08-20 06:50:04 +0000
 title: S3 prefixes are not directories
 summary: Although an S3 prefix looks a lot like a directory path, they aren't the same. Whether or not you include a trailing slash can change the behaviour.
-tags: amazon-s3 aws path-problems
+tags:
+  - amazon-s3
+  - aws
+  - path-problems
 ---
 
 I didn't expect to be writing another post about S3 keys so soon, but life comes at you fast.

--- a/src/_posts/2020/2020-09-08-two-python-functions-for-getting-cloudtrail-events.md
+++ b/src/_posts/2020/2020-09-08-two-python-functions-for-getting-cloudtrail-events.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-09-08 07:06:07 +0000
 title: Two Python functions for getting CloudTrail events
-tags: aws aws-cloudtrail python
+tags:
+  - aws
+  - aws-cloudtrail
+  - python
 ---
 
 Last week I was trying to debug an anomaly in the AWS account at work -- it looked like we were making tens of millions of GetObject API calls, when we expected our code to make a fraction of that number.

--- a/src/_posts/2020/2020-09-26-using-qlmanage-to-create-thumbnails-on-macos.md
+++ b/src/_posts/2020/2020-09-26-using-qlmanage-to-create-thumbnails-on-macos.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-09-26 10:14:58 +0000
 title: Using qlmanage to create thumbnails on macOS
 summary: How you can invoke Quick Look on the command-line to generate high-quality thumbnails.
-tags: macos
+tags:
+  - macos
 colors:
   index_light: "#4b6ca1"
   index_dark:  "#d69e6d"

--- a/src/_posts/2020/2020-10-09-a-sprinkling-of-azure.md
+++ b/src/_posts/2020/2020-10-09-a-sprinkling-of-azure.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-10-09 11:37:47 +0000
 title: Replicating Wellcome Collection's digital archive to Azure Blob Storage
-tags: wellcome-collection digital-preservation azure
+tags:
+  - wellcome-collection
+  - digital-preservation
+  - azure
 link: https://stacks.wellcomecollection.org/a-sprinkling-of-azure-6cef6e150fb2
 colors:
   index_light: "#235b99"

--- a/src/_posts/2020/2020-10-12-a-new-readme-for-docstore.md
+++ b/src/_posts/2020/2020-10-12-a-new-readme-for-docstore.md
@@ -4,7 +4,8 @@ date: 2020-10-12 06:52:55 +0000
 title: A new README for docstore, my tool for organising scanned paperwork
 summary: Although I don't expect anyone to use it directly, there might be some interesting ideas that could apply elsewhere.
 link: https://github.com/alexwlchan/docstore
-tags: productivity
+tags:
+  - productivity
 colors:
   index_light: "#7a2342"
   index_dark:  "#e5bcc9"

--- a/src/_posts/2020/2020-10-12-the-importance-of-good-error-messages.md
+++ b/src/_posts/2020/2020-10-12-the-importance-of-good-error-messages.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-10-12 18:02:18 +0000
 title: The danger of bad error messages
 summary: An Excel mistake shows why learning to write good error messages is a critical skill for software developers.
-tags: error-messages
+tags:
+  - error-messages
 ---
 
 Last week, the UK government came under fire for suspected [poor use of Excel](https://www.engadget.com/microsoft-excel-england-covid-19-delay-114634846.html), which led to an undercounting of COVID-19 cases.

--- a/src/_posts/2020/2020-10-17-how-do-i-use-my-iphone-cameras.md
+++ b/src/_posts/2020/2020-10-17-how-do-i-use-my-iphone-cameras.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-10-17 16:58:18 +0000
 title: How do I use my iPhone cameras?
 summary: A script to work out which camera I use most often on my iPhone, and whether I'd miss a telephoto lens.
-tags: iphone photography
+tags:
+  - iphone
+  - photography
 colors:
   index_light: "#353335"
   index_dark:  "#a2a09e"

--- a/src/_posts/2020/2020-10-30-til-using-git-check-ignore-to-debug-your-gitignore.md
+++ b/src/_posts/2020/2020-10-30-til-using-git-check-ignore-to-debug-your-gitignore.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-10-30 18:25:23 +0000
 title: 'TIL: Using git check-ignore to debug your .gitignore'
-tags: git
+tags:
+  - git
 ---
 
 Here's a useful thing I learnt today: you can use [git check-ignore](https://git-scm.com/docs/git-check-ignore) to debug your gitignore rules and find out why a particular file is (or isn't) being ignored.

--- a/src/_posts/2020/2020-11-01-a-python-function-to-ignore-a-path-with-git-info-exclude.md
+++ b/src/_posts/2020/2020-11-01-a-python-function-to-ignore-a-path-with-git-info-exclude.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-11-01 09:13:27 +0000
 title: A Python function to ignore a path with .git/info/exclude
 summary: If your Python script creates a file that you don't want to track in Git, here's how you can ignore it.
-tags: git python
+tags:
+  - git
+  - python
 ---
 
 One of the things I work on is [a Catalogue API](https://developers.wellcomecollection.org/catalogue) for searching Wellcome Collection's collections.

--- a/src/_posts/2020/2020-11-06-remembering-if-a-details-element-was-opened.md
+++ b/src/_posts/2020/2020-11-06-remembering-if-a-details-element-was-opened.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-11-06 15:20:01 +0000
 title: Remembering if a &lt;details&gt; element was opened
 summary: A JavaScript function that remembers if a details element was reopened, and keeps it open when you reload the page.
-tags: javascript html web-development
+tags:
+  - javascript
+  - html
+  - web-development
 ---
 
 A rather useful HTML feature is the [&lt;details&gt; disclosure element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details).

--- a/src/_posts/2020/2020-11-15-maths-is-about-facing-ambiguity-not-avoiding-it.md
+++ b/src/_posts/2020/2020-11-15-maths-is-about-facing-ambiguity-not-avoiding-it.md
@@ -3,7 +3,8 @@ layout: post
 date: 2020-11-15 10:08:33 +0000
 title: Maths is about facing ambiguity, not avoiding it
 summary: School tells us that “Maths always has one right answer!”, which is a convenient but unhelpful lie.
-tags: maths
+tags:
+  - maths
 ---
 
 Every so often, an expression like this goes viral on Twitter:

--- a/src/_posts/2020/2020-11-16-how-i-read-non-fiction-books.md
+++ b/src/_posts/2020/2020-11-16-how-i-read-non-fiction-books.md
@@ -3,7 +3,10 @@ layout: post
 date: 2020-11-16 09:16:47 +0000
 title: How I read non-fiction books
 summary: I take notes so I remember more of what I read.
-tags: books productivity taking-notes
+tags:
+  - books
+  - productivity
+  - taking-notes
 colors:
   index_light: "#4f391d"
   index_dark:  "#c1ae97"

--- a/src/_posts/2020/2020-11-18-copying-images-from-docker-hub-to-amazon-ecr.md
+++ b/src/_posts/2020/2020-11-18-copying-images-from-docker-hub-to-amazon-ecr.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2020-11-18 09:41:32 +0000
 title: A script to copy images from Docker Hub to Amazon ECR
-tags: docker amazon-ecr aws
+tags:
+  - docker
+  - amazon-ecr
+  - aws
 link: https://github.com/wellcomecollection/platform-infrastructure/blob/4b16beef44efbe8faa9a62f5459ab6f706e07032/builds/copy_docker_images_to_ecr.py
 ---
 

--- a/src/_posts/2020/2020-11-24-non-technical-users.md
+++ b/src/_posts/2020/2020-11-24-non-technical-users.md
@@ -2,7 +2,8 @@
 layout: post
 date: 2020-11-24 11:53:34 +0000
 title: “Non-technical users”
-tags: writing
+tags:
+  - writing
 ---
 
 I was talking about some of my work tonight, and some of the writing I've done to make my work comprehensible to colleagues who aren't software developers.

--- a/src/_posts/2020/2020-12-01-creating-short-lived-temporary-roles-for-experimenting-with-aws-iam-policy-documents.md
+++ b/src/_posts/2020/2020-12-01-creating-short-lived-temporary-roles-for-experimenting-with-aws-iam-policy-documents.md
@@ -3,7 +3,9 @@ layout: post
 date: 2020-12-01 21:19:15 +0000
 title: Creating short-lived, temporary roles for experimenting with AWS IAM policy
   documents
-tags: aws aws-iam
+tags:
+  - aws
+  - aws-iam
 link: https://github.com/alexwlchan/iam-policy-document-tester
 summary: Create short-lived, temporary roles for experimenting with AWS IAM policy documents
 ---

--- a/src/_posts/2021/2021-01-01-what-year-is-it.md
+++ b/src/_posts/2021/2021-01-01-what-year-is-it.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-01-01 11:11:48 +0000
 title: What year is it? (A tale of ISO week dates)
 summary: If you use ICU date formatting, make sure you use the right format specifier for year.
-tags: datetime-shenanigans
+tags:
+  - datetime-shenanigans
 colors:
   index_light: "#b17474"
   index_dark:  "#c28786"

--- a/src/_posts/2021/2021-01-31-kempisbot.md
+++ b/src/_posts/2021/2021-01-31-kempisbot.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-01-31 12:25:06 +0000
 title: How KempisBot works
 summary: How I reincarnated a fifteenth-century monk and taught him to use Twitter.
-tags: python twitter fun-stuff
+tags:
+  - python
+  - twitter
+  - fun-stuff
 colors:
   index_light: "#624230"
   index_dark:  "#aa9f92"

--- a/src/_posts/2021/2021-02-15-digital-verification.md
+++ b/src/_posts/2021/2021-02-15-digital-verification.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-02-15 20:12:06 +0000
 title: Wellcome's approach to digital verification
 summary: How we ensure the safety, security and integrity of the files in Wellcome's digital collections.
-tags: digital-preservation wellcome-collection
+tags:
+  - digital-preservation
+  - wellcome-collection
 link: https://stacks.wellcomecollection.org/our-approach-to-digital-verification-79da59da4ab7
 
 colors:

--- a/src/_posts/2021/2021-02-15-screaming-in-the-cloud.md
+++ b/src/_posts/2021/2021-02-15-screaming-in-the-cloud.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-02-15 19:15:19 +0000
 title: '<em>Screaming in the Cloud</em>: Using the Cloud to Preserve the Future'
 summary: I joined Corey Quinn to discuss my DynamoDB calculator and using the cloud to preserve digital collections.
-tags: podcasts aws
+tags:
+  - podcasts
+  - aws
 link: https://www.lastweekinaws.com/podcast/screaming-in-the-cloud/using-the-cloud-to-preserve-the-future-with-alex-chan/
 colors:
   index_light: "#4497b4"

--- a/src/_posts/2021/2021-03-02-an-applescript-to-toggle-voice-control.md
+++ b/src/_posts/2021/2021-03-02-an-applescript-to-toggle-voice-control.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2021-03-02 13:17:55 +0000
 title: An AppleScript to toggle Voice Control
-tags: applescript macos accessibility
+tags:
+  - applescript
+  - macos
+  - accessibility
 summary: Making it slightly easier for me to enable and disable Voice Control quickly.
 colors:
   index_light: "#595c80"

--- a/src/_posts/2021/2021-03-07-rainbow-hearts.md
+++ b/src/_posts/2021/2021-03-07-rainbow-hearts.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-03-07 10:53:24 +0000
 title: Creating pairs of interlocking rainbow hearts 🌈
 summary: A web app for creating pairs of hearts based on Pride flags.
-tags: glitch generative-art fun-stuff
+tags:
+  - glitch
+  - generative-art
+  - fun-stuff
 link: https://rainbow-hearts.glitch.me/
 colors:
   index_light: "#870788"

--- a/src/_posts/2021/2021-03-12-inner-outer-strokes-svg.md
+++ b/src/_posts/2021/2021-03-12-inner-outer-strokes-svg.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-03-12 14:04:58 +0000
 title: Drawing inner/outer strokes in SVG (clips and masks)
 summary: Showing how clips and masks work, and how they can be used to draw inner and outer strokes of a shape.
-tags: svg drawing-things
+tags:
+  - svg
+  - drawing-things
 colors:
   index_light: "#8f6434"
   index_dark:  "#e7a355"

--- a/src/_posts/2021/2021-04-05-secure-input.md
+++ b/src/_posts/2021/2021-04-05-secure-input.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-04-05 07:25:20 +0000
 title: Finding the app/process that's using Secure Input
 summary: A Python script that shows me the name of processes that have Secure Input enabled.
-tags: macos
+tags:
+  - macos
 ---
 
 macOS has a security feature called [*"Secure Input"*][sec_input].

--- a/src/_posts/2021/2021-04-18-detect-private-browsing.md
+++ b/src/_posts/2021/2021-04-18-detect-private-browsing.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2021-04-18 12:35:57 +0000
 title: Using AppleScript to detect if a Safari window uses Private Browsing
-tags: applescript macos macos:safari
+tags:
+  - applescript
+  - macos
+  - macos:safari
 ---
 
 Last year, I wrote an AppleScript function that [opens a URL in a Private Browsing window in Safari]({% post_url 2020/2020-06-24-using-applescript-to-open-a-url-in-private-browsing-in-safari %}).

--- a/src/_posts/2021/2021-04-27-unified-search.md
+++ b/src/_posts/2021/2021-04-27-unified-search.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-04-27 20:05:02 +0000
 title: Building Wellcome Collection's new unified catalogue search
 summary: Collaboration between our digital and collections teams helped to build a single search box for all of our catalogues.
-tags: wellcome-collection search
+tags:
+  - wellcome-collection
+  - search
 link: https://stacks.wellcomecollection.org/building-our-new-unified-collections-search-ed399c412b01
 colors:
   index_light: "#63605f"

--- a/src/_posts/2021/2021-04-29-coloured-squares.md
+++ b/src/_posts/2021/2021-04-29-coloured-squares.md
@@ -2,7 +2,10 @@
 layout: post
 date: 2021-04-29 09:02:12 +0000
 title: Drawing coloured squares/text in my terminal with Python
-tags: python terminal-tricks colour
+tags:
+  - python
+  - terminal-tricks
+  - colour
 ---
 
 Last night, I [posted a tweet][tweet] wondering about the different colours of the ["spool of thread" emoji][emoji], and I made an illustration to show the variety:

--- a/src/_posts/2021/2021-04-30-s3-progress-bars.md
+++ b/src/_posts/2021/2021-04-30-s3-progress-bars.md
@@ -3,7 +3,11 @@ layout: post
 date: 2021-04-30 18:28:27 +0000
 title: Downloading objects from/uploading files to S3 with progress bars in Python
 summary: Making it easier to see how long a file transfer will take, in the terminal.
-tags: amazon-s3 aws python terminal-tricks
+tags:
+  - amazon-s3
+  - aws
+  - python
+  - terminal-tricks
 ---
 
 I write a lot of scripts to move files in and out of S3, and when I'm dealing with larger files, I find it useful to get an idea of how long the transfer will take.

--- a/src/_posts/2021/2021-06-03-visualising-journal.md
+++ b/src/_posts/2021/2021-06-03-visualising-journal.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-06-03 09:46:46 +0000
 title: Visualising how often I write in my journal
 summary: A Python script that shows me how often I've been journalling, so I can track my progress.
-tags: python
+tags:
+  - python
 colors:
   index_light: "#e94cf2"
   index_dark:  "#fe4afa"

--- a/src/_posts/2021/2021-06-08-s3-deprecates-bittorrent.md
+++ b/src/_posts/2021/2021-06-08-s3-deprecates-bittorrent.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-06-08 06:21:15 +0000
 title: Amazon is discontinuing S3 BitTorrent
 summary: AWS quietly announced that S3 will stop supporting BitTorrent for downloads in April 2022.
-tags: amazon-s3
+tags:
+  - amazon-s3
 index:
   exclude: true
 ---

--- a/src/_posts/2021/2021-07-05-listing-deleted-secrets.md
+++ b/src/_posts/2021/2021-07-05-listing-deleted-secrets.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-07-05 11:46:23 +0000
 title: Listing deleted secrets in AWS Secrets Manager with boto3 and the AWS CLI
 summary: Diving into the internals of the AWS SDK to find deleted secrets.
-tags: python aws aws-secrets-manager
+tags:
+  - python
+  - aws
+  - aws-secrets-manager
 colors:
   index_light: "#00A000"
   index_dark:  "#61ff61"

--- a/src/_posts/2021/2021-07-09-useful-github-searches.md
+++ b/src/_posts/2021/2021-07-09-useful-github-searches.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-07-09 06:27:58 +0000
 title: A few useful GitHub searches
 summary: I have hotkeys to search GitHub in several ways, including by user, by repo, and within the work organisation.
-tags: github
+tags:
+  - github
 colors:
   index_light: "#0e1013"
   index_dark:  "#a5a8ab"

--- a/src/_posts/2021/2021-08-22-finding-misconfigured-or-dangling-cloudwatch-alarms.md
+++ b/src/_posts/2021/2021-08-22-finding-misconfigured-or-dangling-cloudwatch-alarms.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-08-22 07:40:23 +0000
 title: Finding misconfigured or dangling CloudWatch Alarms
 summary: A Python script that finds CloudWatch Alarms which are based on a now non-existent source.
-tags: aws amazon-cloudwatch python
+tags:
+  - aws
+  - amazon-cloudwatch
+  - python
 colors:
   index_light: "#B0084D"
   index_dark:  "#f97bb0"

--- a/src/_posts/2021/2021-08-25-markdown-image-syntax.md
+++ b/src/_posts/2021/2021-08-25-markdown-image-syntax.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-08-25 16:13:23 +0000
 title: Markdown’s gentle encouragement towards accessible images
 summary: The Markdown syntax for images reminds us that we need to write alt text.
-tags: markdown accessibility
+tags:
+  - markdown
+  - accessibility
 colors:
   index_light: "#4B5259"
   index_dark:  "#a6adb5"

--- a/src/_posts/2021/2021-08-28-ignore-lots-of-folders-in-spotlight.md
+++ b/src/_posts/2021/2021-08-28-ignore-lots-of-folders-in-spotlight.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-08-28 17:43:17 +0000
 title: How to ignore lots of folders in Spotlight
 summary: A script that allows me to ignore folders like "target" and "node_modules", so they don't appear in search results.
-tags: macos python
+tags:
+  - macos
+  - python
 ---
 
 I searched my Mac recently, and my results were cluttered with files from `node_modules` folders:

--- a/src/_posts/2021/2021-09-06-perfect-planks.md
+++ b/src/_posts/2021/2021-09-06-perfect-planks.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-09-06 05:49:09 +0000
 title: Picking perfect planks with Python
 summary: How do you pick the right combination of planks to lay a wooden floor? Python and itertools to the rescue!
-tags: python combinatorics maths
+tags:
+  - python
+  - combinatorics
+  - maths
 colors:
   index_light: "#5c422e"
   index_dark:  "#e5bd9e"

--- a/src/_posts/2021/2021-09-14-debugging-eventbridge-cron.md
+++ b/src/_posts/2021/2021-09-14-debugging-eventbridge-cron.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-09-14 20:40:26 +0000
 title: When is my EventBridge cron expression going to run next?
 summary: The AWS console will tell you when your EventBridge rule is going to run… if you know where to look.
-tags: aws amazon-eventbridge
+tags:
+  - aws
+  - amazon-eventbridge
 colors:
   index_light: "#565b62"
   index_dark:  "#bfc3c5"

--- a/src/_posts/2021/2021-09-21-safari-15-favicons.md
+++ b/src/_posts/2021/2021-09-21-safari-15-favicons.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-09-21 21:50:31 +0000
 title: Hiding favicons in Safari 15 (kinda)
 summary: How to reduce the visual intrusiveness of favicons in Safari 15.
-tags: macos safari
+tags:
+  - macos
+  - safari
 index:
   exclude: true
 ---

--- a/src/_posts/2021/2021-09-22-non-commuting-strings.md
+++ b/src/_posts/2021/2021-09-22-non-commuting-strings.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-09-22 07:56:04 +0000
 title: Operations on strings don't always commute
 summary: Is uppercasing then reversing a string the same as reversing and then uppercasing? Of course not.
-tags: unicode
+tags:
+  - unicode
 colors:
   index_light: "#19177C"
   index_dark:  "#514ff3"

--- a/src/_posts/2021/2021-09-25-cloud-costs-report.md
+++ b/src/_posts/2021/2021-09-25-cloud-costs-report.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-09-25 15:41:44 +0000
 title: Getting a monthly cloud costs report in Slack
 summary: Sending the AWS bill to Slack, so everyone can be more informed and intentional about spending.
-tags: aws aws-billing
+tags:
+  - aws
+  - aws-billing
 colors:
   index_light: "#403f40"
   index_dark:  "#d4d3d0"

--- a/src/_posts/2021/2021-09-28-editing-toolbar.md
+++ b/src/_posts/2021/2021-09-28-editing-toolbar.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-09-28 19:23:39 +0000
 title: An editing toolbar for alexwlchan.net
 summary: A bookmarklet that gives me a just-for-me toolbar to make changes to this site.
-tags: blogging-about-blogging javascript bookmarklets
+tags:
+  - blogging-about-blogging
+  - javascript
+  - bookmarklets
 ---
 
 I recently wrote a small bookmarklet that gives me an editing toolbar for this site:

--- a/src/_posts/2021/2021-09-29-septembrse.md
+++ b/src/_posts/2021/2021-09-29-septembrse.md
@@ -2,7 +2,9 @@
 layout: post
 date: 2021-09-29 20:23:05 +0000
 title: "SeptembRSE: Missing narratives in discussions around diversity and inclusion"
-tags: talks inclusion
+tags:
+  - talks
+  - inclusion
 ---
 
 Yesterday I was part of a panel on [missing narratives around diversity inclusion][panel_link] as part of SeptembRSE, a conference for Research Software Engineers.

--- a/src/_posts/2021/2021-10-01-how-do-you-work-with-non-engineers.md
+++ b/src/_posts/2021/2021-10-01-how-do-you-work-with-non-engineers.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-10-01 15:18:28 +0000
 title: How do you work with non-engineers?
 summary: Building a relationship founded on trust and respect.
-tags: work interpersonal-skills
+tags:
+  - work
+  - interpersonal-skills
 colors:
   index_light: "#bf4646"
   index_dark:  "#ebb3af"

--- a/src/_posts/2021/2021-10-04-redacting-pdfs.md
+++ b/src/_posts/2021/2021-10-04-redacting-pdfs.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-10-04 14:48:36 +0000
 title: Beware of incomplete PDF redactions
 summary: If you're not careful when redacting PDFs, it's possible to share more information than you intended.
-tags: infosec
+tags:
+  - infosec
 ---
 
 A while back I was reviewing some legal documents.

--- a/src/_posts/2021/2021-10-06-readmes-for-open-science.md
+++ b/src/_posts/2021/2021-10-06-readmes-for-open-science.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-10-06 21:39:30 +0000
 title: READMEs for Open Science
 summary: Slides for a short talk about READMEs, why they're important, and what they should contain.
-tags: documentation open-life-science talks
+tags:
+  - documentation
+  - open-life-science
+  - talks
 colors:
   css_light: "#20883f"
   css_dark:  "#2fc65d"

--- a/src/_posts/2021/2021-10-14-console-copying.md
+++ b/src/_posts/2021/2021-10-14-console-copying.md
@@ -3,7 +3,10 @@ layout: post
 date: 2021-10-14 18:09:09 +0000
 title: Prevent accidentally copying the prompt character in console code snippets
 summary: When I include console commands in a blog post, I don't want somebody to accidentally copy the command prompt. CSS lets me avoid that.
-tags: markdown css blogging-about-blogging
+tags:
+  - markdown
+  - css
+  - blogging-about-blogging
 ---
 
 My posts often include some commands to be run at a console, for example:

--- a/src/_posts/2021/2021-10-16-oboe-of-optozorax.md
+++ b/src/_posts/2021/2021-10-16-oboe-of-optozorax.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-10-16 16:40:16 +0000
 title: The Oboe of Optozorax, and Other Objects
 summary: A collection of small worldbuilding ideas about magical objects.
-tags: fiction
+tags:
+  - fiction
 ---
 
 *Last week, [waffle] was asking a grammar question in a Discord server:*

--- a/src/_posts/2021/2021-10-19-original-photos-filename.md
+++ b/src/_posts/2021/2021-10-19-original-photos-filename.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-10-19 19:11:45 +0000
 title: Programatically finding the original filename of a photo in the macOS Photos Library
 summary: If you're looking at a UUID'd file in the PhotosLibrary package, how do you find its original filename?
-tags: macos
+tags:
+  - macos
 colors:
   index_light: "#1582c6"
   index_dark:  "#8fcff4"

--- a/src/_posts/2021/2021-11-30-dominant-colours.md
+++ b/src/_posts/2021/2021-11-30-dominant-colours.md
@@ -3,7 +3,11 @@ layout: post
 date: 2021-11-30 09:30:01 +0000
 title: dominant_colours, a CLI tool for finding dominant colours in an image
 summary: A new tool for playing with images.
-tags: images colour rust fun-stuff
+tags:
+  - images
+  - colour
+  - rust
+  - fun-stuff
 colors:
   index_light: "#4576bb"
   index_dark:  "#88a7d3"

--- a/src/_posts/2021/2021-12-01-slashes.md
+++ b/src/_posts/2021/2021-12-01-slashes.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-12-01 14:33:14 +0000
 title: A tale of two path separators
 summary: macOS allows both the slash and colon as path separators, and this caused me no small amount of confusion.
-tags: macos path-problems
+tags:
+  - macos
+  - path-problems
 colors:
   index_light: "#1582c6"
   index_dark:  "#8fcff4"

--- a/src/_posts/2021/2021-12-10-rust-errors.md
+++ b/src/_posts/2021/2021-12-10-rust-errors.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-12-10 21:36:55 +0000
 title: The ever-improving error messages of Rust
 summary: An improvement to Rust's error handling that I almost reported, until I realised it was fixed.
-tags: rust error-messages
+tags:
+  - rust
+  - error-messages
 ---
 
 In [my last-but-one post]({% post_url 2021/2021-11-30-dominant-colours %}), I mentioned the quality of Rust's compiler errors.

--- a/src/_posts/2021/2021-12-24-os-sep.md
+++ b/src/_posts/2021/2021-12-24-os-sep.md
@@ -3,7 +3,9 @@ layout: post
 date: 2021-12-24 09:09:38 +0000
 title: Why is os.sep insufficient for path operations?
 summary: Digging into a throwaway comment in the Python documentation.
-tags: python path-problems
+tags:
+  - python
+  - path-problems
 colors:
   index_light: "#6E0E09"
   index_dark:  "#f1e7e6"

--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -3,7 +3,8 @@ layout: post
 date: 2021-12-31 11:52:34 +0000
 title: My favourite books from 2021
 summary: Aliens and aces, railroads and racism, dating and disasters – what I enjoyed reading this year.
-tags: books
+tags:
+  - books
 colors:
   css_light: "#464646"
   css_dark:  "#adadad"

--- a/src/_posts/2022/2022-01-07-rusty-shelves.md
+++ b/src/_posts/2022/2022-01-07-rusty-shelves.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-01-07 09:05:51 +0000
 title: Creating coloured bookshelf graphics in Rust
 summary: Explaining some code that draws coloured rectangles in a way that looks a bit like an upside-down bookshelf.
-tags: rust generative-art drawing-things
+tags:
+  - rust
+  - generative-art
+  - drawing-things
 ---
 
 In my [last post], I mentioned I have a mini-site where I track the books I've been reading ([books.alexwlchan.net]).

--- a/src/_posts/2022/2022-01-14-animated-artichokes.md
+++ b/src/_posts/2022/2022-01-14-animated-artichokes.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-01-14 10:58:15 +0000
 title: Creating animated GIFs from fruit and veg
 summary: Some Python code for turning MRI scans of fruit and veg into animated GIFs.
-tags: python drawing-things wellcome-collection
+tags:
+  - python
+  - drawing-things
+  - wellcome-collection
 colors:
   index_light: "#5c5a30"
   index_dark:  "#cdca78"

--- a/src/_posts/2022/2022-02-12-route53.md
+++ b/src/_posts/2022/2022-02-12-route53.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-02-12 17:27:21 +0000
 title: Why is Amazon Route 53 named that way?
 summary: Digging into the history of Route 53, DNS, and port number assignments.
-tags: aws amazon-route53
+tags:
+  - aws
+  - amazon-route53
 colors:
   css_light: "#4d27A8"
   css_dark:  "#955df4"

--- a/src/_posts/2022/2022-02-15-safari-tabs.md
+++ b/src/_posts/2022/2022-02-15-safari-tabs.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-02-15 20:54:35 +0000
 title: Closing lots of Safari tabs with JXA
 summary: To help me keep my tab count down, I wrote a JXA script to close tabs that can easily be recreated.
-tags: jxa macos:safari macos
+tags:
+  - jxa
+  - macos:safari
+  - macos
 ---
 
 I have a lot of browser tabs.

--- a/src/_posts/2022/2022-02-19-two-twitter-cards.md
+++ b/src/_posts/2022/2022-02-19-two-twitter-cards.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-02-19 12:45:19 +0000
 title: A tale of two Twitter cards
 summary: Some recent changes I've made to fix or improve my Twitter cards.
-tags: twitter blogging-about-blogging
+tags:
+  - twitter
+  - blogging-about-blogging
 colors:
   index_light: "#1d9bf0"
   index_dark:  "#77c8fe"

--- a/src/_posts/2022/2022-02-28-no-cause-for-alarm.md
+++ b/src/_posts/2022/2022-02-28-no-cause-for-alarm.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-02-28 10:23:14 +0000
 title: Beware delays in SQS metric delivery
 summary: A mysterious problem with SQS-based autoscaling and an over-eager CloudWatch Alarm.
-tags: aws amazon-cloudwatch amazon-sqs
+tags:
+  - aws
+  - amazon-cloudwatch
+  - amazon-sqs
 colors:
   index_light: "#B0084D"
   index_dark:  "#f75095"

--- a/src/_posts/2022/2022-04-02-checking-with-curl.md
+++ b/src/_posts/2022/2022-04-02-checking-with-curl.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-04-02 08:44:29 +0000
 title: Checking lots of URLs with curl
 summary: A bash script to check the HTTP status code of a bunch of URLs, for simple and portable uptime checking.
-tags: shell-scripting curl
+tags:
+  - shell-scripting
+  - curl
 
 colors:
   index_light: "#073551"

--- a/src/_posts/2022/2022-04-23-supposedly-simple-image-layout.md
+++ b/src/_posts/2022/2022-04-23-supposedly-simple-image-layout.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-04-23 23:03:46 +0000
 title: Creating a “simple” three-up image layout in CSS
 summary: A step-by-step breakdown of how I made a one-left, two-right layout for my images.
-tags: css css:grid web-development
+tags:
+  - css
+  - css:grid
+  - web-development
 colors:
   index_light: "#4b536e"
   index_dark:  "#a7a7af"

--- a/src/_posts/2022/2022-04-25-lorenz-wheels.md
+++ b/src/_posts/2022/2022-04-25-lorenz-wheels.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-04-25 21:10:40 +0000
 title: Illustrating the cipher wheels of a Lorenz machine
 summary: Some old code I wrote to draw cam-accurate illustrations of cipher wheels.
-tags: drawing-things latex history
+tags:
+  - drawing-things
+  - latex
+  - history
 link: https://github.com/alexwlchan/lorenz-wheels
 colors:
   index_light: "#423f3a"

--- a/src/_posts/2022/2022-05-05-rust-on-glitch.md
+++ b/src/_posts/2022/2022-05-05-rust-on-glitch.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-05-05 14:01:56 +0000
 title: Running a Rust binary in Glitch
 summary: Using different targets to build Rust binaries that will run in Glitch.
-tags: glitch rust
+tags:
+  - glitch
+  - rust
 
 colors:
   index_light: "#ff386a"

--- a/src/_posts/2022/2022-05-07-dominant-web-colours.md
+++ b/src/_posts/2022/2022-05-07-dominant-web-colours.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-05-07 19:28:31 +0000
 title: Find the dominant colours in an image in your web browser
 summary: Wrapping my CLI tool for finding dominant colours in a lightweight web app.
-tags: colour glitch fun-stuff
+tags:
+  - colour
+  - glitch
+  - fun-stuff
 link: https://dominant-colours.glitch.me/
 
 colors:

--- a/src/_posts/2022/2022-05-17-carbon-monoxide.md
+++ b/src/_posts/2022/2022-05-17-carbon-monoxide.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-05-17 07:25:05 +0000
 title: Changing my carbon monoxide detectors
 summary: Keeping my home safe from deadly gases.
-tags: domestic
+tags:
+  - domestic
 index:
   exclude: true
 ---

--- a/src/_posts/2022/2022-06-03-new-archive.md
+++ b/src/_posts/2022/2022-06-03-new-archive.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-06-03 12:29:46 +0000
 title: Redesigning my archive pages
 summary: Using coloured cards with images and descriptions to make it easier to find posts in my back catalogue.
-tags: blogging-about-blogging
+tags:
+  - blogging-about-blogging
 colors:
   index_light: "#22201f"
   index_dark:  "#fbfafa"

--- a/src/_posts/2022/2022-06-09-forgotten-secrets.md
+++ b/src/_posts/2022/2022-06-09-forgotten-secrets.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-06-09 06:40:48 +0000
 title: Experimenting with jq as a tool for filtering JSON
 summary: I wanted to learn jq's more powerful features, so I tried to filter some JSON from the AWS Secrets Manager CLI.
-tags: aws jq aws-secrets-manager
+tags:
+  - aws
+  - jq
+  - aws-secrets-manager
 colors:
   index_light: "#c5121f"
   index_dark:  "#ef5258"

--- a/src/_posts/2022/2022-06-26-alfred-to-github.md
+++ b/src/_posts/2022/2022-06-26-alfred-to-github.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-06-26 20:53:03 +0000
 title: Creating an Alfred Workflow to open GitHub repos
 summary: Automations for my automations.
-tags: alfred github
+tags:
+  - alfred
+  - github
 link: https://github.com/alexwlchan/github_alfred_shortcuts
 colors:
   index_light: "#1c1c1c"

--- a/src/_posts/2022/2022-06-26-imaginary-numbers.md
+++ b/src/_posts/2022/2022-06-26-imaginary-numbers.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-06-26 23:04:52 +0000
 title: Fictional phone numbers in *For All Mankind*
 summary: Where did this UK phone number come from?
-tags: trivia tv
+tags:
+  - trivia
+  - tv
 colors:
   css_light: "#7b650e"
   css_dark:  "#efb41f"

--- a/src/_posts/2022/2022-07-02-saturn-v.md
+++ b/src/_posts/2022/2022-07-02-saturn-v.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-07-02 10:17:46 +0000
 title: One small stitch for yarn, one giant leap for yarn-kind
 summary: I made a cross-stitch blueprint of the Apollo Moon lander and the Saturn V rocket.
-tags: cross-stitch space
+tags:
+  - cross-stitch
+  - space
 colors:
   css_light:   "#2045a2"
   css_dark:    "#6387e9"

--- a/src/_posts/2022/2022-07-10-martian-plaque.md
+++ b/src/_posts/2022/2022-07-10-martian-plaque.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-07-10 17:09:12 +0000
 title: A Martian plaque for a made-up plot
 summary: If NASA was the first to land on Mars in <em>For All Mankind</em>, what would the commemorative plaque look like?
-tags: trivia tv space
+tags:
+  - trivia
+  - tv
+  - space
 colors:
   css_light: "#495652"
   css_dark:  "#aab6b2"

--- a/src/_posts/2022/2022-07-23-screenshots.md
+++ b/src/_posts/2022/2022-07-23-screenshots.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-07-23 08:45:43 +0000
 title: You should take more screenshots
 summary: If you do any sort of creative digital work, screenshots and screen recordings are a great way to remember it.
-tags: digital-preservation screenshots
+tags:
+  - digital-preservation
+  - screenshots
 ---
 
 I've been using computers for about two decades.

--- a/src/_posts/2022/2022-08-01-screenshots-go-gangbusters.md
+++ b/src/_posts/2022/2022-08-01-screenshots-go-gangbusters.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-08-01 08:21:03 +0000
 title: A surprise smattering of stardom
 summary: My last post was surprisingly popular; a few reflections on the experience.
-tags: blogging-about-blogging
+tags:
+  - blogging-about-blogging
 colors:
   index_light: "#ff6602"
   index_dark:  "#fe6600"

--- a/src/_posts/2022/2022-08-03-no-cute.md
+++ b/src/_posts/2022/2022-08-03-no-cute.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-08-03 19:36:16 +0000
 title: Cut the cutesy errors
 summary: If your app has just ruined my day, I need help, not humour.
-tags: error-messages
+tags:
+  - error-messages
 ---
 
 I had to get a train ticket today, which is a two-step process.

--- a/src/_posts/2022/2022-08-07-spaaaaaace.md
+++ b/src/_posts/2022/2022-08-07-spaaaaaace.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-08-07 21:47:26 +0000
 title: Our Place in Space
 summary: You don’t realise how big the solar system is until you've walked the length of it.
-tags: photography science space
+tags:
+  - photography
+  - science
+  - space
 colors:
   index_light: "#af5418"
   index_dark:  "#d69f30"

--- a/src/_posts/2022/2022-08-08-buildkite-deployments.md
+++ b/src/_posts/2022/2022-08-08-buildkite-deployments.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-08-08 07:49:39 +0000
 title: How to customise the title of Buildkite builds triggered from GitHub deployments
 summary: Getting a more descriptive build label than 'Deployment'.
-tags: builds-and-ci buildkite
+tags:
+  - builds-and-ci
+  - buildkite
 ---
 
 At work, we use [Buildkite] for all our continuous testing and deployment, including the Wellcome Collection website.

--- a/src/_posts/2022/2022-08-10-circle-party.md
+++ b/src/_posts/2022/2022-08-10-circle-party.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-08-10 22:10:42 +0000
 title: Drawing a circular arc in an SVG
 summary: A Python function to help me draw circular arcs, as part of an upcoming project.
-tags: svg drawing-things
+tags:
+  - svg
+  - drawing-things
 ---
 
 For an upcoming project, I need to draw some circular arcs in an SVG.

--- a/src/_posts/2022/2022-08-16-egyptian-mixtape.md
+++ b/src/_posts/2022/2022-08-16-egyptian-mixtape.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-08-16 06:46:19 +0000
 title: An Egyptian 'mixtape' of embroidered material
 summary: Repeating geometric patterns make for a colourful and eye-catching piece.
-tags: cross-stitch
+tags:
+  - cross-stitch
 colors:
   css_light: "#88632e"
   css_dark:  "#b38d42"

--- a/src/_posts/2022/2022-08-18-strict-jinja.md
+++ b/src/_posts/2022/2022-08-18-strict-jinja.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-08-18 07:22:44 +0000
 title: I always want StrictUndefined in Jinja
 summary: When I'm writing templates with Jinja, strict behaviour is what I want, even if it's not the default.
-tags: python python:jinja
+tags:
+  - python
+  - python:jinja
 colors:
   index_light: "#470906"
   index_dark:  "#FF4242"

--- a/src/_posts/2022/2022-08-28-blink-diffs.md
+++ b/src/_posts/2022/2022-08-28-blink-diffs.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-08-28 16:49:37 +0000
 title: Getting blink diffs for photos on the iPad
 summary: The Darkroom app lets me instantly switch between photos, which is how I compare and review shots.
-tags: photography ios ipad
+tags:
+  - photography
+  - ios
+  - ipad
 index:
   exclude: true
 ---

--- a/src/_posts/2022/2022-09-10-nextjs-props.md
+++ b/src/_posts/2022/2022-09-10-nextjs-props.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-09-10 17:04:31 +0000
 title: Finding redundant data in our Next.js props
 summary: A script that helps us optimise our __NEXT_DATA__, which in turn helps reduce page size.
-tags: javascript javascript:next.js web-development
+tags:
+  - javascript
+  - javascript:next.js
+  - web-development
 colors:
   index_light: "#AE160E"
   index_dark:  "#f15850"

--- a/src/_posts/2022/2022-09-13-graph-generative-art.md
+++ b/src/_posts/2022/2022-09-13-graph-generative-art.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-09-13 18:31:40 +0000
 title: Generating art from lattice graphs
 summary: Randomly selecting a subset of edge from a graph can make pretty pictures.
-tags: generative-art drawing-things
+tags:
+  - generative-art
+  - drawing-things
 ---
 
 <style>

--- a/src/_posts/2022/2022-09-22-maths-cross-stitch.md
+++ b/src/_posts/2022/2022-09-22-maths-cross-stitch.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-09-22 21:32:14 +0000
 title: The maths cross-stitch that hangs behind me
 summary: When I’m on video calls, my backdrop has some maths-related art that I helped to make.
-tags: cross-stitch maths
+tags:
+  - cross-stitch
+  - maths
 colors:
   css_light: "#742a0c"
   css_dark:  "#b7834f"

--- a/src/_posts/2022/2022-09-23-moomin-mathematics.md
+++ b/src/_posts/2022/2022-09-23-moomin-mathematics.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-09-23 05:42:28 +0000
 title: '"Fixing" the rules of division'
 summary: If we want to redefine how division works, Ruby is happy to oblige.
-tags: maths ruby code-crimes
+tags:
+  - maths
+  - ruby
+  - code-crimes
 colors:
   css_light:   "#292929"
   css_dark:    "#b0b0b0"

--- a/src/_posts/2022/2022-09-25-rust-1-64.md
+++ b/src/_posts/2022/2022-09-25-rust-1-64.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-09-25 10:55:25 +0000
 title: My (tiny) contribution to Rust 1.64
 summary: A suggestion for a better error message to help people who work in multiple languages.
-tags: rust error-messages
+tags:
+  - rust
+  - error-messages
 colors:
   index_light: "#a15630"
   index_dark:  "#d67643"

--- a/src/_posts/2022/2022-10-05-circle-experiments.md
+++ b/src/_posts/2022/2022-10-05-circle-experiments.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-10-05 22:35:11 +0000
 title: Some experiments with circle-based art
 summary: Casually covering a canvas with coloured circles.
-tags: python:pillow drawing-things generative-art
+tags:
+  - python:pillow
+  - drawing-things
+  - generative-art
 colors:
   index_light: "#ae0000"
   index_dark:  "#ea0000"

--- a/src/_posts/2022/2022-10-05-snapped-elastic.md
+++ b/src/_posts/2022/2022-10-05-snapped-elastic.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-10-05 07:50:53 +0000
 title: Finding a tricky bug in Elasticsearch 8.4.2
 summary: Gradually deleting more and more data helped me get a reliable repro for an elusive bug.
-tags: debugging-stories
+tags:
+  - debugging-stories
 colors:
   index_light: "#52a89f"
   index_dark:  "#4fd6ca"

--- a/src/_posts/2022/2022-10-10-library-lookup.md
+++ b/src/_posts/2022/2022-10-10-library-lookup.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-10-10 19:47:42 +0000
 title: Finding books in nearby library branches
 summary: Some web scraping and Python helps me find books that I can borrow immediately.
-tags: books libraries
+tags:
+  - books
+  - libraries
 colors:
   index_light: "#527345"
   index_dark:  "#97b18a"

--- a/src/_posts/2022/2022-10-25-iterative-project-management.md
+++ b/src/_posts/2022/2022-10-25-iterative-project-management.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-10-25 08:07:13 +0000
 title: Agile and iterative project management
 summary: Notes from a talk about agile and iterative approaches to project management.
-tags: talks open-life-science project-management
+tags:
+  - talks
+  - open-life-science
+  - project-management
 colors:
   css_light: "#20883f"
   css_dark:  "#2fc65d"

--- a/src/_posts/2022/2022-10-26-accessibility-fixes.md
+++ b/src/_posts/2022/2022-10-26-accessibility-fixes.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-10-26 18:58:54 +0000
 title: Some small accessibility fixes
 summary: Making the sites I work on sound a bit nicer for anyone who relies on screen readers.
-tags: accessibility blogging-about-blogging
+tags:
+  - accessibility
+  - blogging-about-blogging
 colors:
   css_light: "#075ba3"
   css_dark:  "#198ff5"

--- a/src/_posts/2022/2022-11-04-obsidian-plugin.md
+++ b/src/_posts/2022/2022-11-04-obsidian-plugin.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-11-04 22:27:35 +0000
 title: A simple gallery plugin for Obsidian
 summary: Making it easier to find all the images in my Obsidian vault.
-tags: obsidian javascript
+tags:
+  - obsidian
+  - javascript
 link: https://github.com/alexwlchan/obsidian-simple-gallery
 colors:
   index_light: "#121212"

--- a/src/_posts/2022/2022-11-06-tweet-alt-text.md
+++ b/src/_posts/2022/2022-11-06-tweet-alt-text.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-11-06 10:39:42 +0000
 title: Saving your alt text from Twitter
 summary: Twitter's archives don't include the alt text you wrote on images, but you can save a copy with their API.
-tags: twitter digital-preservation accessibility
+tags:
+  - twitter
+  - digital-preservation
+  - accessibility
 colors:
   index_light: "#235f88"
   index_dark:  "#5298c7"

--- a/src/_posts/2022/2022-11-12-tin-anniversary.md
+++ b/src/_posts/2022/2022-11-12-tin-anniversary.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-11-12 07:13:02 +0000
 title: Ten years of blogging
 summary: A decade ago, I registered a domain and started writing.
-tags: blogging-about-blogging
+tags:
+  - blogging-about-blogging
 colors:
   index_light: "#50833a"
   index_dark:  "#7bc05d"

--- a/src/_posts/2022/2022-11-17-changing-the-macos-accent-colour.md
+++ b/src/_posts/2022/2022-11-17-changing-the-macos-accent-colour.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-11-17 22:38:39 +0000
 title: Changing the macOS accent colour without System Preferences
 summary: Updating the accent colour everywhere, with immediate effect, using a script written in Swift.
-tags: macos swift colour
+tags:
+  - macos
+  - swift
+  - colour
 ---
 
 In System Preferences, you can change the accent colour of your Mac:

--- a/src/_posts/2022/2022-11-28-bure-valley.md
+++ b/src/_posts/2022/2022-11-28-bure-valley.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-11-28 19:57:52 +0000
 title: A day out at the Bure Valley Railway
 summary: My photos from a delightful day on a steam railway with smol trains.
-tags: photography trains
+tags:
+  - photography
+  - trains
 colors:
   css_light: "#101c75"
   css_dark:  "#238fd1"

--- a/src/_posts/2022/2022-11-29-koa-logger-redactions.md
+++ b/src/_posts/2022/2022-11-29-koa-logger-redactions.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-11-29 23:39:11 +0000
 title: Redacting sensitive query parameters with koa and koa-logger
 summary: Using a custom transporter to modify the log message and remove secret information.
-tags: javascript javascript:koa
+tags:
+  - javascript
+  - javascript:koa
 colors:
   index_light: "#054f17"
   index_dark:  "#08af2f"

--- a/src/_posts/2022/2022-12-04-print-sbt.md
+++ b/src/_posts/2022/2022-12-04-print-sbt.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-12-04 01:16:55 +0000
 title: Getting the base directory of an sbt project
 summary: Some notes on printing sbt settings, so you can use them as the input to another script.
-tags: scala scala:sbt
+tags:
+  - scala
+  - scala:sbt
 colors:
   index_light: "#0e20f0"
   index_dark:  "#4681f6"

--- a/src/_posts/2022/2022-12-16-marquee-rocket.md
+++ b/src/_posts/2022/2022-12-16-marquee-rocket.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-12-16 10:01:11 +0000
 title: Launching a rocket in the worst possible way
 summary: Taking the humble &lt;marquee&gt; tag where no HTML tag has gone before.
-tags: code-crimes html fun-stuff
+tags:
+  - code-crimes
+  - html
+  - fun-stuff
 colors:
   index_light: "#ba4220"
   index_dark:  "#eb7028"

--- a/src/_posts/2022/2022-12-20-prismic-validation.md
+++ b/src/_posts/2022/2022-12-20-prismic-validation.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-12-20 08:31:16 +0000
 title: How we do bulk analysis of our Prismic content
 summary: By downloading all our Prismic documents, we can run validation rules, fix broken links, and find interesting examples.
-tags: prismic
+tags:
+  - prismic
 colors:
   index_light: "#1d1d25"
   index_dark:  "#a1a1b5"

--- a/src/_posts/2022/2022-12-21-cursor-confirmed.md
+++ b/src/_posts/2022/2022-12-21-cursor-confirmed.md
@@ -3,7 +3,10 @@ layout: post
 date: 2022-12-21 20:33:41 +0000
 title: Getting an Important Internet Checkmark to follow your cursor
 summary: Party like it's 1996! A trailing checkmark cursor will make your Brand Website feel fun and authentic.
-tags: fun-stuff code-crimes javascript
+tags:
+  - fun-stuff
+  - code-crimes
+  - javascript
 colors:
   css_light: "#0e558b"
   css_dark:  "#55acee"

--- a/src/_posts/2022/2022-12-31-2022-in-reading.md
+++ b/src/_posts/2022/2022-12-31-2022-in-reading.md
@@ -3,7 +3,8 @@ layout: post
 date: 2022-12-31 18:47:55 +0000
 title: My favourite books from 2022
 summary: Romance and rust, gender and grief, horror and the House – what I enjoyed reading this year.
-tags: books
+tags:
+  - books
 colors:
   css_light: "#464646"
   css_dark:  "#adadad"

--- a/src/_posts/2022/2022-12-31-live-text-script.md
+++ b/src/_posts/2022/2022-12-31-live-text-script.md
@@ -3,7 +3,9 @@ layout: post
 date: 2022-12-31 12:42:13 +0000
 title: A script to get Live Text from images
 summary: Using Apple's built-in tools to get OCR text from an image, but without going through a GUI.
-tags: images swift
+tags:
+  - images
+  - swift
 ---
 
 One of my favourite new features on Apple's OSes in the last few years is Live Text, which is an [optical character recognition][ocr] tool that lets you select text in images.

--- a/src/_posts/2023/2023-01-13-upward-assignment.md
+++ b/src/_posts/2023/2023-01-13-upward-assignment.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-01-13 15:23:18 +0000
 title: Upward assignment in Ruby
 summary: A deep dive into the internals of Ruby and metaprogramming techniques, in a quest for a cursed operator.
-tags: ruby code-crimes
+tags:
+  - ruby
+  - code-crimes
 colors:
   css_light: "#c62229"
   css_dark:  "#dd363f"

--- a/src/_posts/2023/2023-01-15-check-for-transparency.md
+++ b/src/_posts/2023/2023-01-15-check-for-transparency.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-01-15 21:46:18 +0000
 title: Beware of transparent backgrounds when using AVIF with ImageMagick 6
 summary: You probably want to use version 7.
-tags: blogging-about-blogging images imagemagick
+tags:
+  - blogging-about-blogging
+  - images
+  - imagemagick
 colors:
   css_light: "#333333"
   css_dark:  "#cccccc"

--- a/src/_posts/2023/2023-01-22-changing-the-bulb-in-a-meridian-lighting-cir100b-ceiling-light.md
+++ b/src/_posts/2023/2023-01-22-changing-the-bulb-in-a-meridian-lighting-cir100b-ceiling-light.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-01-22 21:22:16 +0000
 title: Changing the bulb in a Meridian Lighting CIR100B ceiling light
 summary: A note to my future self. Also, reverse image search is amazing.
-tags: home
+tags:
+  - home
 ---
 
 I moved into my house a couple of years ago, and for all that time I've had a porch light which doesn't work.

--- a/src/_posts/2023/2023-01-28-responsive-image-bookmarklet.md
+++ b/src/_posts/2023/2023-01-28-responsive-image-bookmarklet.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-01-28 10:30:50 +0000
 title: A bookmarklet to show which responsive image was chosen
 summary: "Debugging my &lt;picture> and &lt;source> tags."
-tags: blogging-about-blogging images web-development
+tags:
+  - blogging-about-blogging
+  - images
+  - web-development
 ---
 
 I've had a lot of fun fiddling with the images on this blog recently, and I think they're better than when I started.

--- a/src/_posts/2023/2023-02-12-moving-to-the-cloud.md
+++ b/src/_posts/2023/2023-02-12-moving-to-the-cloud.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-02-12 08:29:24 +0000
 title: How moving to the cloud took our digital collections to new heights
 summary: Building our own platform allowed us to make decisions based on what’s best for the collections, and not the limitations of our digital infrastructure.
-tags: wellcome-collection digital-preservation
+tags:
+  - wellcome-collection
+  - digital-preservation
 link: https://stacks.wellcomecollection.org/how-moving-to-the-cloud-took-our-digital-collections-to-new-heights-2dc5a896f0be
 
 colors:

--- a/src/_posts/2023/2023-02-13-s3-bucket-inventory.md
+++ b/src/_posts/2023/2023-02-13-s3-bucket-inventory.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-02-13 07:28:36 +0000
 title: A Python function to iterate through an S3 Bucket Inventory
 summary: Getting something that looks more like the output of the ListObjectsV2 API.
-tags: amazon-s3 python aws
+tags:
+  - amazon-s3
+  - python
+  - aws
 colors:
   index_light: "#117A06"
   index_dark:  "#4cdf0a"

--- a/src/_posts/2023/2023-02-15-school-stuff.md
+++ b/src/_posts/2023/2023-02-15-school-stuff.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-02-15 07:37:34 +0000
 title: Going through my old school papers
 summary: Digitising and pruning my boxes of paper from school. In which I have nostalgia, sadness, and the sense that everything old is new again.
-tags: personal digital-preservation
+tags:
+  - personal
+  - digital-preservation
 ---
 
 I left school in 2011, and I graduated from university in 2014.

--- a/src/_posts/2023/2023-02-16-css-formatting-in-the-console.md
+++ b/src/_posts/2023/2023-02-16-css-formatting-in-the-console.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-02-16 10:58:09 +0000
 title: CSS formatting in the console
 summary: Did you know you can use `%c` to format your `console.log` messages?
-tags: web-development javascript
+tags:
+  - web-development
+  - javascript
 ---
 
 I was poking around in Google Lens recently (which is Google's magical [reverse image lookup service][bulb]) and I was mildly surprised by what I saw in the developer tools console:

--- a/src/_posts/2023/2023-02-20-testing-javascript-without-a-framework.md
+++ b/src/_posts/2023/2023-02-20-testing-javascript-without-a-framework.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-02-20 08:28:16 +0000
 title: Testing JavaScript without a (third-party) framework
 summary: The browser can be a pretty good place to run your JavaScript tests.
-tags: javascript web-development
+tags:
+  - javascript
+  - web-development
 ---
 
 Last week Julia Evans posted [Writing Javascript without a build system], and it resonated with my own experience.

--- a/src/_posts/2023/2023-03-02-balancing-act.md
+++ b/src/_posts/2023/2023-03-02-balancing-act.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-03-02 14:03:08 +0000
 title: Splitting a class into balanced groups
 summary: How do you make sure everyone gets to work with everyone else?
-tags: combinatorics python
+tags:
+  - combinatorics
+  - python
 colors:
   index_light: "#8c3526"
   index_dark:  "#d7a59d"

--- a/src/_posts/2023/2023-03-02-dictionaries-and-userdict.md
+++ b/src/_posts/2023/2023-03-02-dictionaries-and-userdict.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-03-02 15:51:47 +0000
 title: Creating a Python dictionary with multiple, equivalent keys
 summary: Using collections.UserDict, we can create a dictionary where dict[key1] and dict[key2] always point to the same value.
-tags: python
+tags:
+  - python
 colors:
   index_light: "#035e96"
   index_dark:  "#6fd0fd"

--- a/src/_posts/2023/2023-03-05-filtering-netlify-analytics.md
+++ b/src/_posts/2023/2023-03-05-filtering-netlify-analytics.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-03-05 12:33:07 +0000
 title: Filtering out bogus requests from Netlify Analytics
 summary: Using redirects to filter out bots trying to hack my non-existent PHP installation.
-tags: blogging-about-blogging netlify
+tags:
+  - blogging-about-blogging
+  - netlify
 colors:
   index_light: "#73714B"
   index_dark:  "#c9ba8d"

--- a/src/_posts/2023/2023-03-13-cats-cross-stitch-and-copyright.md
+++ b/src/_posts/2023/2023-03-13-cats-cross-stitch-and-copyright.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-03-13 13:24:57 +0000
 title: Cats, cross-stitch, and copyright
 summary: In celebration of my favourite apex predator.
-tags: cross-stitch
+tags:
+  - cross-stitch
 colors:
   index_light: "#7c590f"
   index_dark:  "#debd4d"

--- a/src/_posts/2023/2023-04-11-working-with-jq-and-tags-in-the-aws-cli.md
+++ b/src/_posts/2023/2023-04-11-working-with-jq-and-tags-in-the-aws-cli.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-04-11 21:04:12 +0000
 title: Filtering AWS CLI output by tags using jq
 summary: Using `from_entries` is a nicer way to deal with the list of Name/Value pairs returned by the AWS CLI.
-tags: jq
+tags:
+  - jq
 colors:
   index_dark:  "#d4d1c0"
   index_light: "#46362e"

--- a/src/_posts/2023/2023-04-16-my-sns-firehose.md
+++ b/src/_posts/2023/2023-04-16-my-sns-firehose.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-04-16 18:37:04 +0000
 title: Publishing lots and lots of messages to SNS
 summary: Careful use of the `PublishBatch` API makes it quick and easy for me to send thousands of messages into SNS.
-tags: aws amazon-sns
+tags:
+  - aws
+  - amazon-sns
 colors:
   index_light: "#B0084D"
   index_dark:  "#FF4F8B"

--- a/src/_posts/2023/2023-04-21-terraform-template-docs.md
+++ b/src/_posts/2023/2023-04-21-terraform-template-docs.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-04-21 15:40:25 +0000
 title: Using templates in Terraform to document a deployment
 summary: Terraform can fill in placeholders with exact values from your deployment, for easy copy/paste instructions.
-tags: terraform documentation
+tags:
+  - terraform
+  - documentation
 colors:
   index_light: "#7B42BC"
   index_dark:  "#af75fa"

--- a/src/_posts/2023/2023-04-25-erratic-ecs-events.md
+++ b/src/_posts/2023/2023-04-25-erratic-ecs-events.md
@@ -4,7 +4,10 @@ date: 2023-04-25 13:40:02 +0000
 title: Getting alerts about flaky ECS tasks in Slack
 summary: |
   When ECS is "unable to consistently start tasks successfully", we get a Slack alert that tells us to investigate.
-tags: amazon-ecs aws slack
+tags:
+  - amazon-ecs
+  - aws
+  - slack
 colors:
   index_light: "#b24c0e"
   index_dark:  "#e7862a"

--- a/src/_posts/2023/2023-05-11-redecorating-my-bedroom.md
+++ b/src/_posts/2023/2023-05-11-redecorating-my-bedroom.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-05-11 20:21:18 +0000
 title: Redecorating my bedroom
 summary: Splashing some sunshine in the space where I sleep.
-tags: home domestic
+tags:
+  - home
+  - domestic
 colors:
   css_light:   "#815701"
   index_light: "#815701"

--- a/src/_posts/2023/2023-05-17-s3tree.md
+++ b/src/_posts/2023/2023-05-17-s3tree.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-05-17 17:20:28 +0000
 title: "s3tree: viewing a tree of objects in S3 in my terminal"
 summary: A script to give me a quick overview of some objects in a hierarchical view.
-tags: amazon-s3 aws drawing-things
+tags:
+  - amazon-s3
+  - aws
+  - drawing-things
 link: https://github.com/alexwlchan/scripts/blob/main/aws/s3tree.py
 colors:
   index_light: "#005400"

--- a/src/_posts/2023/2023-05-25-managing-albums-in-photos.md
+++ b/src/_posts/2023/2023-05-25-managing-albums-in-photos.md
@@ -3,7 +3,11 @@ layout: post
 date: 2023-05-25 21:02:22 +0000
 title: Snippets to manage albums in Photos.app
 summary: AppleScript only allows us to add photos to an album; dipping into Swift and PhotoKit lets us both add and remove photos.
-tags: photography applescript swift macos
+tags:
+  - photography
+  - applescript
+  - swift
+  - macos
 colors:
   index_light: "#4f4f4f"
   index_dark:  "#9da3a8"

--- a/src/_posts/2023/2023-05-30-docker-on-demand.md
+++ b/src/_posts/2023/2023-05-30-docker-on-demand.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-05-30 19:41:48 +0000
 title: Starting Docker just before I need it
 summary: I don’t keep Docker running all the time, but intercepting the `docker` command means it’s always running when I need it.
-tags: docker shell-scripting
+tags:
+  - docker
+  - shell-scripting
 colors:
   index_light: "#3a5781"
   index_dark:  "#cfe7f7"

--- a/src/_posts/2023/2023-06-05-now.md
+++ b/src/_posts/2023/2023-06-05-now.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-06-04 21:46:48 +0000
 title: Have a single definition of “now”
 summary: Having one function that you always use to get the current time is super handy when debugging issues that only occur at specific times.
-tags: datetime-shenanigans
+tags:
+  - datetime-shenanigans
 colors:
   index_light: "#940106"
   index_dark:  "#f8ecea"

--- a/src/_posts/2023/2023-06-18-blink.md
+++ b/src/_posts/2023/2023-06-18-blink.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-06-18 10:19:04 +0000
 title: Writing a Mac app to review my photos
 summary: Dipping my toes into SwiftUI to make a tool for reviewing my photos with just the keyboard.
-tags: photo-management swift swift/swiftui
+tags:
+  - photo-management
+  - swift
+  - swift/swiftui
 colors:
   css_light: "#3e8036"
   css_dark:  "#70e662"

--- a/src/_posts/2023/2023-06-28-preserved-dates.md
+++ b/src/_posts/2023/2023-06-28-preserved-dates.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-06-28 16:38:25 +0000
 title: Preserving Dates during JSON serialisation with vanilla JS
 summary: How to make sure you get a `Date` back when you call `JSON.parse` and `JSON.stringify`.
-tags: javascript datetime-shenanigans
+tags:
+  - javascript
+  - datetime-shenanigans
 colors:
   css_light: "#662c29"
   css_dark:  "#bda9a1"

--- a/src/_posts/2023/2023-07-03-bedtime-for-ecs.md
+++ b/src/_posts/2023/2023-07-03-bedtime-for-ecs.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-07-03 13:43:19 +0000
 title: Turning off ECS tasks overnight using an EventBridge Schedule
 summary: Calling the UpdateService API on a fixed schedule allows us to turn services off in the evening, and back on again the next morning.
-tags: amazon-ecs amazon-eventbridge
+tags:
+  - amazon-ecs
+  - amazon-eventbridge
 colors:
   css_light: "#9a255e"
   css_dark:  "#ff3d9c"

--- a/src/_posts/2023/2023-07-08-spy-for-spy.md
+++ b/src/_posts/2023/2023-07-08-spy-for-spy.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-07-08 06:35:17 +0000
 title: "*Spy for Spy*"
 summary: A two-handed sapphic romance with a clever narrative twist makes for a compelling and thoughtful new play.
-tags: theatre london
+tags:
+  - theatre
+  - london
 colors:
   index_light: "#214781"
   index_dark:  "#86a4c2"

--- a/src/_posts/2023/2023-07-15-picture-plugin.md
+++ b/src/_posts/2023/2023-07-15-picture-plugin.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-07-15 06:46:12 +0000
 title: "My custom &lt;picture&gt; plugin for Jekyll"
 summary: How I make images that load quickly and look good for readers, and which are easy for me to manage.
-tags: web-development jekyll blogging-about-blogging
+tags:
+  - web-development
+  - jekyll
+  - blogging-about-blogging
 colors:
   css_light: "#df1b4a"
   css_dark:  "#fd96af"

--- a/src/_posts/2023/2023-07-26-snake-walker.md
+++ b/src/_posts/2023/2023-07-26-snake-walker.md
@@ -3,7 +3,8 @@ layout: post
 date: 2023-07-26 16:07:14 +0000
 title: My Python snippet for walking a file tree
 summary: A function to find all the files in a directory is one of my most-used snippets.
-tags: python
+tags:
+  - python
 colors:
   index_dark:  "#7e9327"
   index_light: "#4f5f10"

--- a/src/_posts/2023/2023-07-28-cloudfront-logs.md
+++ b/src/_posts/2023/2023-07-28-cloudfront-logs.md
@@ -3,7 +3,10 @@ layout: post
 date: 2023-07-28 05:13:02 +0000
 title: Parsing CloudFront logs with Python
 summary: A couple of functions I use to get access to CloudFront logs as easy-to-use iterators.
-tags: python aws amazon-cloudfront
+tags:
+  - python
+  - aws
+  - amazon-cloudfront
 colors:
   css_light: "#673ABB"
   css_dark:  "#C9ABFF"

--- a/src/_posts/2023/2023-08-18-tag-iac-resources.md
+++ b/src/_posts/2023/2023-08-18-tag-iac-resources.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-08-18 08:04:30 +0000
 title: Tag your infrastructure-as-code resources with a link to their definitions
 summary: Applying a default tag that points to the IaC definition makes it easy to go from the console to the code.
-tags: aws terraform
+tags:
+  - aws
+  - terraform
 colors:
   index_light: "#016d01"
   index_dark:  "#88a284"

--- a/src/_posts/2023/2023-08-19-hester.md
+++ b/src/_posts/2023/2023-08-19-hester.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-08-19 07:14:31 +0000
 title: A blue plaque for Hester
 summary: Making a small memorial to a forgotten secretary who helped pull off one of the most daring deceptions of WWII.
-tags: theatre cross-stitch
+tags:
+  - theatre
+  - cross-stitch
 colors:
   css_light:   "#2045a2"
   css_dark:    "#6387e9"

--- a/src/_posts/2023/2023-08-26-iam-keys.md
+++ b/src/_posts/2023/2023-08-26-iam-keys.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-08-26 09:22:23 +0000
 title: Finding a mystery IAM access key
 summary: Using the GetAccessKeyInfo and GetAccessKeyLastUsed APIs can help us trace an IAM key back to its source.
-tags: aws aws-iam
+tags:
+  - aws
+  - aws-iam
 colors:
   index_light: "#6f4e34"
   index_dark:  "#b3d775"

--- a/src/_posts/2023/2023-09-19-obsidian-setup.md
+++ b/src/_posts/2023/2023-09-19-obsidian-setup.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-09-19 21:30:59 +0000
 title: How I set up my Obsidian vaults
 summary: The tags, folders, and themes I use to manage information in my Obsidian vaults.
-tags: obsidian taking-notes
+tags:
+  - obsidian
+  - taking-notes
 ---
 
 {% comment %}
@@ -120,6 +122,9 @@ This might seem messy to some people, but it works for me – even if a tag is o
 
 I use prefixes as a way to namespace some of tags, like `aws/amazon-s3` and `python/pip`.
 This helps keep my list of tags somewhat organised, but otherwise it’s a bit of an inconsistent mess.
+e.g. I don't have any rules about singular vs plural
+
+I have different tags in each of my vaults, but I try to use the same tag in both places if it means the same thing.
 
 [tagging]: https://alexwlchan.net/2019/my-scanning-setup/#how-should-i-organise-my-files
 [search_engine]: https://idlewords.com/talks/fan_is_a_tool_using_animal.htm

--- a/src/_posts/2023/2023-09-20-fare-wellcome-collection.md
+++ b/src/_posts/2023/2023-09-20-fare-wellcome-collection.md
@@ -3,7 +3,9 @@ layout: post
 date: 2023-09-20 07:12:54 +0000
 title: Fare-Wellcome Collection
 summary: After nearly seven years, it's time for something new.
-tags: personal wellcome-collection
+tags:
+  - personal
+  - wellcome-collection
 ---
 I still remember the first time I visited Wellcome Collection -- just over seven years ago.
 I was living and working in the Cambridge at the time, and I'd come into London for the day to hang out with a friend who lived near King's Cross.


### PR DESCRIPTION
Jekyll will do the right thing with a space-delimited list, but this is the syntax I think of when I imagine lists in YAML, and it's how I do it on books.alexwlchan.net -- this makes the two sites more consistent.