### PR TITLE
Remove the 'px' suffix from the 'width' parameter on pictures

### DIFF
--- a/src/_plugins/tag_picture.rb
+++ b/src/_plugins/tag_picture.rb
@@ -117,7 +117,7 @@ module Jekyll
 
       @width = get_required_attribute(
         @attrs, { tag: 'picture', attribute: 'width' }
-      ).gsub('px', '').to_i
+      ).to_i
 
       @parent = @attrs.delete('parent')
 

--- a/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
+++ b/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
@@ -26,7 +26,7 @@ Once a page is archived, it appears with a small grey checkmark next to the link
 {%
   picture
   filename="pinboard_archive.png"
-  width="388px"
+  width="388"
   alt="A Pinboard link with a small grey checkmark next to the link."
   class="screenshot"
 %}
@@ -40,7 +40,7 @@ In the archival account of your Pinboard settings, you can ask for a backup down
 {%
   picture
   filename="archive_backup.png"
-  width="618px"
+  width="618"
   alt="Screenshot of the Pinboard archive backup screen. Titled “Archive Backup” and a “Request a download” button."
   class="screenshot"
 %}

--- a/src/_posts/2020/2020-04-19-complex-failures.md
+++ b/src/_posts/2020/2020-04-19-complex-failures.md
@@ -25,7 +25,7 @@ If you imagine some overlapping pieces of Swiss cheese, the holes have to line u
   {%
     picture
     filename="swiss_cheese.png"
-    width="450px"
+    width="450"
     alt="Four slices of Swiss cheese, with a red arrow passing through a hole in all four layers."
   %}
   <figcaption>

--- a/src/_posts/2020/2020-10-12-the-importance-of-good-error-messages.md
+++ b/src/_posts/2020/2020-10-12-the-importance-of-good-error-messages.md
@@ -17,7 +17,7 @@ This is the message I received:
 {%
   picture
   filename="excel_truncation_error.png"
-  width="526px"
+  width="526"
   alt="An Excel alert dialog that says 'File not loaded completely', with a single 'OK' button."
 %}
 

--- a/src/_posts/2021/2021-04-29-coloured-squares.md
+++ b/src/_posts/2021/2021-04-29-coloured-squares.md
@@ -13,7 +13,7 @@ Last night, I [posted a tweet][tweet] wondering about the different colours of t
 {%
   picture
   filename="emoji.png"
-  width="587px"
+  width="587"
   alt="A collection of different thread emojis, labelled by the platform/company they’re from. There are four red spools on the left, two blue spools on the right, a purple and two pink spools along the top, and a green spool along the bottom."
 %}
 
@@ -26,7 +26,7 @@ I was able to use the script from the end of that post to get a list of suggesti
 {%
   picture
   filename="terminal_without_colours.png"
-  width="587px"
+  width="587"
   alt="A terminal window running a Python script that prints five hex colours."
   style="border-radius: 6px;"
 %}
@@ -41,7 +41,7 @@ I rewrote it in Python, and then I could see the hex code and the colour it repr
 {%
   picture
   filename="terminal_with_colours.png"
-  width="587px"
+  width="587"
   alt="A terminal window running a Python script that prints five hex colours, and a solid block of colour to the left of each code."
   style="border-radius: 6px;"
 %}
@@ -94,7 +94,7 @@ For example, I can use a lower seven-eights block to add a gap between squares, 
 {%
   picture
   filename="terminal_with_coloured_text.png"
-  width="587px"
+  width="587"
   alt="A terminal window running a Python script that prints five hex colours, and a solid block of colour to the left of each code. The hex codes have the same colour as the blocks."
   style="border-radius: 6px;"
 %}

--- a/src/_posts/2022/2022-04-25-lorenz-wheels.md
+++ b/src/_posts/2022/2022-04-25-lorenz-wheels.md
@@ -23,7 +23,7 @@ Here's a close-up photo of two of the wheels:
   {%
     picture
     filename="lorenz_cams.jpg"
-    width="303px"
+    width="303"
     alt="A close-up photo of two metal wheels. The wheels have numbers running around the rim, and next to each number is a small metal switch."
   %}
   <figcaption>

--- a/src/_posts/2022/2022-08-28-blink-diffs.md
+++ b/src/_posts/2022/2022-08-28-blink-diffs.md
@@ -56,7 +56,7 @@ Unfortunately, the built-in Photos app doesn't have a way to do the instant swit
 {%
   picture
   filename="ipad_photos.jpg"
-  width="600px"
+  width="600"
   style="border: 0.5px solid #d4d3d4;"
   alt="Screenshot of the iPad photos app. The photo of the two trams takes up most of the screen, with a toolbar along the top and a carousel of small thumbnails along the bottom. The carousel images are all tall and narrow, and tightly scrunched together."
 %}
@@ -75,7 +75,7 @@ This is what it looks like:
 {%
   picture
   filename="darkroom_photos.jpg"
-  width="600px"
+  width="600"
   alt="Screenshot of the Darkroom photos app. The photo of the two trams takes up most of the screen, with toolbars along the left and right, and a carousel of square thumbnails up the left hand side. The selected thumbnail is shown with a red outline, and the thumbnails are bigger and wider-spaced than in the built-in app."
 %}
 

--- a/src/_posts/2022/2022-10-05-circle-experiments.md
+++ b/src/_posts/2022/2022-10-05-circle-experiments.md
@@ -54,7 +54,7 @@ It's meant to be subtle, but I think it still gives the site a unique look:
 {%
   picture
   filename="header_image.png"
-  width="750px"
+  width="750"
   alt="The site header, which is made of small tiling squares in slightly varying shades of red."
 %}
 

--- a/src/_posts/2022/2022-11-12-tin-anniversary.md
+++ b/src/_posts/2022/2022-11-12-tin-anniversary.md
@@ -36,14 +36,14 @@ This is the oldest screenshot I have of the homepage, compared to how it looks t
   {%
     picture
     filename="homepage_2012.jpg"
-    width="650px"
+    width="650"
     class="screenshot"
     alt="A website with a dark blue stripe across the top, which has my name and some horizontal navigation. Below is a post titled ‘Automatic Pinboard backups’, which goes straight into the post text, and on the right is a sidebar with a list of recent posts."
   %}
   {%
     picture
     filename="homepage_2022.jpg"
-    width="650px"
+    width="650"
     class="screenshot"
     alt="A website with a bright green stripe across the top, with my name and horizontal navigation (albeit different links). Below is a large, colour photo of me in a matching green dress and smiling at the camera, and below that is some introductory text that starts “Hi, I’m Alex”, rather than jumping straight into a blog post."
   %}

--- a/src/_posts/2023/2023-08-19-hester.md
+++ b/src/_posts/2023/2023-08-19-hester.md
@@ -49,7 +49,7 @@ Several of the lines in the song are taken directly from her words. (*"Darling, 
   {%
     picture
     filename="jak-on-stage.jpg"
-    width="270px"
+    width="270"
     alt="A senior officer (Colonel Bevan, played by Zoë Roberts) looks on sceptically at something happening out of shot. Standing next to him, Hester (Jak Malone) stands sternly, her head held down in disapproval."
   %}
   <figcaption>
@@ -97,7 +97,7 @@ I'm told that it now hangs backstage at the Fortune, among other pieces of fan a
 {%
   picture
   filename="a-small-plaque.jpg"
-  width="750px"
+  width="750"
   alt="Some embroidery on blue fabric with a circular frame. There's white text that says “Hester Leggatt / a timeless inspiration / 1905–1995”. I’m holding it in the auditorium of the Fortune Theatre, where the play is being shown – some seats are visible in the background, along with the bright yellow curtain on stage."
 %}
 

--- a/src/_posts/2023/2023-09-19-obsidian-setup.md
+++ b/src/_posts/2023/2023-09-19-obsidian-setup.md
@@ -65,14 +65,14 @@ If I learn something which is generically useful and not specific to my employer
   {%
     picture
     filename="obsidian-personal-theme.png"
-    width="523px"
+    width="523"
     class="screenshot first"
     alt="A screenshot of a note and the top bar in my personal vault. The top bar has a red tint, and the title of the note is a matching shade of red. The note text is in a serif font (Geneva)."
   %}
   {%
     picture
     filename="obsidian-work-theme.png"
-    width="523px"
+    width="523"
     class="screenshot second"
     alt="A screenshot of a note and the top bar in my work vault. The top bar has a yellow tint, but the title of the note is a dark green. The note text is in a sans serif font (Inter)."
   %}
@@ -102,7 +102,7 @@ I use a similar set of colour-based themes to help me distinguish between Slack 
 {%
   picture
   filename="obsidian-tags.png"
-  width="299px"
+  width="299"
   class="screenshot"
   id="obsidian_tags"
   alt="A screenshot of my tag panel in Obsidian. There's a list of tags on the left-hand side, and counts down the right. The first few tags are daily-journal (773), books-ive-read (173), articles-to-write (124) and talks-ive-watched (97). There are also a couple of collapsed tag lists, which indicate prefixes, including 'aws', 'event' and 'python'."

--- a/src/_posts/2023/2023-09-20-fare-wellcome-collection.md
+++ b/src/_posts/2023/2023-09-20-fare-wellcome-collection.md
@@ -15,7 +15,7 @@ We wandered up the Euston Road, popped into the British Library and the British 
   {%
     picture
     filename="reading-room.jpg"
-    width="750px"
+    width="750"
     alt="The Reading Room at Wellcome Collection. A large, brightly-lit room with shelves interspersed with museum objects and comfy chairs."
     class="fullwidth_img"
   %}

--- a/src/_posts/2023/2023-09-24-adding-watch-locations.md
+++ b/src/_posts/2023/2023-09-24-adding-watch-locations.md
@@ -26,7 +26,7 @@ Although my camera doesn't know where I was, I had a walking workout running on 
 {%
   picture
   filename="confused-camera.jpg"
-  width="750px"
+  width="750"
   class="full_width"
   alt="A black Olympus character looking out of a window, with a cartoon thought bubble showing a location pin and a question mark. It’s wondering what GPS and locations are."
 %}
@@ -65,7 +65,7 @@ If I preview one of those files in Quick Look, I can see my walking route shown 
 {%
   picture
   filename="bohinj_gpx.png"
-  width="750px"
+  width="750"
   alt="An outline map of mostly green countryside with a blue lake (Bohinjsko jezero) in the middle. There's a thick green line that goes around the lake, showing my walking route."
 %}
 
@@ -268,7 +268,7 @@ Once this was done, I imported all the files into my Photos Library, and voila: 
 {%
   picture
   filename="photos_on_map.png"
-  width="950px"
+  width="950"
   class="screenshot"
   alt="A map view of Lake Bohinj. Dotted around the map are small markers with a photo and number, showing the number of photos taken at that exact location."
 %}

--- a/src/_posts/2023/2023-09-28-spotting-spam-in-our-cloudfront-logs.md
+++ b/src/_posts/2023/2023-09-28-spotting-spam-in-our-cloudfront-logs.md
@@ -188,7 +188,7 @@ As part of this change, we tweaked the copy on our "no results" page, asking peo
 {%
   picture
   filename="weco_no_results.png"
-  width="750px"
+  width="750"
   alt="Screenshot of a search page with no results. “We couldn’t find anything that matched â\x8f©â\x9c\x94ï\x8fã\x8a. Please adjust your search terms and try again. If you think this search should show some results, please email digital@wellcomecollection.org.”"
 %}
 

--- a/src/_posts/2023/2023-10-20-forgetful-fish.md
+++ b/src/_posts/2023/2023-10-20-forgetful-fish.md
@@ -24,7 +24,7 @@ I can press the right arrow to accept the suggestion, or I can keep typing to ig
 {%
   picture
   filename="fish_autosuggestion.png"
-  width="500px"
+  width="500"
   class="screenshot"
   alt="Screenshot of my terminal, showing three commands. The first is 'mate src/_drafts/forgetful-fish.md' and the second is 'make html'. For the third command, I've typed 'mate', and it’s suggested the filename 'src/_drafts/forgetful-fish.md' based on my first command."
 %}


### PR DESCRIPTION
This is a preliminary bit of refactoring I spotted while looking at #707 – there's no reason to be adding the `px` suffix if it's going to be `gsub`-ed away later, and removing it means I can remove the `gsub`.