### PR TITLE
Tidy up the HTML in my end of year book posts

### DIFF
--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -62,24 +62,22 @@ I'd recommend any of them.
 ---
 
 <div class="book_review" id="becky_chambers">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="the-galaxy-and-the-ground-within.jpg"
-        alt="The cover of “The Galaxy, and the Ground Within”. White serif text with the title and the author's name on top of a purple-tinged view of space."
-        width="91"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="The Galaxy, and the Ground Within"
-      author="Becky Chambers"
-      review_url="https://books.alexwlchan.net/reviews/the-galaxy-and-the-ground-within/"
-      review_date="17 April 2021"
-      publication_year="2021"
+      picture
+      filename="the-galaxy-and-the-ground-within.jpg"
+      alt="The cover of “The Galaxy, and the Ground Within”. White serif text with the title and the author's name on top of a purple-tinged view of space."
+      width="91"
     %}
   </div>
+  {%
+    include book_info.html
+    title="The Galaxy, and the Ground Within"
+    author="Becky Chambers"
+    review_url="https://books.alexwlchan.net/reviews/the-galaxy-and-the-ground-within/"
+    review_date="17 April 2021"
+    publication_year="2021"
+  %}
 </div>
 
 The residents of a space hotel have to make friends after an external crisis means they're stuck inside (sound familiar?).
@@ -92,24 +90,22 @@ There are almost no humans in the book, and they’re treated as a bit of a curi
 It's the final entry in the *Wayfarers* series of space operas, which I adore.
 
 <div class="book_review" id="alice_oseman">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="loveless.jpg"
-        alt="The cover of “Loveless”. It’s a purpley-pink background with a black-and-white drawing of a girl texting on her phone. A series of small hearts are drifting upwards out of the phone. The title and author’s name are written in a handwriting-like font at the bottom of the cover."
-        width="90"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Loveless"
-      author="Alice Oseman"
-      review_url="https://books.alexwlchan.net/reviews/loveless/"
-      review_date="14 June 2021"
-      publication_year="2018"
+      picture
+      filename="loveless.jpg"
+      alt="The cover of “Loveless”. It’s a purpley-pink background with a black-and-white drawing of a girl texting on her phone. A series of small hearts are drifting upwards out of the phone. The title and author’s name are written in a handwriting-like font at the bottom of the cover."
+      width="90"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Loveless"
+    author="Alice Oseman"
+    review_url="https://books.alexwlchan.net/reviews/loveless/"
+    review_date="14 June 2021"
+    publication_year="2018"
+  %}
 </div>
 
 This is a tale of self-discovery and acceptance.
@@ -122,24 +118,22 @@ I only wish I'd been able to read something like this when I was at that age.
 [aromantic]: https://en.wikipedia.org/wiki/Romantic_orientation#Aromanticism
 
 <div class="book_review" id="colson_whitehead">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="the-underground-railroad.jpg"
-        alt="The cover of “The Underground Railroad”. It’s made up of three drawings: a woman looking into the distance, a woman embracing a taller man, and a figure shrouded by darkness holding a lantern."
-        width="93"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="The Underground Railroad"
-      author="Colson Whitehead"
-      review_url="https://books.alexwlchan.net/reviews/the-underground-railroad/"
-      review_date="21 June 2021"
-      publication_year="2018"
+      picture
+      filename="the-underground-railroad.jpg"
+      alt="The cover of “The Underground Railroad”. It’s made up of three drawings: a woman looking into the distance, a woman embracing a taller man, and a figure shrouded by darkness holding a lantern."
+      width="93"
     %}
   </div>
+  {%
+    include book_info.html
+    title="The Underground Railroad"
+    author="Colson Whitehead"
+    review_url="https://books.alexwlchan.net/reviews/the-underground-railroad/"
+    review_date="21 June 2021"
+    publication_year="2018"
+  %}
 </div>
 
 This is an alt history novel about the American slave trade which reimagines the so-called "underground railroad" of [secret routes and safe houses] as a literal railroad.
@@ -153,24 +147,22 @@ It’s not the most pleasant book, but I’m glad I read it.
 [secret routes and safe houses]: https://en.wikipedia.org/wiki/Underground_Railroad
 
 <div class="book_review" id="garrett_graff">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="the-only-plane-in-the-sky.jpg"
-        alt="The cover of “The Only Plane in the Sky”, with the subtitle “An Oral History of 9/11”. The cover is plain black with the title in gold lettering, and the author's name in small white lettering."
-        width="92"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="The Only Plane in the Sky"
-      author="Garrett M. Graff"
-      review_url="https://books.alexwlchan.net/reviews/the-only-plane-in-the-sky/"
-      review_date="25 June 2021"
-      publication_year="2019"
+      picture
+      filename="the-only-plane-in-the-sky.jpg"
+      alt="The cover of “The Only Plane in the Sky”, with the subtitle “An Oral History of 9/11”. The cover is plain black with the title in gold lettering, and the author's name in small white lettering."
+      width="92"
     %}
   </div>
+  {%
+    include book_info.html
+    title="The Only Plane in the Sky"
+    author="Garrett M. Graff"
+    review_url="https://books.alexwlchan.net/reviews/the-only-plane-in-the-sky/"
+    review_date="25 June 2021"
+    publication_year="2019"
+  %}
 </div>
 
 I don't have strong memories of 9/11 because I was quite young when it happened, and this book helped me understand why it left such an impact.
@@ -179,24 +171,22 @@ It's a collection of quotes from different people, carefully combined into a sin
 The audiobook has a cast of actors interspersed with real audio, and I think it worked better than if I'd read it on the printed page.
 
 <div class="book_review" id="clyde_w_ford">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="think-black.jpg"
-        alt="The cover of “Think Black”. A man in  a flak cap and dark glasses is holding a newspaper and looking towards the camera. The title is prominently displayed, with the word “Black” made up of horizontal stripes similar to the IBM logo."
-        width="92"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Think Black"
-      author="Clyde W. Ford"
-      review_url="https://books.alexwlchan.net/reviews/think-black/"
-      review_date="7 September 2021"
-      publication_year="2019"
+      picture
+      filename="think-black.jpg"
+      alt="The cover of “Think Black”. A man in  a flak cap and dark glasses is holding a newspaper and looking towards the camera. The title is prominently displayed, with the word “Black” made up of horizontal stripes similar to the IBM logo."
+      width="92"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Think Black"
+    author="Clyde W. Ford"
+    review_url="https://books.alexwlchan.net/reviews/think-black/"
+    review_date="7 September 2021"
+    publication_year="2019"
+  %}
 </div>
 
 A memoir from the son of the first Black systems engineer at IBM.
@@ -205,24 +195,22 @@ It's a powerful account of the intersection of race relations and the tech indus
 The author also worked at IBM, and he contrasts his experience with his father's -- what was different, and what was unchanged.
 
 <div class="book_review" id="alexandria_bellefleur">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="written-in-the-stars.jpg"
-        alt="The cover of “Written in the Stars”. It’s a blue background with the title in large white handwritten text, and some constellations dotted around the edges. Along the bottom are two women embracing, and a silhouette of the Seattle skyline."
-        width="93"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Written in the Stars"
-      author="Alexandria Bellefleur"
-      review_url="https://books.alexwlchan.net/reviews/written-in-the-stars/"
-      review_date="24 October 2021"
-      publication_year="2020"
+      picture
+      filename="written-in-the-stars.jpg"
+      alt="The cover of “Written in the Stars”. It’s a blue background with the title in large white handwritten text, and some constellations dotted around the edges. Along the bottom are two women embracing, and a silhouette of the Seattle skyline."
+      width="93"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Written in the Stars"
+    author="Alexandria Bellefleur"
+    review_url="https://books.alexwlchan.net/reviews/written-in-the-stars/"
+    review_date="24 October 2021"
+    publication_year="2020"
+  %}
 </div>
 
 A queer rom-com with Elle (a self-confident astrologist looking for love) and Darcy (a guarded actuary who's sworn off dating).
@@ -232,24 +220,22 @@ I fell in love with all the characters and I adored this book.
 It's part of a trilogy, so the subsequent books are on my reading list for 2022.
 
 <div class="book_review" id="computer_fire">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="your-computer-is-on-fire.jpg"
-        alt="The cover of “Your Computer is on Fire”. It's a yellow background with a simple graphic of a black-and-red fire, the title of the book, and the names of the four editors."
-        width="109"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Your Computer is on Fire"
-      editor="Thomas S. Mullaney, Benjamin Peters, Mar Hicks, and Kavita Philip"
-      review_url="https://books.alexwlchan.net/reviews/your-computer-is-on-fire/"
-      review_date="31 October 2021"
-      publication_year="2021"
+      picture
+      filename="your-computer-is-on-fire.jpg"
+      alt="The cover of “Your Computer is on Fire”. It's a yellow background with a simple graphic of a black-and-red fire, the title of the book, and the names of the four editors."
+      width="109"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Your Computer is on Fire"
+    editor="Thomas S. Mullaney, Benjamin Peters, Mar Hicks, and Kavita Philip"
+    review_url="https://books.alexwlchan.net/reviews/your-computer-is-on-fire/"
+    review_date="31 October 2021"
+    publication_year="2021"
+  %}
 </div>
 
 A series of essays about technology and computing, countering the myth of a technological utopia, and explaining the inequality and marginalisation caused by the current tech industry.

--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -12,30 +12,6 @@ card_attribution: |
   Background photo by Emily from Pexels: https://www.pexels.com/photo/books-768125/
 ---
 
-<style type="x-text/scss">
-  @import "posts/_end_of_year_books.scss";
-
-  #becky_chambers        { @include book_styles(#9d418d);}
-  #alice_oseman          { @include book_styles(#ce63cc);}
-  #colson_whitehead      { @include book_styles(#845657);}
-  #garrett_graff         { @include book_styles(#222);}
-  #clyde_w_ford          { @include book_styles(#222);}
-  #alexandria_bellefleur { @include book_styles(#0f5987); }
-  #computer_fire         { @include book_styles(#eb2122); }
-</style>
-
-<style type="x-text/scss" media="(prefers-color-scheme: dark)">
-  @import "posts/_end_of_year_books.scss";
-
-  #becky_chambers        { @include book_styles(#916cac); }
-  #alice_oseman          { @include book_styles(#ce63cc); }
-  #colson_whitehead      { @include book_styles(#c6a186); }
-  #garrett_graff         { @include book_styles(#d3bb63); }
-  #clyde_w_ford          { @include book_styles(#9e9e9e); }
-  #alexandria_bellefleur { @include book_styles(#1b7ebb); }
-  #computer_fire         { @include book_styles(#e6cb33); }
-</style>
-
 I read 52 books this year, which is a nice round number.
 I don't set a reading target so there's no "pass/fail" grade for the year, but I'm happy with that.
 
@@ -55,6 +31,33 @@ That has the list of everything I read this year, including books I tried to rea
 
 These are my seven favourites from 2021, in the order I read them.
 I'd recommend any of them.
+
+[herts]: https://www.hertfordshire.gov.uk/services/libraries-and-archives/books-and-reading/ebooks-and-audiobooks/ebooks-and-audiobooks.aspx
+[app]: https://twitter.com/alexwlchan/status/1418827399702224896
+[books]: https://books.alexwlchan.net/reviews/#books_by_year_2021
+[notes]: {% post_url 2020/2020-11-16-how-i-read-non-fiction-books %}
+
+<style type="x-text/scss">
+  @import "posts/_end_of_year_books.scss";
+
+  #becky_chambers        { @include book_styles(#9d418d);}
+  #alice_oseman          { @include book_styles(#ce63cc);}
+  #colson_whitehead      { @include book_styles(#845657);}
+  #garrett_graff         { @include book_styles(#222);}
+  #clyde_w_ford          { @include book_styles(#222);}
+  #alexandria_bellefleur { @include book_styles(#0f5987); }
+  #computer_fire         { @include book_styles(#eb2122); }
+  
+  @media screen and (prefers-color-scheme: dark) {
+    #becky_chambers        { @include book_styles(#916cac); }
+    #alice_oseman          { @include book_styles(#ce63cc); }
+    #colson_whitehead      { @include book_styles(#c6a186); }
+    #garrett_graff         { @include book_styles(#d3bb63); }
+    #clyde_w_ford          { @include book_styles(#9e9e9e); }
+    #alexandria_bellefleur { @include book_styles(#1b7ebb); }
+    #computer_fire         { @include book_styles(#e6cb33); }
+  }
+</style>
 
 ---
 
@@ -77,21 +80,16 @@ I'd recommend any of them.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      The residents of a space hotel have to make friends after an external crisis means they&rsquo;re stuck inside (sound familiar?).
-      It&rsquo;s a variety of non-human, alien species, and they use the time together to learn more about each other.
-    </p>
-    <p>
-      This is the sort of character work where Becky Chambers really shines – I love how truly alien they feel &ndash; not just humans in face paint, they have different social structures, cultural habits, physical biology.
-      There are almost no humans in the book, and they’re treated as a bit of a curiosity – it made me reflect on what I think of as &ldquo;normal&rdquo;.
-      (I particularly enjoyed an extended discussion of the weirdness of cheese.)
-    </p>
-    <p>
-      It&rsquo;s the final entry in the <em>Wayfarers</em> series of space operas, which I adore.
-    </p>
-  </div>
 </div>
+
+The residents of a space hotel have to make friends after an external crisis means they're stuck inside (sound familiar?).
+It's a variety of non-human, alien species, and they use the time together to learn more about each other.
+
+This is the sort of character work where Becky Chambers really shines – I love how truly alien they feel -- not just humans in face paint, they have different social structures, cultural habits, physical biology.
+There are almost no humans in the book, and they’re treated as a bit of a curiosity – it made me reflect on what I think of as "normal"
+(I particularly enjoyed an extended discussion of the weirdness of cheese.)
+
+It's the final entry in the *Wayfarers* series of space operas, which I adore.
 
 <div class="book_review" id="alice_oseman">
   <div class="heading">
@@ -112,17 +110,16 @@ I'd recommend any of them.
       publication_year="2018"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is a tale of self-discovery and acceptance.
-      Georgia is going to university looking for &ldquo;one true love&rdquo;, but realises she&rsquo;s actually ace-aro &ndash; after learning that ace-aro is a thing (<a href="https://en.wikipedia.org/wiki/Asexuality">asexual</a>, <a href="https://en.wikipedia.org/wiki/Romantic_orientation#Aromanticism">aromantic</a>) – and she has to navigate these new feelings without hurting her two best friends or her roommate.
-    </p>
-    <p>
-      I&rsquo;m somewhere in the ace-aro probability cloud and this book resonated strongly with me (almost painfully so); I made a lot of the same mistakes as Georgia.
-      I only wish I&rsquo;d been able to read something like this when I was at that age.
-    </p>
-  </div>
 </div>
+
+This is a tale of self-discovery and acceptance.
+Georgia is going to university looking for "one true love", but realises she's actually ace-aro -- after learning that ace-aro is a thing ([asexual], [aromantic]) – and she has to navigate these new feelings without hurting her two best friends or her roommate.
+
+I'm somewhere in the ace-aro probability cloud and this book resonated strongly with me (almost painfully so); I made a lot of the same mistakes as Georgia.
+I only wish I'd been able to read something like this when I was at that age.
+
+[asexual]: https://en.wikipedia.org/wiki/Asexuality
+[aromantic]: https://en.wikipedia.org/wiki/Romantic_orientation#Aromanticism
 
 <div class="book_review" id="colson_whitehead">
   <div class="heading">
@@ -143,20 +140,17 @@ I'd recommend any of them.
       publication_year="2018"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is an alt history novel about the American slave trade which reimagines the so-called &ldquo;underground railroad&rdquo; of <a href="https://en.wikipedia.org/wiki/Underground_Railroad">secret routes and safe houses</a> as a literal railroad.
-      It follows Cora, a woman who escapes a cotton plantation in Georgia, and it&rsquo;s unflinching and upfront about the horrors of slavery.
-    </p>
-    <p>
-      It doesn’t belittle or dismiss the atrocities afflicted on Cora and other Black people, but nor does it treat them as something to gawp at.
-      It’s a careful balance that helps them feel real and heavy, not cartoonish or fictional.
-    </p>
-    <p>
-      It’s not the most pleasant book, but I’m glad I read it.
-    </p>
-  </div>
 </div>
+
+This is an alt history novel about the American slave trade which reimagines the so-called "underground railroad" of [secret routes and safe houses] as a literal railroad.
+It follows Cora, a woman who escapes a cotton plantation in Georgia, and it's unflinching and upfront about the horrors of slavery.
+
+It doesn’t belittle or dismiss the atrocities afflicted on Cora and other Black people, but nor does it treat them as something to gawp at.
+It’s a careful balance that helps them feel real and heavy, not cartoonish or fictional.
+
+It’s not the most pleasant book, but I’m glad I read it.
+
+[secret routes and safe houses]: https://en.wikipedia.org/wiki/Underground_Railroad
 
 <div class="book_review" id="garrett_graff">
   <div class="heading">
@@ -177,16 +171,12 @@ I'd recommend any of them.
       publication_year="2019"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      I don&rsquo;t have strong memories of 9/11 because I was quite young when it happened, and this book helped me understand why it left such an impact.
-    </p>
-    <p>
-      It&rsquo;s a collection of quotes from different people, carefully combined into a single timeline to tell a striking story.
-      The audiobook has a cast of actors interspersed with real audio, and I think it worked better than if I&rsquo;d read it on the printed page.
-    </p>
-  </div>
 </div>
+
+I don't have strong memories of 9/11 because I was quite young when it happened, and this book helped me understand why it left such an impact.
+
+It's a collection of quotes from different people, carefully combined into a single timeline to tell a striking story.
+The audiobook has a cast of actors interspersed with real audio, and I think it worked better than if I'd read it on the printed page.
 
 <div class="book_review" id="clyde_w_ford">
   <div class="heading">
@@ -207,16 +197,12 @@ I'd recommend any of them.
       publication_year="2019"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      A memoir from the son of the first Black systems engineer at IBM.
-      It&rsquo;s a powerful account of the intersection of race relations and the tech industry, and the struggles of being a Black man at a predominantly white company.
-    </p>
-    <p>
-      The author also worked at IBM, and he contrasts his experience with his father&rsquo;s &ndash; what was different, and what was unchanged.
-    </p>
-  </div>
 </div>
+
+A memoir from the son of the first Black systems engineer at IBM.
+It's a powerful account of the intersection of race relations and the tech industry, and the struggles of being a Black man at a predominantly white company.
+
+The author also worked at IBM, and he contrasts his experience with his father's -- what was different, and what was unchanged.
 
 <div class="book_review" id="alexandria_bellefleur">
   <div class="heading">
@@ -237,17 +223,13 @@ I'd recommend any of them.
       publication_year="2020"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      A queer rom-com with Elle (a self-confident astrologist looking for love) and Darcy (a guarded actuary who&rsquo;s sworn off dating).
-      After a disastrous blind date, they start fake dating, but realise neither of them have fake feelings.
-    </p>
-    <p>
-      I fell in love with all the characters and I adored this book.
-      It&rsquo;s part of a trilogy, so the subsequent books are on my reading list for 2022.
-    </p>
-  </div>
 </div>
+
+A queer rom-com with Elle (a self-confident astrologist looking for love) and Darcy (a guarded actuary who's sworn off dating).
+After a disastrous blind date, they start fake dating, but realise neither of them have fake feelings.
+
+I fell in love with all the characters and I adored this book.
+It's part of a trilogy, so the subsequent books are on my reading list for 2022.
 
 <div class="book_review" id="computer_fire">
   <div class="heading">
@@ -268,15 +250,7 @@ I'd recommend any of them.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      A series of essays about technology and computing, countering the myth of a technological utopia, and explaining the inequality and marginalisation caused by the current tech industry.
-      It&rsquo;s a strong collection which doesn&rsquo;t pull its punches, and which I&rsquo;d recommend to anyone working in tech.
-    </p>
-  </div>
 </div>
 
-[herts]: https://www.hertfordshire.gov.uk/services/libraries-and-archives/books-and-reading/ebooks-and-audiobooks/ebooks-and-audiobooks.aspx
-[app]: https://twitter.com/alexwlchan/status/1418827399702224896
-[books]: https://books.alexwlchan.net/reviews/#books_by_year_2021
-[notes]: {% post_url 2020/2020-11-16-how-i-read-non-fiction-books %}
+A series of essays about technology and computing, countering the myth of a technological utopia, and explaining the inequality and marginalisation caused by the current tech industry.
+It's a strong collection which doesn't pull its punches, and which I'd recommend to anyone working in tech.

--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -62,14 +62,13 @@ I'd recommend any of them.
 ---
 
 <div class="book_review" id="becky_chambers">
-  <div class="book_cover">
-    {%
-      picture
-      filename="the-galaxy-and-the-ground-within.jpg"
-      alt="The cover of “The Galaxy, and the Ground Within”. White serif text with the title and the author's name on top of a purple-tinged view of space."
-      width="91"
-    %}
-  </div>
+  {%
+    picture
+    filename="the-galaxy-and-the-ground-within.jpg"
+    alt="The cover of “The Galaxy, and the Ground Within”. White serif text with the title and the author's name on top of a purple-tinged view of space."
+    width="91"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="The Galaxy, and the Ground Within"
@@ -90,14 +89,13 @@ There are almost no humans in the book, and they’re treated as a bit of a curi
 It's the final entry in the *Wayfarers* series of space operas, which I adore.
 
 <div class="book_review" id="alice_oseman">
-  <div class="book_cover">
-    {%
-      picture
-      filename="loveless.jpg"
-      alt="The cover of “Loveless”. It’s a purpley-pink background with a black-and-white drawing of a girl texting on her phone. A series of small hearts are drifting upwards out of the phone. The title and author’s name are written in a handwriting-like font at the bottom of the cover."
-      width="90"
-    %}
-  </div>
+  {%
+    picture
+    filename="loveless.jpg"
+    alt="The cover of “Loveless”. It’s a purpley-pink background with a black-and-white drawing of a girl texting on her phone. A series of small hearts are drifting upwards out of the phone. The title and author’s name are written in a handwriting-like font at the bottom of the cover."
+    width="90"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Loveless"
@@ -118,14 +116,13 @@ I only wish I'd been able to read something like this when I was at that age.
 [aromantic]: https://en.wikipedia.org/wiki/Romantic_orientation#Aromanticism
 
 <div class="book_review" id="colson_whitehead">
-  <div class="book_cover">
-    {%
-      picture
-      filename="the-underground-railroad.jpg"
-      alt="The cover of “The Underground Railroad”. It’s made up of three drawings: a woman looking into the distance, a woman embracing a taller man, and a figure shrouded by darkness holding a lantern."
-      width="93"
-    %}
-  </div>
+  {%
+    picture
+    filename="the-underground-railroad.jpg"
+    alt="The cover of “The Underground Railroad”. It’s made up of three drawings: a woman looking into the distance, a woman embracing a taller man, and a figure shrouded by darkness holding a lantern."
+    width="93"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="The Underground Railroad"
@@ -147,14 +144,13 @@ It’s not the most pleasant book, but I’m glad I read it.
 [secret routes and safe houses]: https://en.wikipedia.org/wiki/Underground_Railroad
 
 <div class="book_review" id="garrett_graff">
-  <div class="book_cover">
-    {%
-      picture
-      filename="the-only-plane-in-the-sky.jpg"
-      alt="The cover of “The Only Plane in the Sky”, with the subtitle “An Oral History of 9/11”. The cover is plain black with the title in gold lettering, and the author's name in small white lettering."
-      width="92"
-    %}
-  </div>
+  {%
+    picture
+    filename="the-only-plane-in-the-sky.jpg"
+    alt="The cover of “The Only Plane in the Sky”, with the subtitle “An Oral History of 9/11”. The cover is plain black with the title in gold lettering, and the author's name in small white lettering."
+    width="92"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="The Only Plane in the Sky"
@@ -171,14 +167,13 @@ It's a collection of quotes from different people, carefully combined into a sin
 The audiobook has a cast of actors interspersed with real audio, and I think it worked better than if I'd read it on the printed page.
 
 <div class="book_review" id="clyde_w_ford">
-  <div class="book_cover">
-    {%
-      picture
-      filename="think-black.jpg"
-      alt="The cover of “Think Black”. A man in  a flak cap and dark glasses is holding a newspaper and looking towards the camera. The title is prominently displayed, with the word “Black” made up of horizontal stripes similar to the IBM logo."
-      width="92"
-    %}
-  </div>
+  {%
+    picture
+    filename="think-black.jpg"
+    alt="The cover of “Think Black”. A man in  a flak cap and dark glasses is holding a newspaper and looking towards the camera. The title is prominently displayed, with the word “Black” made up of horizontal stripes similar to the IBM logo."
+    width="92"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Think Black"
@@ -195,14 +190,13 @@ It's a powerful account of the intersection of race relations and the tech indus
 The author also worked at IBM, and he contrasts his experience with his father's -- what was different, and what was unchanged.
 
 <div class="book_review" id="alexandria_bellefleur">
-  <div class="book_cover">
-    {%
-      picture
-      filename="written-in-the-stars.jpg"
-      alt="The cover of “Written in the Stars”. It’s a blue background with the title in large white handwritten text, and some constellations dotted around the edges. Along the bottom are two women embracing, and a silhouette of the Seattle skyline."
-      width="93"
-    %}
-  </div>
+  {%
+    picture
+    filename="written-in-the-stars.jpg"
+    alt="The cover of “Written in the Stars”. It’s a blue background with the title in large white handwritten text, and some constellations dotted around the edges. Along the bottom are two women embracing, and a silhouette of the Seattle skyline."
+    width="93"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Written in the Stars"
@@ -220,14 +214,13 @@ I fell in love with all the characters and I adored this book.
 It's part of a trilogy, so the subsequent books are on my reading list for 2022.
 
 <div class="book_review" id="computer_fire">
-  <div class="book_cover">
-    {%
-      picture
-      filename="your-computer-is-on-fire.jpg"
-      alt="The cover of “Your Computer is on Fire”. It's a yellow background with a simple graphic of a black-and-red fire, the title of the book, and the names of the four editors."
-      width="109"
-    %}
-  </div>
+  {%
+    picture
+    filename="your-computer-is-on-fire.jpg"
+    alt="The cover of “Your Computer is on Fire”. It's a yellow background with a simple graphic of a black-and-red fire, the title of the book, and the names of the four editors."
+    width="109"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Your Computer is on Fire"

--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -8,53 +8,18 @@ tags:
 colors:
   css_light: "#464646"
   css_dark:  "#adadad"
+card_attribution: |
+  Background photo by Emily from Pexels: https://www.pexels.com/photo/books-768125/
 ---
 
 <style type="x-text/scss">
   @import "posts/_end_of_year_books.scss";
 
-  #becky_chambers {
-    @include book_styles(#9d418d);
-  }
-
-  #alice_oseman  {
-    @include book_styles(#ce63cc);
-  }
-
-  #colson_whitehead {
-    @include book_styles(#845657);
-  }
-
-  #garrett_graff {
-    @include book_styles(#222);
-  }
-
-  #clyde_w_ford {
-    @include book_styles(#222);
-  }
-
-  #alexandria_bellefleur {
-    @include book_styles(#0f5987);
-  }
-
-  #computer_fire {
-    @include book_styles(#eb2122);
-  }
-</style>
-
-
-{% comment %}
-Card image: https://www.pexels.com/photo/books-768125/
-{% endcomment %}
-
-<style type="x-text/scss">
-  @import "posts/_end_of_year_books.scss";
-
-  #becky_chambers        { @include book_styles(#9d418d); }
-  #alice_oseman          { @include book_styles(#ce63cc); }
-  #colson_whitehead      { @include book_styles(#845657); }
-  #garrett_graff         { @include book_styles(#222);    }
-  #clyde_w_ford          { @include book_styles(#222);    }
+  #becky_chambers        { @include book_styles(#9d418d);}
+  #alice_oseman          { @include book_styles(#ce63cc);}
+  #colson_whitehead      { @include book_styles(#845657);}
+  #garrett_graff         { @include book_styles(#222);}
+  #clyde_w_ford          { @include book_styles(#222);}
   #alexandria_bellefleur { @include book_styles(#0f5987); }
   #computer_fire         { @include book_styles(#eb2122); }
 </style>

--- a/src/_posts/2022/2022-12-31-2022-in-reading.md
+++ b/src/_posts/2022/2022-12-31-2022-in-reading.md
@@ -62,14 +62,13 @@ They all get a strong recommendation from me.
 ---
 
 <div class="book_review" id="piranesi">
-  <div class="book_cover">
-    {%
-      picture
-      filename="piranesi.jpg"
-      alt="The cover of “Piranesi”. A person with goat’s legs and a man’s torso stand atop a pillar, playing a musical instrument. It sits above a sea of swirling brown curves. The title and author’s name are shown in a serif font."
-      width="99"
-    %}
-  </div>
+  {%
+    picture
+    filename="piranesi.jpg"
+    alt="The cover of “Piranesi”. A person with goat’s legs and a man’s torso stand atop a pillar, playing a musical instrument. It sits above a sea of swirling brown curves. The title and author’s name are shown in a serif font."
+    width="99"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Piranesi"
@@ -95,14 +94,13 @@ I listened to this as an audiobook, read by Chiwetel Ejiofor.
 He brought a lot of depth to the character, and I think I enjoyed it more than if I’d read the text first.
 
 <div class="book_review" id="hang_the_moon">
-  <div class="book_cover">
-    {%
-      picture
-      filename="hang-the-moon.jpg"
-      alt="The cover of “Hang the Moon”. A man in a leather jacket has a blonde woman swooning over him, with a bunch of roses held behind him. There’s a ferris wheel and a city skyline in the background, against a pink and purple sky."
-      width="93"
-    %}
-  </div>
+  {%
+    picture
+    filename="hang-the-moon.jpg"
+    alt="The cover of “Hang the Moon”. A man in a leather jacket has a blonde woman swooning over him, with a bunch of roses held behind him. There’s a ferris wheel and a city skyline in the background, against a pink and purple sky."
+    width="93"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Hang the Moon"
@@ -127,14 +125,13 @@ This is the second part of a trilogy, which concluded with *Count Your Lucky Sta
 I read that this year also, but I didn’t enjoy it as much – *Hang the Moon* is the high point of the series for me.
 
 <div class="book_review" id="antimemetics">
-  <div class="book_cover">
-    {%
-      picture
-      filename="there-is-no-antimemetics-division.jpg"
-      alt="The cover of “There Is No Antimemetics Division”. A large black, featureless monolith set against a forest landscape."
-      width="88"
-    %}
-  </div>
+  {%
+    picture
+    filename="there-is-no-antimemetics-division.jpg"
+    alt="The cover of “There Is No Antimemetics Division”. A large black, featureless monolith set against a forest landscape."
+    width="88"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="There Is No Antimemetics Division"
@@ -158,14 +155,13 @@ It’s a mixture of short stories and a longer narrative, and I was absolutely g
 I’ve read it three times and I still don’t completely get it, but I think that’s the point.
 
 <div class="book_review" id="euphoria">
-  <div class="book_cover">
-    {%
-      picture
-      filename="gender-euphoria.jpg"
-      alt="The cover of “Gender Euphoria”. Diagonal stripes in the trans pride colours (baby blue, baby pink, white), and the title in large friendly letters."
-      width="91"
-    %}
-  </div>
+  {%
+    picture
+    filename="gender-euphoria.jpg"
+    alt="The cover of “Gender Euphoria”. Diagonal stripes in the trans pride colours (baby blue, baby pink, white), and the title in large friendly letters."
+    width="91"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Gender Euphoria"
@@ -185,14 +181,13 @@ I like that it has a diverse selection of authors, in multiple dimensions – no
 Particular favourite essays were “Gender-Creative Parenting”, “The First Signs Hormones Were Working for Me”, and “Punks Against Gender Conformity”.
 
 <div class="book_review" id="coffee">
-  <div class="book_cover">
-    {%
-      picture
-      filename="before-the-coffee-gets-cold-tales-from-the-cafe.jpg"
-      alt="The cover of “Tales from the Café”. There’s a gold wallpaper with several clocks, a chair, and a black cat."
-      width="92"
-    %}
-  </div>
+  {%
+    picture
+    filename="before-the-coffee-gets-cold-tales-from-the-cafe.jpg"
+    alt="The cover of “Tales from the Café”. There’s a gold wallpaper with several clocks, a chair, and a black cat."
+    width="92"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Before the Coffee Gets Cold: Tales from the Café"
@@ -216,14 +211,13 @@ A mother who goes forward to see their grown-up daughter.
 It’s a clever idea, executed well.
 
 <div class="book_review" id="rust">
-  <div class="book_cover">
-    {%
-      picture
-      filename="rust.jpg"
-      alt="The cover of “Rust”. It’s a white background with the title in black text, and flecks of reddish-orange rust across the cover."
-      width="93"
-    %}
-  </div>
+  {%
+    picture
+    filename="rust.jpg"
+    alt="The cover of “Rust”. It’s a white background with the title in black text, and flecks of reddish-orange rust across the cover."
+    width="93"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Rust"
@@ -246,14 +240,13 @@ I originally came across this book as a joke – I was looking for a “Rust Boo
 I’m glad it stuck in my brain.
 
 <div class="book_review" id="another_life">
-  <div class="book_cover">
-    {%
-      picture
-      filename="another-life.jpg"
-      alt="The cover of “Another Life”. A woman in a black-and-white scene holds some balloons which are blowing away, while the title of the book is shown in coloured letters."
-      width="91"
-    %}
-  </div>
+  {%
+    picture
+    filename="another-life.jpg"
+    alt="The cover of “Another Life”. A woman in a black-and-white scene holds some balloons which are blowing away, while the title of the book is shown in coloured letters."
+    width="91"
+    class="book_cover"
+  %}
   {%
     include book_info.html
     title="Another Life"

--- a/src/_posts/2022/2022-12-31-2022-in-reading.md
+++ b/src/_posts/2022/2022-12-31-2022-in-reading.md
@@ -62,24 +62,22 @@ They all get a strong recommendation from me.
 ---
 
 <div class="book_review" id="piranesi">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="piranesi.jpg"
-        alt="The cover of “Piranesi”. A person with goat’s legs and a man’s torso stand atop a pillar, playing a musical instrument. It sits above a sea of swirling brown curves. The title and author’s name are shown in a serif font."
-        width="99"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Piranesi"
-      author="Susanna Clarke"
-      review_url="https://books.alexwlchan.net/reviews/piranesi/"
-      review_date="20 January 2022"
-      publication_year="2020"
+      picture
+      filename="piranesi.jpg"
+      alt="The cover of “Piranesi”. A person with goat’s legs and a man’s torso stand atop a pillar, playing a musical instrument. It sits above a sea of swirling brown curves. The title and author’s name are shown in a serif font."
+      width="99"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Piranesi"
+    author="Susanna Clarke"
+    review_url="https://books.alexwlchan.net/reviews/piranesi/"
+    review_date="20 January 2022"
+    publication_year="2020"
+  %}
 </div>
 
 This is a novel with some gorgeous worldbuilding.
@@ -97,24 +95,22 @@ I listened to this as an audiobook, read by Chiwetel Ejiofor.
 He brought a lot of depth to the character, and I think I enjoyed it more than if I’d read the text first.
 
 <div class="book_review" id="hang_the_moon">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="hang-the-moon.jpg"
-        alt="The cover of “Hang the Moon”. A man in a leather jacket has a blonde woman swooning over him, with a bunch of roses held behind him. There’s a ferris wheel and a city skyline in the background, against a pink and purple sky."
-        width="93"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Hang the Moon"
-      author="Alexandria Bellefleur"
-      review_url="https://books.alexwlchan.net/reviews/hang-the-moon/"
-      review_date="5 March 2022"
-      publication_year="2021"
+      picture
+      filename="hang-the-moon.jpg"
+      alt="The cover of “Hang the Moon”. A man in a leather jacket has a blonde woman swooning over him, with a bunch of roses held behind him. There’s a ferris wheel and a city skyline in the background, against a pink and purple sky."
+      width="93"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Hang the Moon"
+    author="Alexandria Bellefleur"
+    review_url="https://books.alexwlchan.net/reviews/hang-the-moon/"
+    review_date="5 March 2022"
+    publication_year="2021"
+  %}
 </div>
 
 This is the sequel to *Written in the Stars*, which was one of my favourite books <a href="{% post_url 2021/2021-12-31-2021-in-reading %}#alexandria_bellefleur">last year</a>.
@@ -131,24 +127,22 @@ This is the second part of a trilogy, which concluded with *Count Your Lucky Sta
 I read that this year also, but I didn’t enjoy it as much – *Hang the Moon* is the high point of the series for me.
 
 <div class="book_review" id="antimemetics">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="there-is-no-antimemetics-division.jpg"
-        alt="The cover of “There Is No Antimemetics Division”. A large black, featureless monolith set against a forest landscape."
-        width="88"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="There Is No Antimemetics Division"
-      author="qntm"
-      review_url="https://books.alexwlchan.net/reviews/there-is-no-antimemetics-division/"
-      review_date="30 March 2022"
-      publication_year="2021"
+      picture
+      filename="there-is-no-antimemetics-division.jpg"
+      alt="The cover of “There Is No Antimemetics Division”. A large black, featureless monolith set against a forest landscape."
+      width="88"
     %}
   </div>
+  {%
+    include book_info.html
+    title="There Is No Antimemetics Division"
+    author="qntm"
+    review_url="https://books.alexwlchan.net/reviews/there-is-no-antimemetics-division/"
+    review_date="30 March 2022"
+    publication_year="2021"
+  %}
 </div>
 
 This book makes my head hurt.
@@ -164,24 +158,22 @@ It’s a mixture of short stories and a longer narrative, and I was absolutely g
 I’ve read it three times and I still don’t completely get it, but I think that’s the point.
 
 <div class="book_review" id="euphoria">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="gender-euphoria.jpg"
-        alt="The cover of “Gender Euphoria”. Diagonal stripes in the trans pride colours (baby blue, baby pink, white), and the title in large friendly letters."
-        width="91"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Gender Euphoria"
-      editor="Laura Kate Dale"
-      review_url="https://books.alexwlchan.net/reviews/gender-euphoria/"
-      review_date="23 June 2022"
-      publication_year="2021"
+      picture
+      filename="gender-euphoria.jpg"
+      alt="The cover of “Gender Euphoria”. Diagonal stripes in the trans pride colours (baby blue, baby pink, white), and the title in large friendly letters."
+      width="91"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Gender Euphoria"
+    editor="Laura Kate Dale"
+    review_url="https://books.alexwlchan.net/reviews/gender-euphoria/"
+    review_date="23 June 2022"
+    publication_year="2021"
+  %}
 </div>
 
 This is an anthology of essays about different people’s experiences of gender, focusing on a sense of joy rather than despair.
@@ -193,23 +185,21 @@ I like that it has a diverse selection of authors, in multiple dimensions – no
 Particular favourite essays were “Gender-Creative Parenting”, “The First Signs Hormones Were Working for Me”, and “Punks Against Gender Conformity”.
 
 <div class="book_review" id="coffee">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="before-the-coffee-gets-cold-tales-from-the-cafe.jpg"
-        alt="The cover of “Tales from the Café”. There’s a gold wallpaper with several clocks, a chair, and a black cat."
-        width="92"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Before the Coffee Gets Cold: Tales from the Café"
-      author="Toshikazu Kawaguchi" review_url="https://books.alexwlchan.net/reviews/before-the-coffee-gets-cold-tales-from-the-cafe/"
-      review_date="9 July 2022"
-      publication_year="2020"
+      picture
+      filename="before-the-coffee-gets-cold-tales-from-the-cafe.jpg"
+      alt="The cover of “Tales from the Café”. There’s a gold wallpaper with several clocks, a chair, and a black cat."
+      width="92"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Before the Coffee Gets Cold: Tales from the Café"
+    author="Toshikazu Kawaguchi" review_url="https://books.alexwlchan.net/reviews/before-the-coffee-gets-cold-tales-from-the-cafe/"
+    review_date="9 July 2022"
+    publication_year="2020"
+  %}
 </div>
 
 This is a charming little book about a café with a novel approach to time travel.
@@ -226,23 +216,21 @@ A mother who goes forward to see their grown-up daughter.
 It’s a clever idea, executed well.
 
 <div class="book_review" id="rust">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="rust.jpg"
-        alt="The cover of “Rust”. It’s a white background with the title in black text, and flecks of reddish-orange rust across the cover."
-        width="93"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Rust"
-      author="Jonathan Waldman" review_url="https://books.alexwlchan.net/reviews/rust/"
-      review_date="15 November 2022"
-      publication_year="2015"
+      picture
+      filename="rust.jpg"
+      alt="The cover of “Rust”. It’s a white background with the title in black text, and flecks of reddish-orange rust across the cover."
+      width="93"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Rust"
+    author="Jonathan Waldman" review_url="https://books.alexwlchan.net/reviews/rust/"
+    review_date="15 November 2022"
+    publication_year="2015"
+  %}
 </div>
 
 This is a book of stories about rust, and the people whose job it is to make it go away.
@@ -258,24 +246,22 @@ I originally came across this book as a joke – I was looking for a “Rust Boo
 I’m glad it stuck in my brain.
 
 <div class="book_review" id="another_life">
-  <div class="heading">
-    <div class="book_cover">
-      {%
-        picture
-        filename="another-life.jpg"
-        alt="The cover of “Another Life”. A woman in a black-and-white scene holds some balloons which are blowing away, while the title of the book is shown in coloured letters."
-        width="91"
-      %}
-    </div>
+  <div class="book_cover">
     {%
-      include book_info.html
-      title="Another Life"
-      author="Jodie Chapman"
-      review_url="https://books.alexwlchan.net/reviews/another-life/"
-      review_date="19 November 2022"
-      publication_year="2021"
+      picture
+      filename="another-life.jpg"
+      alt="The cover of “Another Life”. A woman in a black-and-white scene holds some balloons which are blowing away, while the title of the book is shown in coloured letters."
+      width="91"
     %}
   </div>
+  {%
+    include book_info.html
+    title="Another Life"
+    author="Jodie Chapman"
+    review_url="https://books.alexwlchan.net/reviews/another-life/"
+    review_date="19 November 2022"
+    publication_year="2021"
+  %}
 </div>
 
 This is the story of Nick and Anna, two teenagers who meet while working a summer job together, and the way their lives drift alternately further apart and closer together as they get older.

--- a/src/_posts/2022/2022-12-31-2022-in-reading.md
+++ b/src/_posts/2022/2022-12-31-2022-in-reading.md
@@ -8,35 +8,9 @@ tags:
 colors:
   css_light: "#464646"
   css_dark:  "#adadad"
+card_attribution: |
+  Background photo by Element5 Digital from Pexels: https://www.pexels.com/photo/assorted-books-on-book-shelves-1370295/
 ---
-
-{% comment %}
-Card image: https://www.pexels.com/photo/assorted-books-on-book-shelves-1370295/
-{% endcomment %}
-
-<style type="x-text/scss">
-  @import "posts/_end_of_year_books.scss";
-
-  #piranesi      { @include book_styles(#916540); }
-  #hang_the_moon { @include book_styles(#965792); }
-  #antimemetics  { @include book_styles(#dd4366); }
-  #euphoria      { @include book_styles(#01a0e4); }
-  #coffee        { @include book_styles(#86654b); }
-  #rust          { @include book_styles(#86361f); }
-  #another_life  { @include book_styles(#464349); }
-</style>
-
-<style type="x-text/scss" media="(prefers-color-scheme: dark)">
-  @import "posts/_end_of_year_books.scss";
-
-  #piranesi      { @include book_styles(#b6723a); }
-  #hang_the_moon { @include book_styles(#d97d99); }
-  #antimemetics  { @include book_styles(#fa6360); }
-  #euphoria      { @include book_styles(#01a0e4); }
-  #coffee        { @include book_styles(#ebc067); }
-  #rust          { @include book_styles(#b4805f); }
-  #another_life  { @include book_styles(#b3b3b3); }
-</style>
 
 I read 71 books this year, which is the most I've read in a single year since I started keeping detailed records.
 I don't set reading goals, but I'm pleased with that.
@@ -59,6 +33,32 @@ I've also been writing private notes on fiction books, usually the characters an
 These are my favourites from 2022, in the order I read them.
 They all get a strong recommendation from me.
 
+[library_lookup]: {% post_url 2022/2022-10-10-library-lookup %}
+[2021]: {% post_url 2021/2021-12-31-2021-in-reading %}
+[books]: https://books.alexwlchan.net/
+
+<style type="x-text/scss">
+  @import "posts/_end_of_year_books.scss";
+
+  #piranesi      { @include book_styles(#916540); }
+  #hang_the_moon { @include book_styles(#965792); }
+  #antimemetics  { @include book_styles(#dd4366); }
+  #euphoria      { @include book_styles(#01a0e4); }
+  #coffee        { @include book_styles(#86654b); }
+  #rust          { @include book_styles(#86361f); }
+  #another_life  { @include book_styles(#464349); }
+  
+  @media screen and (prefers-color-scheme: dark) {
+    #piranesi      { @include book_styles(#b6723a); }
+    #hang_the_moon { @include book_styles(#d97d99); }
+    #antimemetics  { @include book_styles(#fa6360); }
+    #euphoria      { @include book_styles(#01a0e4); }
+    #coffee        { @include book_styles(#ebc067); }
+    #rust          { @include book_styles(#b4805f); }
+    #another_life  { @include book_styles(#b3b3b3); }
+  }
+</style>
+
 ---
 
 <div class="book_review" id="piranesi">
@@ -80,27 +80,21 @@ They all get a strong recommendation from me.
       publication_year="2020"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is a novel with some gorgeous worldbuilding.
-    </p>
-    <p>
-      The protagonist lives in “the House”, an endless series of halls filled with statues, sea, and sky.
-      His reverence for the house is infectious, and I love the world that’s been created.
-      He records his life in journals, and the story is told through its entries.
-      He believes he’s lived there his whole life, and assists “the Other” in scientific experiments, but the truth – which is only revealed gradually – is much more horrifying.
-    </p>
-    <p>
-      I was initially quite confused, and I took a while to get into it – but I think that’s intentional.
-      The setting is a bit mysterious and fantastical, and we don’t just get answers on a silver platter.
-      It’s a book that gives you a lot to think about.
-    </p>
-    <p>
-      I listened to this as an audiobook, read by Chiwetel Ejiofor.
-      He brought a lot of depth to the character, and I think I enjoyed it more than if I’d read the text first.
-    </p>
-  </div>
 </div>
+
+This is a novel with some gorgeous worldbuilding.
+
+The protagonist lives in “the House”, an endless series of halls filled with statues, sea, and sky.
+His reverence for the house is infectious, and I love the world that’s been created.
+He records his life in journals, and the story is told through its entries.
+He believes he’s lived there his whole life, and assists “the Other” in scientific experiments, but the truth – which is only revealed gradually – is much more horrifying.
+
+I was initially quite confused, and I took a while to get into it – but I think that’s intentional.
+The setting is a bit mysterious and fantastical, and we don’t just get answers on a silver platter.
+It’s a book that gives you a lot to think about.
+
+I listened to this as an audiobook, read by Chiwetel Ejiofor.
+He brought a lot of depth to the character, and I think I enjoyed it more than if I’d read the text first.
 
 <div class="book_review" id="hang_the_moon">
   <div class="heading">
@@ -121,26 +115,20 @@ They all get a strong recommendation from me.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is the sequel to <em>Written in the Stars</em>, which was one of my favourite books <a href="{% post_url 2021/2021-12-31-2021-in-reading %}#alexandria_bellefleur">last year</a>.
-    </p>
-    <p>
-      It’s a romance novel, this time between Darcy’s brother Brendon and her best friend Annie.
-      Where the first book used the fake dating trope, this one leans into big romantic gestures.
-      It’s a charming tale of them both learning to be vulnerable and loving, and navigating each other’s love languages.
-    </p>
-    <p>
-      It’s a sweet book, and I inhaled it in a day.
-      Everyone is nice and bubbly, the friendships and love feel warm and genuine, and I enjoyed spending more time with these characters.
-      These two books are very much comfort reads, and I expect to return to them again and again.
-    </p>
-    <p>
-      This is the second part of a trilogy, which concluded with <em>Count Your Lucky Stars</em>.
-      I read that this year also, but I didn’t enjoy it as much – <em>Hang the Moon</em> is the high point of the series for me.
-    </p>
-  </div>
 </div>
+
+This is the sequel to *Written in the Stars*, which was one of my favourite books <a href="{% post_url 2021/2021-12-31-2021-in-reading %}#alexandria_bellefleur">last year</a>.
+
+It’s a romance novel, this time between Darcy’s brother Brendon and her best friend Annie.
+Where the first book used the fake dating trope, this one leans into big romantic gestures.
+It’s a charming tale of them both learning to be vulnerable and loving, and navigating each other’s love languages.
+
+It’s a sweet book, and I inhaled it in a day.
+Everyone is nice and bubbly, the friendships and love feel warm and genuine, and I enjoyed spending more time with these characters.
+These two books are very much comfort reads, and I expect to return to them again and again.
+
+This is the second part of a trilogy, which concluded with *Count Your Lucky Stars*.
+I read that this year also, but I didn’t enjoy it as much – *Hang the Moon* is the high point of the series for me.
 
 <div class="book_review" id="antimemetics">
   <div class="heading">
@@ -161,24 +149,19 @@ They all get a strong recommendation from me.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This book makes my head hurt.
-    </p>
-    <p>
-      It’s about “anti-memes” – ideas that you literally can’t remember.
-      It’s a clever and mind-bending concept, dialled up to 11 in a mix of sci-fi, horror, and intrigue.
-      The <a href="https://en.wikipedia.org/wiki/SCP_Foundation">Foundation agent</a> who forgets they work in antimemetics.
-      A monster that eats your memories and then other people’s memories of you.
-      A pet antimeme that has to be fed with trivia and useless facts.
-      Pure nightmare fuel.
-    </p>
-    <p>
-      It’s a mixture of short stories and a longer narrative, and I was absolutely gripped.
-      I’ve read it three times and I still don’t completely get it, but I think that’s the point.
-    </p>
-  </div>
 </div>
+
+This book makes my head hurt.
+
+It’s about “anti-memes” – ideas that you literally can’t remember.
+It’s a clever and mind-bending concept, dialled up to 11 in a mix of sci-fi, horror, and intrigue.
+The <a href="https://en.wikipedia.org/wiki/SCP_Foundation">Foundation agent</a> who forgets they work in antimemetics.
+A monster that eats your memories and then other people’s memories of you.
+A pet antimeme that has to be fed with trivia and useless facts.
+Pure nightmare fuel.
+
+It’s a mixture of short stories and a longer narrative, and I was absolutely gripped.
+I’ve read it three times and I still don’t completely get it, but I think that’s the point.
 
 <div class="book_review" id="euphoria">
   <div class="heading">
@@ -199,20 +182,15 @@ They all get a strong recommendation from me.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is an anthology of essays about different people’s experiences of gender, focusing on a sense of joy rather than despair.
-      It’s lovely to see such a variety of perspectives on gender, and how even tiny moments can bring such happiness.
-    </p>
-    <p>
-      I really enjoyed getting the different perspectives, some of which resonate closely with me, others which are very different.
-      I like that it has a diverse selection of authors, in multiple dimensions – not just the white, binary, trans women who often dominate such conversations.
-    </p>
-    <p>
-      Particular favourite essays were “Gender-Creative Parenting”, “The First Signs Hormones Were Working for Me”, and “Punks Against Gender Conformity”.
-    </p>
-  </div>
 </div>
+
+This is an anthology of essays about different people’s experiences of gender, focusing on a sense of joy rather than despair.
+It’s lovely to see such a variety of perspectives on gender, and how even tiny moments can bring such happiness.
+
+I really enjoyed getting the different perspectives, some of which resonate closely with me, others which are very different.
+I like that it has a diverse selection of authors, in multiple dimensions – not just the white, binary, trans women who often dominate such conversations.
+
+Particular favourite essays were “Gender-Creative Parenting”, “The First Signs Hormones Were Working for Me”, and “Punks Against Gender Conformity”.
 
 <div class="book_review" id="coffee">
   <div class="heading">
@@ -232,25 +210,20 @@ They all get a strong recommendation from me.
       publication_year="2020"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is a charming little book about a café with a novel approach to time travel.
-      You sit in a chair, drink your coffee, and you can go and meet people from your past and future.
-      But there are rules – you can’t change what happens, you can’t get up from your chair, and you have to leave before your single cup of coffee goes cold.
-    </p>
-    <p>
-      This is part of a series that also includes <em>Before the Coffee Gets Cold</em> and <em>Before Your Memory Fades</em>.
-      I discovered it this year, I read all of it, and I loved it.
-    </p>
-    <p>
-      Each book is a collection of short stories about different people who choose to sit in the chair – every one with a beautiful tale of emotion, heartbreak, and love.
-      A man who goes back to visit his long-dead best friend.
-      An orphan who wants to meet the parents they never knew.
-      A mother who goes forward to see their grown-up daughter.
-      It’s a clever idea, executed well.
-    </p>
-  </div>
 </div>
+
+This is a charming little book about a café with a novel approach to time travel.
+You sit in a chair, drink your coffee, and you can go and meet people from your past and future.
+But there are rules – you can’t change what happens, you can’t get up from your chair, and you have to leave before your single cup of coffee goes cold.
+
+This is part of a series that also includes *Before the Coffee Gets Cold* and *Before Your Memory Fades*.
+I discovered it this year, I read all of it, and I loved it.
+
+Each book is a collection of short stories about different people who choose to sit in the chair – every one with a beautiful tale of emotion, heartbreak, and love.
+A man who goes back to visit his long-dead best friend.
+An orphan who wants to meet the parents they never knew.
+A mother who goes forward to see their grown-up daughter.
+It’s a clever idea, executed well.
 
 <div class="book_review" id="rust">
   <div class="heading">
@@ -270,25 +243,19 @@ They all get a strong recommendation from me.
       publication_year="2015"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is a book of stories about rust, and the people whose job it is to make it go away.
-      It sounds like a dry topic, but it’s a real page turner.
-      Each chapter focuses on a different group of people with a good mix of technical information and lighter anecdotes.
-    </p>
-    <p>
-      Some particular favourite chapters include Coating the Can (about creating canned drinks which are safe for customers), Pigging the Pipe (monitoring the state of corrosion in long oil pipelines), and Indiana Jane (photographing rusting buildings).
-      I took a lot of notes, because I found it fascinating.
-    </p>
-    <p>
-      I was struck by the parallels to software engineering – in particular the difficulty corrosion engineers have in getting others to care about their work, and how many people want to chase the new shiny rather than maintain the existing thing.
-    </p>
-    <p>
-      I originally came across this book as a joke – I was looking for a “Rust Book” that wasn’t about <a href="https://doc.rust-lang.org/book/">the programming language</a> to mention in a sarcastic tweet.
-      I’m glad it stuck in my brain.
-    </p>
-  </div>
 </div>
+
+This is a book of stories about rust, and the people whose job it is to make it go away.
+It sounds like a dry topic, but it’s a real page turner.
+Each chapter focuses on a different group of people with a good mix of technical information and lighter anecdotes.
+
+Some particular favourite chapters include Coating the Can (about creating canned drinks which are safe for customers), Pigging the Pipe (monitoring the state of corrosion in long oil pipelines), and Indiana Jane (photographing rusting buildings).
+I took a lot of notes, because I found it fascinating.
+
+I was struck by the parallels to software engineering – in particular the difficulty corrosion engineers have in getting others to care about their work, and how many people want to chase the new shiny rather than maintain the existing thing.
+
+I originally came across this book as a joke – I was looking for a “Rust Book” that wasn’t about <a href="https://doc.rust-lang.org/book/">the programming language</a> to mention in a sarcastic tweet.
+I’m glad it stuck in my brain.
 
 <div class="book_review" id="another_life">
   <div class="heading">
@@ -309,24 +276,15 @@ They all get a strong recommendation from me.
       publication_year="2021"
     %}
   </div>
-  <div class="review_text">
-    <p>
-      This is the story of Nick and Anna, two teenagers who meet while working a summer job together, and the way their lives drift alternately further apart and closer together as they get older.
-      I was expecting a traditional “happily ever after” romance, but it’s so much more than that.
-    </p>
-    <p>
-      It’s a beautiful book about flawed, messy humans, and the love between them.
-      It explores different aspects of the human experience: love, memory, grief, regret.
-      The characters have depth, complexity, and I cared about what happened to them.
-      There are some profound and lovely lines, and I wrote down a lot of quotes.
-    </p>
-    <p>
-      This recommendation comes with caveats: it’s quite a heavy story, and needs content warnings for suicide, family trauma, and religion.
-      But if you don’t mind those, I think it’s a rewarding read.
-    </p>
-  </div>
 </div>
 
-[library_lookup]: {% post_url 2022/2022-10-10-library-lookup %}
-[2021]: {% post_url 2021/2021-12-31-2021-in-reading %}
-[books]: https://books.alexwlchan.net/
+This is the story of Nick and Anna, two teenagers who meet while working a summer job together, and the way their lives drift alternately further apart and closer together as they get older.
+I was expecting a traditional “happily ever after” romance, but it’s so much more than that.
+
+It’s a beautiful book about flawed, messy humans, and the love between them.
+It explores different aspects of the human experience: love, memory, grief, regret.
+The characters have depth, complexity, and I cared about what happened to them.
+There are some profound and lovely lines, and I wrote down a lot of quotes.
+
+This recommendation comes with caveats: it’s quite a heavy story, and needs content warnings for suicide, family trauma, and religion.
+But if you don’t mind those, I think it’s a rewarding read.

--- a/src/_scss/posts/_end_of_year_books.scss
+++ b/src/_scss/posts/_end_of_year_books.scss
@@ -69,6 +69,6 @@
 
 /* The correct margin is applied by either the book cover or the
    heading text, whichever is lower */
-.review_text p:first-child {
+.book_review + p {
   margin-top: 0;
 }

--- a/src/_scss/posts/_end_of_year_books.scss
+++ b/src/_scss/posts/_end_of_year_books.scss
@@ -6,7 +6,7 @@
   }
 }
 
-.heading {
+.book_review {
   display: grid;
   grid-template-columns: 140px auto;
   min-height: calc(140px + 1em);

--- a/src/_scss/posts/_end_of_year_books.scss
+++ b/src/_scss/posts/_end_of_year_books.scss
@@ -1,7 +1,8 @@
 @mixin book_styles($color) {
   a { @include link_styles($color, 0.2); }
   h2.book_title { color: $color; }
-  .book_cover img {
+
+  img.book_cover {
     box-shadow: 0px 0px 5px rgba($color, 1);
   }
 }
@@ -35,12 +36,8 @@
   }
 
   @media screen and (min-width: 500px) {
-    & .book_cover img {
+    img.book_cover {
       margin-bottom: 1em;
-    }
-
-    & .book_info {
-      padding-bottom: 1em;
     }
   }
 
@@ -61,7 +58,7 @@
       margin-top: 5px;
     }
 
-    .book_cover img {
+    img.book_cover {
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
There are a couple of unnecessary wrapper &lt;div>'s which can be replaced by targeting the semantic HTML elements. As a bonus, now I can write the review text in Markdown!