### PR TITLE
Use the <time> element for timestamps on posts

### DIFF
--- a/src/_layouts/post.html
+++ b/src/_layouts/post.html
@@ -30,7 +30,9 @@ layout: default
       <li class="post__date">
         Posted
         {% if post.title == "Taking tuple unpacking to terrible places" %}Truesday{% endif %}
-        {{ post.date | date: site.date_format }}
+        <time datetime="{{ post.date | date: "%Y-%m-%d" }}">
+          {{- post.date | date: site.date_format -}}
+        </time>
       </li>
       {% if post.date_updated %}
       <li class="post__updated_date">Updated {{ post.date_updated | date: site.date_format }}</li>


### PR DESCRIPTION
According to the MDN documentation, the "24 September 2023" format I'm using as the child text content isn't a valid date format (all the valid formats are numeric, so maybe it's to do with internationalisation?).

I suspect search engines already know how to parse this, but it seems semantically nice to provide the date in a machine-readable format here.

Closes #696.