### PR TITLE
Start using CSS variables in place of Sass

### DIFF
--- a/src/_includes/contact/emails.html
+++ b/src/_includes/contact/emails.html
@@ -79,7 +79,7 @@
       }
 
       .accent {
-        fill: $body-color-light;
+        fill: var(--body-text);
       }
     }
   }

--- a/src/_includes/contact/emails.html
+++ b/src/_includes/contact/emails.html
@@ -9,7 +9,7 @@
 
     display: grid;
     grid-template-columns: auto auto;
-    grid-gap: $default-grid-gap;
+    grid-gap: $grid-gap;
   }
 
   @media screen and (max-width: 650px) {

--- a/src/_includes/contact/socials.html
+++ b/src/_includes/contact/socials.html
@@ -9,7 +9,7 @@
 
     display: grid;
     grid-template-columns: auto auto auto;
-    grid-gap: $default-grid-gap;
+    grid-gap: $grid-gap;
 
     @media screen and (max-width: 500px) {
       grid-template-columns: auto;

--- a/src/_posts/2022/2022-02-19-two-twitter-cards.md
+++ b/src/_posts/2022/2022-02-19-two-twitter-cards.md
@@ -59,7 +59,7 @@ This can give some unfortunate results:
     #images {
       display: grid;
       grid-template-columns: auto auto;
-      grid-gap: $default-grid-gap;
+      grid-gap: $grid-gap;
 
       img {
         display: inline-block;

--- a/src/_posts/2023/2023-01-15-check-for-transparency.md
+++ b/src/_posts/2023/2023-01-15-check-for-transparency.md
@@ -70,7 +70,7 @@ I had it all tested and working, so imagine my dismay when I opened [my latest p
     display: grid;
     grid-template-columns: auto auto;
     width: 600px;
-    grid-column-gap: $default-grid-gap;
+    grid-column-gap: $grid-gap;
 
     picture:nth-child(1) img {
       border-top-right-radius: 0;

--- a/src/_posts/2023/2023-01-15-check-for-transparency.md
+++ b/src/_posts/2023/2023-01-15-check-for-transparency.md
@@ -12,34 +12,6 @@ colors:
   css_dark:  "#cccccc"
 ---
 
-<style type="x-text/scss">
-  #avif_comparison {
-    display: grid;
-    grid-template-columns: auto auto;
-    width: 600px;
-    grid-column-gap: $grid-gap;
-
-    picture:nth-child(1) img {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-      grid-row: 1 / 2;
-      grid-column: 1 / 2;
-    }
-
-    picture:nth-child(2) img {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-      grid-row: 1 / 2;
-      grid-column: 2 / 2;
-    }
-
-    figcaption {
-      grid-row: 2 / 2;
-      grid-column: 1 / span 2;
-    }
-  }
-</style>
-
 One of the things I did over my Christmas break was redo all the image handling on this site.
 Mostly I'm catching up on the current "best practices" for images on the web.
 I've written a [Jekyll plugin][plugin] which allows me to use an image in a post like so:
@@ -65,7 +37,7 @@ When I first enabled AVIF support, I thought I'd broken something, because a 5x 
 
 I had it all tested and working, so imagine my dismay when I opened [my latest post]({% post_url 2023/2023-01-13-upward-assignment %}) on my phone and discovered the images were broken:
 
-<style text="x-text/scss">
+<style type="x-text/scss">
   #avif_comparison {
     display: grid;
     grid-template-columns: auto auto;

--- a/src/_posts/2023/2023-09-19-obsidian-setup.md
+++ b/src/_posts/2023/2023-09-19-obsidian-setup.md
@@ -43,7 +43,7 @@ If I learn something which is generically useful and not specific to my employer
   #screenshots {
     display: grid;
     grid-template-columns: auto;
-    grid-gap: $default-grid-gap;
+    grid-gap: $grid-gap;
 
     /* This feels like it should be possible using the :nth-child selector,
      * but I couldn't get it working

--- a/src/_posts/2024/2024-01-07-best-age-picker.md
+++ b/src/_posts/2024/2024-01-07-best-age-picker.md
@@ -234,7 +234,7 @@ This is what I came up with:
   #two_columns {
     display: grid;
     grid-template-columns: 2fr 1fr;
-    grid-gap: $default-grid-gap;
+    grid-gap: $grid-gap;
     align-items: center;
   }
 </style>

--- a/src/_scss/_settings.scss
+++ b/src/_scss/_settings.scss
@@ -9,5 +9,3 @@ $meta-size: 0.82;
 $meta-font-size:   $meta-size * $default-font-size;
 $meta-line-height: $meta-size * $line-height * 1.15;
 
-$max-width:       750px !default;
-$default-padding: 20px !default;

--- a/src/_scss/_settings.scss
+++ b/src/_scss/_settings.scss
@@ -1,11 +1,2 @@
 $primary-color-light: #d01c11 !default;
 $primary-color-dark:  #d01c11 !default;
-$primary-dark:  darken($primary-color-light, 15%);
-
-$default-font-size: 1em;
-$line-height:       1.5em;
-
-$meta-size: 0.82;
-$meta-font-size:   $meta-size * $default-font-size;
-$meta-line-height: $meta-size * $line-height * 1.15;
-

--- a/src/_scss/_settings.scss
+++ b/src/_scss/_settings.scss
@@ -2,10 +2,6 @@ $primary-color-light: #d01c11 !default;
 $primary-color-dark:  #d01c11 !default;
 $primary-dark:  darken($primary-color-light, 15%);
 
-$midtone-gray: #ccc;
-
-//$primary-green: #0c9718;
-
 $default-font-size: 1em;
 $line-height:       1.5em;
 

--- a/src/_scss/_settings.scss
+++ b/src/_scss/_settings.scss
@@ -11,5 +11,3 @@ $meta-line-height: $meta-size * $line-height * 1.15;
 
 $max-width:       750px !default;
 $default-padding: 20px !default;
-
-$default-grid-gap: 10px;

--- a/src/_scss/base/layout.scss
+++ b/src/_scss/base/layout.scss
@@ -19,8 +19,6 @@ body {
   }
 }
 
-
-
 main, #footer_inner, #nav_inner, #editing-toolbar_inner, #subscribe form {
   max-width: $max-width;
   padding-left:  calc(#{$default-padding} + env(safe-area-inset-left));
@@ -86,19 +84,7 @@ article, main {
   }
 }
 
-svg[role="separator"] {
-  display: block;
-  margin: 3.5em auto;
 
-
-  & + h2 {
-    margin-top: 0;
-  }
-
-  rect {
-    fill: $midtone-grey-light;
-  }
-}
 
 img.screenshot {
   border-color: #f0f0f0;
@@ -116,10 +102,6 @@ img.screenshot {
     /* Pattern from https://www.toptal.com/designers/subtlepatterns/white-waves-pattern/,
        then contrast dropped and colours flipped. */
     background-image: url('/theme/black-waves-transparent.png');
-  }
-
-  svg[role="separator"] rect {
-    fill: $body-color-dark;
   }
 
   img.screenshot {

--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -4,7 +4,7 @@ body {
 }
 
 body, .post_cards .card a .card_description {
-  color: $body-color-light;
+  color: var(--body-text);
 }
 
 h1, h2, h3, p.card_title {
@@ -114,10 +114,6 @@ sup {
 }
 
 @media (prefers-color-scheme: dark) {
-  body, .post_cards .card a .card_description {
-    color: $body-color-dark;
-  }
-
   .post_cards .card .card_posting_date p,
   .title.linkpost_title::after {
     color: $accent-grey-dark;

--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -99,34 +99,16 @@ sup {
 
 .post_cards .card .card_posting_date p,
 .title.linkpost_title::after {
-  color: $accent-grey-light;
+  color: var(--accent-grey);
 }
 
 .meta, figcaption {
-  color: $accent-grey-light;
+  color: var(--accent-grey);
 
   a, a:visited {
-    color: $accent-grey-light !important;
+    color: var(--accent-grey) !important;
     &:hover {
-      background: rgba($accent-grey-light, 0.2) !important;
-    }
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .post_cards .card .card_posting_date p,
-  .title.linkpost_title::after {
-    color: $accent-grey-dark;
-  }
-
-  .meta, figcaption {
-    color: $accent-grey-dark;
-
-    a, a:visited {
-      color: $accent-grey-dark !important;
-      &:hover {
-        background: rgba($accent-grey-dark, 0.2) !important;
-      }
+      background: var(--accent-grey-link-hover) !important;
     }
   }
 }

--- a/src/_scss/components/pretty_hr.scss
+++ b/src/_scss/components/pretty_hr.scss
@@ -1,0 +1,23 @@
+/* Styles for the "pretty hr", a line of squares I use in place of an <hr/>. */
+
+svg[role="separator"] {
+  display: block;
+  margin: 3.5em auto;
+
+  & + h2 {
+    margin-top: 0;
+  }
+
+  /* In light mode, these squares are lighter than the text.
+   * In dark mode, they're the same colour.
+   */
+  --fill-color: #{$midtone-grey-light};
+
+  @media (prefers-color-scheme: dark) {
+    --fill-color: var(--body-text);
+  }
+
+  rect {
+    fill: var(--fill-color);
+  }
+}

--- a/src/_scss/components/pretty_hr.scss
+++ b/src/_scss/components/pretty_hr.scss
@@ -11,7 +11,7 @@ svg[role="separator"] {
   /* In light mode, these squares are lighter than the text.
    * In dark mode, they're the same colour.
    */
-  --fill-color: #{$midtone-grey-light};
+  --fill-color: #ccc;
 
   @media (prefers-color-scheme: dark) {
     --fill-color: var(--body-text);

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -22,18 +22,21 @@ $border-radius: 10px;
 $border-style: solid;
 $border-width: 3px;
 
+$accent-grey-light: #999;
+$accent-grey-dark:  #999;
+
 :root {
-  --body-text: #202020;
+  --body-text:   #202020;
+
+  --accent-grey:            #{$accent-grey-light};
+  --accent-grey-link-hover: #{rgba($accent-grey-light, 0.2)};
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --body-text: #c7c7c7;
+    --body-text:   #c7c7c7;
+
+    --accent-grey:            #{$accent-grey-dark};
+    --accent-grey-link-hover: #{rgba($accent-grey-dark, 0.2)};
   }
 }
-
-$accent-grey-light: #999;
-$accent-grey-dark:  #878787;
-
-$midtone-grey-dark:  #333;
-$midtone-grey-light: #ccc;

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -22,8 +22,15 @@ $border-radius: 10px;
 $border-style: solid;
 $border-width: 3px;
 
-$body-color-light: #202020;
-$body-color-dark:  #c7c7c7;
+:root {
+  --body-text: #202020;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --body-text: #c7c7c7;
+  }
+}
 
 $accent-grey-light: #999;
 $accent-grey-dark:  #878787;

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -19,6 +19,8 @@
 @import "base/pygments.scss";
 @import "base/tweets.scss";
 
+@import "components/pretty_hr.scss";
+
 // This is for the "Skip to main content" link at the top of the page
 //
 // See https://accessibility.oit.ncsu.edu/it-accessibility-at-nc-state/developers/accessibility-handbook/mouse-and-keyboard-events/skip-to-main-content/
@@ -59,14 +61,14 @@ a.download {
   }
 
   .post_cards .card .card_posting_date p {
-    color: $body-color-light;
+    color: var(--body-text);
   }
 
   .meta, figcaption {
-    color: $body-color-light;
+    color: var(--body-text);
 
     a {
-      color: $body-color-light;
+      color: var(--body-text);
     }
   }
 }


### PR DESCRIPTION
My Sass is a bit of a mess: I support custom colours per page, plus dark mode, plus a bunch of complexity I've built around the Sass preprocessor. The result is that it's hard to find where CSS stuff is defined and it's often split across multiple files. Yuck!

It's 2024. CSS variables are in [97.47% of browsers](https://caniuse.com/css-variables). They make a lot of this stuff much easier, so I should use them. (And if you're running a super old browser, you'll get the default colours and/or sans-CSS styling, which should still be fine, given I'm using a lot of semantic HTML.)

This patch takes the first step in that direction:

* It moves some of the global colours into CSS variables
* It introduces a `components` namespace for SCSS files, to make stuff easier to find
* It starts to consolidate `_settings.scss`/`variables.scss`, which is a remnant of a long-ago refactor

For #741