### PR TITLE
Move all the Sass layout variables into CSS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,16 @@ liquid:
   # (e.g. I don't want to set an empty `nav_section: ""` for every page
   # which doesn't belong to a section).
 
+# =============================
+# jekyll-sass-converter options
+# =============================
+#
+# See https://github.com/jekyll/jekyll-sass-converter
+
+sass:
+  sass_dir: "_scss"
+  style: "compressed"
+
 # ==================
 # Template variables
 # ==================
@@ -95,7 +105,3 @@ highlighter: "rouge"
 
 plugins:
   - "jekyll-include-cache"
-
-sass:
-  sass_dir: "_scss"
-  style: "compressed"

--- a/src/_scss/base/code.scss
+++ b/src/_scss/base/code.scss
@@ -12,7 +12,7 @@ pre code {
 code {
   margin: 2px;
   border-radius: 3px;
-  font-size: 1em * $code-scaling-factor;
+  font-size: calc(1em * var(--code-scaling-factor));
 }
 
 // Disable selecting the $ or the following space in ``console`` code blocks.
@@ -28,7 +28,7 @@ pre {
     calc(2 * var(--default-padding) / 3)
     calc(var(--default-padding) - var(--border-width));
 
-  line-height: $default-line-height * $code-scaling-factor * 1.08;
+  line-height: calc(var(--line-height) * var(--code-scaling-factor) * 1.08);
 
   // This ensures that code blocks don't get blown up to big sizes
   // on iPhone displays.

--- a/src/_scss/base/code.scss
+++ b/src/_scss/base/code.scss
@@ -1,7 +1,5 @@
-@use "sass:math";
-
 code, pre {
-  font-family: $mono-font-family;
+  font-family: var(--mono-font-family);
   overflow-x: auto;
 }
 

--- a/src/_scss/base/footer.scss
+++ b/src/_scss/base/footer.scss
@@ -5,11 +5,11 @@ footer {
 
 #footer_inner {
   p:not(:last-child) {
-    margin-bottom: $meta-size * 1em;
+    margin-bottom: calc(var(--meta-scaling-factor) * 1em);
   }
 
   p:not(:first-child) {
-    margin-top: $meta-size * 1em;
+    margin-top:    calc(var(--meta-scaling-factor) * 1em);
   }
 
   display: grid;

--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -48,8 +48,8 @@ sup {
 }
 
 .meta, figcaption, footer {
-  font-size:   $meta-font-size;
-  line-height: $meta-line-height;
+  font-size:   calc(var(--font-size)   * var(--meta-scaling-factor));
+  line-height: calc(var(--line-height) * var(--meta-scaling-factor) * 1.15);
 }
 
 .footnotes {

--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -53,8 +53,8 @@ sup {
 }
 
 .footnotes {
-  font-size:   $default-font-size   * $scaling-factor;
-  line-height: $default-line-height * $scaling-factor;
+  font-size:   calc(var(--font-size)   * var(--footnote-scaling-factor));
+  line-height: calc(var(--line-height) * var(--footnote-scaling-factor));
 }
 
 .title {

--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -1,6 +1,6 @@
 body {
-  font: 13pt $main-font-family;
-  line-height: $default-line-height;
+  font: 13pt var(--text-font-family);
+  line-height: var(--line-height);
 }
 
 body, .post_cards .card a .card_description {

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -1,16 +1,13 @@
-$main-font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
-$mono-font-family: Menlo, Consolas, monospace;
-
-$default-font-size:   1em;
-$default-line-height: 1.5em;
-
 :root {
   /* ====================
    * Font and text styles
    * ==================== */
-  --font-size: #{$default-font-size};
+  --text-font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
+  --mono-font-family: Menlo, Consolas, monospace;
 
-  --line-height: #{$default-line-height};
+  --font-size: 1em;
+
+  --line-height: 1.5em;
 
   --meta-scaling-factor:     0.82;
   --footnote-scaling-factor: 0.95;

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -1,13 +1,8 @@
 $main-font-family: Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
 $mono-font-family: Menlo, Consolas, monospace;
 
-$meta-size:           0.82;
-
 $default-font-size:   1em;
-$meta-font-size:      $meta-size * $default-font-size;
-
 $default-line-height: 1.5em;
-$meta-line-height:    $meta-size * $default-line-height * 1.15;
 
 :root {
   /* ====================
@@ -17,6 +12,7 @@ $meta-line-height:    $meta-size * $default-line-height * 1.15;
 
   --line-height: #{$default-line-height};
 
+  --meta-scaling-factor:     0.82;
   --footnote-scaling-factor: 0.95;
   --code-scaling-factor:     0.88;
 

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -27,7 +27,9 @@
   --border-width:  3px;
 }
 
-/* Variables for colours */
+/* =====================================
+ * Colours which are the same everywhere
+ * ===================================== */
 
 $accent-grey-light: #999;
 $accent-grey-dark:  #999;

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -9,10 +9,20 @@ $meta-font-size:      $meta-size * $default-font-size;
 $default-line-height: 1.5em;
 $meta-line-height:    $meta-size * $default-line-height * 1.15;
 
-$scaling-factor:      0.95;
-$code-scaling-factor: 0.88;
-
 :root {
+  /* ====================
+   * Font and text styles
+   * ==================== */
+  --font-size: #{$default-font-size};
+
+  --line-height: #{$default-line-height};
+
+  --footnote-scaling-factor: 0.95;
+  --code-scaling-factor:     0.88;
+
+  /* =============================
+   * Margins and page layout stuff
+   * ============================= */
   --max-width: 750px;
 
   --grid-gap: 10px;


### PR DESCRIPTION
This gets rid of the worst of the Sass variable interpolation and replaces it with a lot of vanilla CSS. Yay!

For #741