### PR TITLE
Replace the {% post_url %} tag with hard-coded URLs

### DIFF
--- a/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
+++ b/src/_posts/2013/2013-08-06-untagged-tumblr-posts.md
@@ -82,7 +82,7 @@ Once that's done, you just run the Python script (if you haven't done that befor
 
   You'll still need to use this method if you have a private blog, but anybody else should check out the new way.
 
-  [redux]: {% post_url 2014/2014-06-13-untagged-tumblr-posts-redux %}
+  [redux]: /2014/untagged-tumblr-posts-redux/
 {% endupdate %}
 
 {% update 2015-08-02 %}

--- a/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
+++ b/src/_posts/2014/2014-06-13-untagged-tumblr-posts-redux.md
@@ -43,6 +43,6 @@ Mathmo is written with the AngularJS framework, and since that was the last time
 
 All of the source code is in [a GitHub repo][github], and the site itself is hosted (like this one) with GitHub Pages.
 
-[original_post]: {% post_url 2013/2013-08-06-untagged-tumblr-posts %}
+[original_post]: /2013/untagged-tumblr-posts/
 [privacy]: http://finduntaggedtumblrposts.com/privacy/
 [github]: https://github.com/alexwlchan/untagged-tumblr-posts

--- a/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
+++ b/src/_posts/2014/2014-12-06-skeletors-all-the-way-down.md
@@ -13,5 +13,5 @@ He's made an interactive chart which shows not only which episodes featured Skel
 
 And now, if you'll excuse me, I have to indulge in some Skeletor nostalgia.
 
-[me]: {% post_url 2014/2014-06-29-skeletor %}
+[me]: /2014/skeletor/
 [panel]: http://gouwens.net/people-of-the-incomparable

--- a/src/_posts/2015/2015-02-12-lists.md
+++ b/src/_posts/2015/2015-02-12-lists.md
@@ -37,7 +37,7 @@ I've given this light testing on the latest versions of Safari and Chrome on OS 
 
 ## How it works
 
-I've done [something very similar before]({% post_url 2013/2013-08-20-google-maps %}). We use JavaScript to get all the UL and OL elements, then apply the appropriate collection of styles to create the effect we want.
+I've done [something very similar before](/2013/google-maps/). We use JavaScript to get all the UL and OL elements, then apply the appropriate collection of styles to create the effect we want.
 
 First we get a collection of all the UL and OL elements on the page.
 

--- a/src/_posts/2015/2015-03-29-exam-advice.md
+++ b/src/_posts/2015/2015-03-29-exam-advice.md
@@ -8,7 +8,7 @@ tags:
 title: Some exam advice
 ---
 
-As the exam season approaches, I see a gentle trickle of hits to my [exam advice]({% post_url 2014/2014-05-14-part-ia-exams %}) for first-year maths students. It's been a year since I wrote it, and I still agree with almost all of it.
+As the exam season approaches, I see a gentle trickle of hits to my [exam advice](/2014/part-ia-exams/) for first-year maths students. It's been a year since I wrote it, and I still agree with almost all of it.
 
 Looking it over, I think a lot of it is applicable to other technical subjects, so I've tidied it up and tried to make the advice a little less maths-specific. Rather than letting it get lost in my blog archives, I've also given it a new, permanent page.
 

--- a/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
+++ b/src/_posts/2015/2015-08-19-untagged-tumblr-v2.md
@@ -8,7 +8,7 @@ tags:
 title: Finding even more untagged posts on Tumblr
 ---
 
-When I wrote [my original script]({% post_url 2013/2013-08-06-untagged-tumblr-posts %}) for finding untagged Tumblr posts, I expected it to be a one-off. I never expected to write [a dedicated site]({% post_url 2014/2014-06-13-untagged-tumblr-posts-redux %}), or for that site to become the most popular thing I've ever made. I've been flattered by some of the emails and tweets I've received about the site.
+When I wrote [my original script](/2013/untagged-tumblr-posts/) for finding untagged Tumblr posts, I expected it to be a one-off. I never expected to write [a dedicated site](/2014/untagged-tumblr-posts-redux/), or for that site to become the most popular thing I've ever made. I've been flattered by some of the emails and tweets I've received about the site.
 
 But I've also been letting it stagnate. I've been putting off a steady trickle of bug reports and feature requests, and the site was getting rough around the edges. On Monday, I inadvertently broke the site completely with some changes on the blog, so I decided that it was finally time to fix it.
 

--- a/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
+++ b/src/_posts/2016/2016-04-16-hiding-the-youtube-search-bar.md
@@ -14,7 +14,7 @@ This morning, I got an email from Sam, asking if I had a way to cover up the per
 
 <img src="/images/2016/youtube-search.png" style="border: 1px solid #ddd;" alt="The search bar at the top of YouTube.">
 
-Three years ago, I wrote a bookmarklet [for cleaning up the worst of the Google Maps interface]({% post_url 2013/2013-08-20-google-maps %}), and we can adapt this to clean up YouTube as well.
+Three years ago, I wrote a bookmarklet [for cleaning up the worst of the Google Maps interface](/2013/google-maps/), and we can adapt this to clean up YouTube as well.
 Unlike that post, this is one I'm likely to use myself.
 (Writing the Maps bookmarklet was a fun exercise in JavaScript, but I almost always use Google Maps on my phone, so I was never as annoyed by the clutter on the desktop version.)
 

--- a/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
+++ b/src/_posts/2016/2016-05-16-finding-404s-in-apache-logs.md
@@ -124,5 +124,5 @@ But it's useful to have in my back pocket for a rainy day.
 
 [drang]: https://leancrew.com/all-this/2013/07/parsing-my-apache-logs/
 [github]: https://github.com/alexwlchan/apache-utils
-[404help]: {% post_url 2014/2014-09-14-404-pages %}
+[404help]: /2014/404-pages/
 [ctr]: https://docs.python.org/3.5/library/collections.html?highlight=collections.counter

--- a/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
+++ b/src/_posts/2016/2016-06-16-reading-web-pages-on-my-kindle.md
@@ -159,6 +159,6 @@ If you've got a Kindle, I'd recommend trying something like this.
 [apidocs]: https://www.instaparser.com/docs/1/article_api
 [docs]: http://www.amazon.com/gp/help/customer/display.html/ref=hp_pdoc_main_short_us?nodeId=200767340
 [tempfile]: https://docs.python.org/3.5/library/tempfile.html
-[fastmail]: {% post_url 2016/2016-05-10-python-smtplib-and-fastmail %}
+[fastmail]: /2016/python-smtplib-and-fastmail/
 [pythonista]: http://omz-software.com/pythonista/
 [appex]: http://omz-software.com/pythonista/docs/ios/appex.html

--- a/src/_posts/2016/2016-08-07-clean-up-directories.md
+++ b/src/_posts/2016/2016-08-07-clean-up-directories.md
@@ -7,7 +7,7 @@ tags:
   - python
 ---
 
-Last month, I wrote about [some tools]({% post_url 2016/2016-07-04-clearing-disk-space-on-os-x %}) I'd been using to clear disk space on my Mac.
+Last month, I wrote about [some tools](/2016/clearing-disk-space-on-os-x/) I'd been using to clear disk space on my Mac.
 I've been continuing to clean up my mess of files and folders as I try to simplify my hard drive, and there are two new scripts I've been using to help me.
 Neither is particularly complicated, but I thought they were worth writing up properly.
 

--- a/src/_posts/2016/2016-09-14-pyconuk2016.md
+++ b/src/_posts/2016/2016-09-14-pyconuk2016.md
@@ -12,7 +12,7 @@ index:
 ---
 
 This is a presentation I gave at [PyCon&nbsp;UK&nbsp;2016](http://2016.pyconuk.org).
-This is a refined version of a talk I gave [at CamPUG]({% post_url 2016/2016-06-07-hypothesis-intro %}) in June.
+This is a refined version of a talk I gave [at CamPUG](/2016/hypothesis-intro/) in June.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/fhFXg2f9D2A" frameborder="0" allowfullscreen></iframe>
 

--- a/src/_posts/2016/2016-09-19-silence-is-golden.md
+++ b/src/_posts/2016/2016-09-19-silence-is-golden.md
@@ -12,7 +12,7 @@ tags:
 As I write this, it's the last day of [PyCon UK](http://2016.pyconuk.org/).
 The air is buzzing with the sound of [sprints](http://2016.pyconuk.org/what-are-sprints/) and productivity.
 I'll write a blog post about everything that happened at PyCon later (spoiler: I've had a great time), but right now I'd like to write about one specific feature – an idea I'd love to see at every conference.
-I've already talked about [live captioning]({% post_url 2016/2016-09-17-speech-to-text %}) – now let's talk about quiet rooms.
+I've already talked about [live captioning](/2016/speech-to-text/) – now let's talk about quiet rooms.
 
 I'm an introvert.
 Don't get me wrong: I enjoy socialising at conferences and meetups.

--- a/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
+++ b/src/_posts/2016/2016-10-22-wallpapers-with-pillow.md
@@ -13,7 +13,7 @@ colors:
   index_dark:  "#ffd20b"
 ---
 
-In my [last post]({% post_url 2016/2016-10-21-tiling-the-plane-with-pillow %}), I explained how I'd been using Pillow to draw regular tilings of the plane.
+In my [last post](/2016/tiling-the-plane-with-pillow/), I explained how I'd been using Pillow to draw regular tilings of the plane.
 What I was actually trying to do was get some new desktop wallpapers, and getting to use a new Python library was just a nice bonus.
 
 A while back, the [Code Review Stack Exchange](http://codereview.stackexchange.com) got a fresh design that featured, among other things, a low-contrast background of coloured squares:

--- a/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
+++ b/src/_posts/2017/2017-01-14-experiments-with-ao3-and-python.md
@@ -21,4 +21,4 @@ Instructions are in the README, and you can install it from PyPI (`pip install a
 I'm not actively working on this (I have what I need for now), but this code might be useful for somebody else.
 Enjoy!
 
-[previous]: {% post_url 2017/2017-01-07-scrape-logged-in-ao3 %}
+[previous]: /2017/scrape-logged-in-ao3/

--- a/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
+++ b/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
@@ -54,7 +54,7 @@ All the bathrooms at AlterConf are gender-neutral, and it's a staple of the conf
 
 I've written about [the value of quiet rooms][quiet] before, and it was good to have one at AlterConf. Personally I found the venue (the King offices) to be a bit loud and crowded at times, and having a space to relax and recharge was essential.
 
-[quiet]: {% post_url 2016/2016-09-19-silence-is-golden %}
+[quiet]: /2016/silence-is-golden/
 
 ### Live captioning and BSL interpreters
 
@@ -62,7 +62,7 @@ I wrote [about live captioning][sttr] at PyCon UK, and I was unsurprised to see 
 
 Alongside the live captioning, we had a pair of BSL interpreters. Both excellent provisions for attendees who are hard of hearing, or really anyone who just drifts off for a moment.
 
-[sttr]: {% post_url 2016/2016-09-17-speech-to-text %}
+[sttr]: /2016/speech-to-text/
 
 ### Ticket pricing
 

--- a/src/_posts/2017/2017-07-18-listing-s3-keys.md
+++ b/src/_posts/2017/2017-07-18-listing-s3-keys.md
@@ -11,7 +11,7 @@ title: Listing keys in an S3 bucket with Python
 
 {% update 2019-07-03 %}
   In the two years since I wrote this post, I've fixed a couple of bugs, made the code more efficient, and started using [paginators](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) to make it simpler.
-  If you want to use it, I'd recommend using the [updated version]({% post_url 2019/2019-07-03-listing-s3-keys %}).
+  If you want to use it, I'd recommend using the [updated version](/2019/listing-s3-keys/).
 {% endupdate %}
 
 A lot of my recent work has involved batch processing on files stored in Amazon S3.
@@ -225,7 +225,7 @@ Although S3 isn't actually a traditional filesystem, it behaves in very similar 
 
 {% update 2019-07-03 %}
   In the two years since I wrote this post, I've fixed a couple of bugs, made the code more efficient, and started using [paginators](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) to make it simpler.
-  If you want to use it, I'd recommend using the [updated version]({% post_url 2019/2019-07-03-listing-s3-keys %}).
+  If you want to use it, I'd recommend using the [updated version](/2019/listing-s3-keys/).
 {% endupdate %}
 
 [boto3]: https://github.com/boto/boto3

--- a/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
+++ b/src/_posts/2017/2017-07-31-backing-up-pinboard-archives.md
@@ -11,7 +11,7 @@ title: Backing up full-page archives from Pinboard
 Several years ago, I blogged about [a Python script][python] I'd written to back up my Pinboard bookmarks.
 I've been using Pinboard since then -- a brief homebrew solution aside -- and recently, I wanted to turn my attention to my archival account.
 
-[python]: {% post_url 2013/2013-03-31-pinboard-backups %}
+[python]: /2013/pinboard-backups/
 
 As well as storing a list of pages you've saved, you can pay [a small annual fee][upgrade] and Pinboard will save a complete copy of the pages you bookmark.
 This helps keep your bookmarks useful in the face of link rot -- when pages change, or even disappear completely.

--- a/src/_posts/2017/2017-10-27-pyconuk-2017-resources.md
+++ b/src/_posts/2017/2017-10-27-pyconuk-2017-resources.md
@@ -10,12 +10,12 @@ index:
 This post is a signpost to useful resources for my PyCon UK talks/workshops.
 I'll update it as I post new resources/links.
 
-*   Talk: [**Using privilege to improve inclusion**]({% post_url 2017/2017-11-03-pyconuk-2017-privilege-inclusion %}), Friday at 10:30
+*   Talk: [**Using privilege to improve inclusion**](/2017/pyconuk-2017-privilege-inclusion/), Friday at 10:30
 
     I've posted my slides and notes.
     The official video isn't available yet, but I'll post a link on that page when it's up.
 
-*   Workshop: [**A plumber's guide to Git**]({% post_url 2017/2017-11-09-a-plumbers-guide-to-git %}), Friday at 14:30
+*   Workshop: [**A plumber's guide to Git**](/2017/a-plumbers-guide-to-git/), Friday at 14:30
 
     I've posted my exercises and cheat sheet, and the Git Book is a good reference if you want to work through the exercises at home.
 

--- a/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
+++ b/src/_posts/2017/2017-11-22-fetching-cloudwatch-logs.md
@@ -174,7 +174,7 @@ $ python3 print_log_events.py platform/catalogue_api > catalogue_api.log
 This gives us a script that can download all the logs, and get them from any log group we have access to.
 
 [docopt]: http://docopt.org/
-[before]: {% post_url 2017/2017-09-11-ode-to-docopt %}
+[before]: /2017/ode-to-docopt/
 
 ## Filtering by date
 

--- a/src/_posts/2018/2018-01-20-listing-s3-keys-redux.md
+++ b/src/_posts/2018/2018-01-20-listing-s3-keys-redux.md
@@ -11,10 +11,10 @@ title: Listing keys in an S3 bucket with Python, redux
 
 {% update 2019-07-03 %}
   In the two years since I wrote this post, I've fixed a couple of bugs, made the code more efficient, and started using [paginators](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) to make it simpler.
-  If you want to use it, I'd recommend using the [updated version]({% post_url 2019/2019-07-03-listing-s3-keys %}).
+  If you want to use it, I'd recommend using the [updated version](/2019/listing-s3-keys/).
 {% endupdate %}
 
-A few months ago, I wrote about some code for [listing keys in an S3 bucket]({% post_url 2017/2017-07-18-listing-s3-keys %}).
+A few months ago, I wrote about some code for [listing keys in an S3 bucket](/2017/listing-s3-keys/).
 I've been running variants of that code in production since then, and found a pair of mistakes in the original version.
 
 Specifically:
@@ -189,5 +189,5 @@ You can download [a zip file](/files/2018/matching_s3_objects.zip) with both the
 
 {% update 2019-07-03 %}
   In the two years since I wrote this post, I've fixed a couple of bugs, made the code more efficient, and started using [paginators](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html) to make it simpler.
-  If you want to use it, I'd recommend using the [updated version]({% post_url 2019/2019-07-03-listing-s3-keys %}).
+  If you want to use it, I'd recommend using the [updated version](/2019/listing-s3-keys/).
 {% endupdate %}

--- a/src/_posts/2018/2018-04-18-anti-social-media.md
+++ b/src/_posts/2018/2018-04-18-anti-social-media.md
@@ -38,7 +38,7 @@ The PDF slides are the most up-to-date, and I'll try to go back and update the i
 
 <em><strong>Content warning:</strong> this talk includes discussion of online harassment, misogyny, racism, suicide, domestic abuse, police violence, sexual violence and assault, rape threats and death threats.</em>
 
-[pycon]: {% post_url 2017/2017-11-03-pyconuk-2017-privilege-inclusion %}
+[pycon]: /2017/pyconuk-2017-privilege-inclusion/
 
 <!-----
 

--- a/src/_posts/2018/2018-07-19-leaking-my-ssh-keys.md
+++ b/src/_posts/2018/2018-07-19-leaking-my-ssh-keys.md
@@ -78,4 +78,4 @@ Best I can hope is that I'll be similarly lucky, and whatever it is won't be an 
 [autoflake]: https://pypi.org/project/autoflake/
 [traviszip]: https://docs.travis-ci.com/user/encrypting-files/
 [tf_key]: https://www.terraform.io/docs/providers/github/r/repository_deploy_key.html
-[subprocess]: {% post_url 2018/2018-05-04-beware-logged-errors %}
+[subprocess]: /2018/beware-logged-errors/

--- a/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
+++ b/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
@@ -128,5 +128,5 @@ We haven't found a definite cause yet, but we're a lot closer than we were befor
 [session]: http://docs.python-requests.org/en/master/user/advanced/#session-objects
 [headers]: https://developer.travis-ci.com/gettingstarted
 [client]: https://developer.travis-ci.com/authentication
-[hooks]: {% post_url 2017/2017-10-20-requests-hooks %}
+[hooks]: /2017/requests-hooks/
 [builds]: https://developer.travis-ci.com/resource/builds#Builds

--- a/src/_posts/2018/2018-08-13-inclusive-conferences.md
+++ b/src/_posts/2018/2018-08-13-inclusive-conferences.md
@@ -281,7 +281,7 @@ Give people a space to take a break away from the bustle of the conference.
 
 Networking and socialising is an important part of conferences, but it tires a lot of people out.
 Have a clearly-marked, designated space where people can sit quietly, not talk to anybody, and recover some of their energy.
-I wrote [about the quiet room at PyCon UK]({% post_url 2016/2016-09-19-silence-is-golden %}) in 2016, and sitting in the quiet room is how I've got through a number of other conferences.
+I wrote [about the quiet room at PyCon UK](/2016/silence-is-golden/) in 2016, and sitting in the quiet room is how I've got through a number of other conferences.
 
 <figure>
   {%
@@ -376,7 +376,7 @@ I expect we'll run the same process this year.
 
 [lightning]: https://en.wikipedia.org/wiki/Lightning_talk
 [pycon]: https://us.pycon.org/2018/schedule/talks/
-[lottery]: {% post_url 2017/2017-10-28-lightning-talks %}
+[lottery]: /2017/lightning-talks/
 
 <figure>
   {%
@@ -537,7 +537,7 @@ They can be programmed into the stenographer's keyboards, so you get more accura
 I first saw this [at PyCon UK 2016][sttr], but I've also seen it at AlterConf and Coed:Ethics, and heard of it at other conferences.
 
 [sttr]: https://en.wikipedia.org/wiki/Speech-to-text_reporter
-[sttr]: {% post_url 2016/2016-09-17-speech-to-text %}
+[sttr]: /2016/speech-to-text/
 
 <figure>
   {%

--- a/src/_posts/2018/2018-08-26-maps-for-pyconuk.md
+++ b/src/_posts/2018/2018-08-26-maps-for-pyconuk.md
@@ -35,7 +35,7 @@ A good internal map helps people find their way around an unfamiliar venue, and 
 Chloe runs the registration desk, and I think she spent half of last year's conference giving out directions.
 A map can also translate between venue room names and conference terminology, which don't always match.
 
-[conf]: {% post_url 2018/2018-08-13-inclusive-conferences %}#clear-internal-signage
+[conf]: /2018/inclusive-conferences/#clear-internal-signage
 
 Since a few people were asking, this is how I made the maps:
 

--- a/src/_posts/2018/2018-09-17-lessons-in-signage.md
+++ b/src/_posts/2018/2018-09-17-lessons-in-signage.md
@@ -19,13 +19,13 @@ We got a lot of stuff right off the bat:
 *   A sign for every room where we were running sessions
 *   Laminated for durability
 *   Arrows highlighting the way to non-obvious rooms
-*   [Internal maps]({% post_url 2018/2018-08-26-maps-for-pyconuk %}) with red dots showing "you are here"
+*   [Internal maps](/2018/maps-for-pyconuk/) with red dots showing "you are here"
 
 But this was a first attempt, and inevitably I didn't get it all right -- for the benefit of my future self, and anybody else making venue signage, here's a few of the things I've learnt this year.
 
 {% tweet https://twitter.com/anabalica/status/1040947442735345664 %}
 
-[inclusivity]: {% post_url 2018/2018-08-13-inclusive-conferences %}#clear-internal-signage
+[inclusivity]: /2018/inclusive-conferences/#clear-internal-signage
 
 
 

--- a/src/_posts/2018/2018-09-24-assume-worst-intent.md
+++ b/src/_posts/2018/2018-09-24-assume-worst-intent.md
@@ -16,7 +16,7 @@ colors:
 
 This is a talk I gave last Sunday [at PyCon UK 2018](https://2018.hq.pyconuk.org/schedule/item/54DC/).
 
-Gail Ollis invited me to give a talk about [online harassment]({% post_url 2018/2018-04-18-anti-social-media %}) in April, based on my talk about [privilege and inclusion]({% post_url 2017/2017-11-03-pyconuk-2017-privilege-inclusion %}) at the previous year's conference.
+Gail Ollis invited me to give a talk about [online harassment](/2018/anti-social-media/) in April, based on my talk about [privilege and inclusion](/2017/pyconuk-2017-privilege-inclusion/) at the previous year's conference.
 We were chatting afterwards, and I realised with a bit of tidying, I could reuse it.
 This is a refined and shortened (and hopefully better!) version of the April talk.
 
@@ -41,7 +41,7 @@ The transcript is based on the captions on the YouTube video, with some light tw
   alt="Title slide."
 %}
 
-Since you've [already heard from me before]({% post_url 2018/2018-09-22-suspicious-minds %}), I'll skip the introduction and gets right into the talk.
+Since you've [already heard from me before](/2018/suspicious-minds/), I'll skip the introduction and gets right into the talk.
 
 This morning we're talking about online harassment, and specifically, how do we build systems to prevent it, reduce it, and reduce the risk of it.
 I'm going to show you some mechanisms and practical tips that I've found are most successful in reducing online harassment.
@@ -396,7 +396,7 @@ In the same way, there are lots of ways these techniques can make a service bett
 What's the first thing you can do?
 
 First of all, **diversify the team**.
-I [talked about this a lot last year]({% post_url 2017/2017-11-03-pyconuk-2017-privilege-inclusion %}), so I won't go into much detail -- the important thing to note is that we are all individuals.
+I [talked about this a lot last year](/2017/pyconuk-2017-privilege-inclusion/), so I won't go into much detail -- the important thing to note is that we are all individuals.
 We all have a single lived experience, and there are people who are different from us, who have to worry about different things, who have to worry about different forms of harassment.
 
 For example, I'm male.

--- a/src/_posts/2019/2019-01-28-notes-from-you-got-this.md
+++ b/src/_posts/2019/2019-01-28-notes-from-you-got-this.md
@@ -30,7 +30,7 @@ Every session was interesting, well-presented, and left me with at least a few n
 
 The emphasis in the introduction was that these are "topics we should be talking about more" -- which is precisely why I decided to go.
 
-I care a lot about running inclusive events, and [have a long list of ideas for doing so]({% post_url 2018/2018-08-13-inclusive-conferences %}).
+I care a lot about running inclusive events, and [have a long list of ideas for doing so](/2018/inclusive-conferences/).
 For a first-time conference, I was pleased by how many of them they hit:
 
 -   When I arrived, I was asked if I was happy to appear in photographs -- and if not, I could wear a bright yellow lanyard.
@@ -68,7 +68,7 @@ And here's some stuff that felt a little odd:
 
     I also felt the spaces were a bit small, and felt crowded during the lunch break.
 
-No conference gets inclusivity perfect, and the gold standard for me is still [AlterConf London]({% post_url 2017/2017-04-04-lessons-from-alterconf %}) -- but this was pretty good, overall.
+No conference gets inclusivity perfect, and the gold standard for me is still [AlterConf London](/2017/lessons-from-alterconf/) -- but this was pretty good, overall.
 I'd happily attend again.
 
 If you read the post and think sounds interesting, there's a sequel planned for January 2020, with a [mailing list](https://yougotthis.io/) on the website.

--- a/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
+++ b/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
@@ -14,7 +14,7 @@ colors:
 Earlier today I did a talk at [Monki Gras 2019](https://monkigras.com/).
 The theme of the conference is *"Accessible Craft: Creating great experiences for everyone"*, so I did a talk about inclusive design -- and in particular, something called the Curb Cut Effect.
 
-I originally pitched a talk based on [Assume Worst Intent]({% post_url 2018/2018-09-24-assume-worst-intent %}), because if you're thinking about inclusion you might think about ways to avoid exclusion (specifically, exclusion of harassment and abuse victims).
+I originally pitched a talk based on [Assume Worst Intent](/2018/assume-worst-intent/), because if you're thinking about inclusion you might think about ways to avoid exclusion (specifically, exclusion of harassment and abuse victims).
 That talk was definitely too narrow for this conference, but James isolated a key idea -- making a service better for vulnerable uses makes it better for everyone -- and I wrote an entirely new talk around it.
 
 The talk went really well -- everybody was very nice afterwards, and I'm enjoying the rest of talks too.

--- a/src/_posts/2019/2019-02-05-inclusive-events-redux.md
+++ b/src/_posts/2019/2019-02-05-inclusive-events-redux.md
@@ -11,7 +11,7 @@ index:
   exclude: true
 ---
 
-Last year, I wrote [a blog post]({% post_url 2018/2018-08-13-inclusive-conferences %}) with my ideas for running inclusive conferences.
+Last year, I wrote [a blog post](/2018/inclusive-conferences/) with my ideas for running inclusive conferences.
 I was thrilled by the number of people who read, shared, or gave me feedback and suggestions.
 I kept all the suggestions in a text file, but I never quite got around to writing an updated post.
 

--- a/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
+++ b/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
@@ -253,7 +253,7 @@ This helper method creates an HTTP session that, on every request:
     This uses a requests hook, which I've written about [in a previous post][hooks].
 
 [pr_api]: https://developer.github.com/v3/pulls/
-[hooks]: {% post_url 2017/2017-10-20-requests-hooks %}
+[hooks]: /2017/requests-hooks/
 
 I have to add `pip3 install requests` to the `Dockerfile` so I can use the requests library.
 

--- a/src/_posts/2019/2019-04-11-getting-a-transcript-of-a-talk-from-youtube.md
+++ b/src/_posts/2019/2019-04-11-getting-a-transcript-of-a-talk-from-youtube.md
@@ -14,7 +14,7 @@ When I give conference talks, my talks are often videoed and shared on YouTube.
 Along with the video, I like to post the slides afterwards, and include an inline transcript.
 A written transcript is easier to skim, to search, and for Google to index.
 Plus, it makes the talk more accessible for people with hearing difficulties.
-Here's an example from PyCon UK last year: [Assume Worst Intent]({% post_url 2018/2018-09-24-assume-worst-intent %}).
+Here's an example from PyCon UK last year: [Assume Worst Intent](/2018/assume-worst-intent/).
 
 I share a transcript rather than pre-prepared notes because I often ad lib the content of my talks.
 I might add or remove something at the last minute, make subtle changes based on the mood of the audience, or make a reference to a previous session that wasn't in my original notes.

--- a/src/_posts/2019/2019-04-23-some-tips-for-conferences.md
+++ b/src/_posts/2019/2019-04-23-some-tips-for-conferences.md
@@ -98,4 +98,4 @@ These are a few items that I find especially useful for conferences:
     I carry them all day, so I never lose conference time finding a pharmacy in a strange city.
 
 [anker]: https://www.amazon.co.uk/Anker-PowerCore-Aluminum-Portable-Lipstick-Sized-Black/dp/B005QI1A8C/ref=as_li_ss_tl?keywords=anker+battery+powercore&qid=1555965890&s=gateway&sr=8-9&linkCode=ll1&tag=alechasblo-21&linkId=def216483d182e2bcf208f5148faadf8&language=en_GB
-[tech_bag]: {% post_url 2016/2016-09-30-travelling-tech-bag %}
+[tech_bag]: /2016/travelling-tech-bag/

--- a/src/_posts/2019/2019-06-09-acorn-on-the-command-line.md
+++ b/src/_posts/2019/2019-06-09-acorn-on-the-command-line.md
@@ -277,7 +277,7 @@ This is the final script, including a comment at the top explaining how to use i
 -- is already open for editing, it uses that, otherwise it opens the file
 -- and then closes it afterward.
 --
--- Taken from https://alexwlchan.net{% post_url 2019/2019-06-09-acorn-on-the-command-line %}
+-- Taken from https://alexwlchan.net/2019/acorn-on-the-command-line/
 
 on run argv
   if (count of argv) is not 2

--- a/src/_posts/2019/2019-07-03-listing-s3-keys.md
+++ b/src/_posts/2019/2019-07-03-listing-s3-keys.md
@@ -9,10 +9,10 @@ tags:
   - aws
 ---
 
-Two years ago, I wrote a Python function for [listing keys in an S3 bucket]({% post_url 2017/2017-07-18-listing-s3-keys %}).
+Two years ago, I wrote a Python function for [listing keys in an S3 bucket](/2017/listing-s3-keys/).
 At the time I was still very new to AWS and the boto3 library, and I thought this might be a useful snippet -- turns out it's by far the most popular post on the site!
 
-I added [a couple of bugfixes]({% post_url 2018/2018-01-20-listing-s3-keys-redux %}) a few months later, but otherwise I haven't touched it since.
+I added [a couple of bugfixes](/2018/listing-s3-keys-redux/) a few months later, but otherwise I haven't touched it since.
 
 Part of that code is handling pagination in the S3 API -- it makes a series of calls to the ListObjectsV2 API, fetching up to 1000 objects at a time.
 Every response includes a "continuation token", and you pass that token into your next API call to get the next page of results.

--- a/src/_posts/2019/2019-08-19-finding-tint-colours-with-k-means.md
+++ b/src/_posts/2019/2019-08-19-finding-tint-colours-with-k-means.md
@@ -45,7 +45,7 @@ I've come up with an approach that seems to work fairly well, which uses [*k*-me
 I've tried my code with a few thousand images, and it picks reasonable colours each time -- not always optimal, but scanning the list I didn't see anything wildly inappropriate or unusable.
 
 [docstore]: https://github.com/alexwlchan/docstore
-[thumbnails]: {% post_url 2019/2019-07-08-creating-preview-thumbnails-of-pdf-documents %}
+[thumbnails]: /2019/creating-preview-thumbnails-of-pdf-documents/
 [bootstrap]: https://getbootstrap.com
 [k_means]: https://en.wikipedia.org/wiki/K-means_clustering
 

--- a/src/_posts/2019/2019-09-05-unpacking-compressed-archives-in-scala.md
+++ b/src/_posts/2019/2019-09-05-unpacking-compressed-archives-in-scala.md
@@ -252,7 +252,7 @@ It uses Either rather than Try to handle errors, which is a design pattern it in
 If you want to use this code in your project, all of Wellcome's code is available under [an MIT license][license] -- just the copyright notice and a link back to our repo.
 If you found my walkthrough helpful, perhaps [say thanks on Twitter][thanks]?
 
-[s3_python]: {% post_url 2019/2019-02-09-working-with-large-s3-objects %}
+[s3_python]: /2019/working-with-large-s3-objects/
 [commons]: https://en.wikipedia.org/wiki/Apache_Commons
 [ghurl]: https://github.com/wellcometrust/storage-service/blob/5582edcd3a3d1dd876aa311d1c8c03ba66347e7d/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Unarchiver.scala
 [tests]: https://github.com/wellcometrust/storage-service/blob/5582edcd3a3d1dd876aa311d1c8c03ba66347e7d/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/UnarchiverTest.scala

--- a/src/_posts/2019/2019-09-12-streaming-large-s3-objects.md
+++ b/src/_posts/2019/2019-09-12-streaming-large-s3-objects.md
@@ -9,14 +9,14 @@ tags:
   - scala
 ---
 
-In [my last post]({% post_url 2019/2019-09-05-unpacking-compressed-archives-in-scala %}), I talked about how to take a Java `InputStream` for a tar.gz file, and get an iterator of `(ArchiveEntry, InputStream)`.
+In [my last post](/2019/unpacking-compressed-archives-in-scala/), I talked about how to take a Java `InputStream` for a tar.gz file, and get an iterator of `(ArchiveEntry, InputStream)`.
 If we want to use that code, we need to get an InputStream for our tar.gz file -- which in our case, is stored in S3.
 Some of our archives are very big (the biggest is half a terabyte), and getting a reliable InputStream for an S3 object turns out to be non-trivial.
 
 In this post, I'm going to walk through some code we've written to reliably stream large objects from S3.
 This is similar to something I wrote in February about [reading large objects in Python][s3_python], but you don't need to read that post before this one.
 
-[s3_python]: {% post_url 2019/2019-02-09-working-with-large-s3-objects %}
+[s3_python]: /2019/working-with-large-s3-objects/
 
 To get an InputStream for an object, we can use the GetObject API in the S3 SDK:
 

--- a/src/_posts/2019/2019-10-16-adventures-with-concurrent-futures.md
+++ b/src/_posts/2019/2019-10-16-adventures-with-concurrent-futures.md
@@ -119,7 +119,7 @@ The pattern above loads all the tasks immediately, potentially using a lot of me
 It would be nicer if it was only keeping a small number of tasks in memory -- the ones that were currently being worked on.
 
 One approach to handle a very large number of tasks would be to break them into small chunks, and process each chunk in turn using the pattern above.
-Using my chunked_iterable() method [from a previous post]({% post_url 2018/2018-12-23-iterating-in-fixed-size-chunks %}), we could do something like:
+Using my chunked_iterable() method [from a previous post](/2018/iterating-in-fixed-size-chunks/), we could do something like:
 
 ```python
 for task_set in chunked_iterable(get_tasks_to_do(), HOW_MANY_TASKS_AT_ONCE):

--- a/src/_posts/2020/2020-01-04-finding-the-bottlenecks-in-an-ecs-cluster.md
+++ b/src/_posts/2020/2020-01-04-finding-the-bottlenecks-in-an-ecs-cluster.md
@@ -282,7 +282,7 @@ It's less typing, and less risk of a typo messing up your selection.
 So now we can ask the user to select a cluster, get a list of all the services in that cluster, and look up the CPU/memory statistics for that service.
 How do we display that to the user?
 
-I've done a bit of this before -- two years ago I wrote a post about [drawing ASCII bar charts in Python]({% post_url 2018/2018-05-26-ascii-bar-charts %}), and that code is pretty useful here.
+I've done a bit of this before -- two years ago I wrote a post about [drawing ASCII bar charts in Python](/2018/ascii-bar-charts/), and that code is pretty useful here.
 I'm not going to go through it again, just note a couple of tweaks I've made to the code from that post, in particular:
 
 *   removing common prefixes from the service names

--- a/src/_posts/2020/2020-01-16-pride-valknuts.md
+++ b/src/_posts/2020/2020-01-16-pride-valknuts.md
@@ -15,7 +15,7 @@ colors:
   index_dark:  "#c8c8c8"
 ---
 
-You might remember a couple of months back, I was playing with [alternative coordinate systems in SVG]({% post_url 2019/2019-09-23-triangular-coordinates-in-svg %}).
+You might remember a couple of months back, I was playing with [alternative coordinate systems in SVG](/2019/triangular-coordinates-in-svg/).
 There are some shapes which are easier to define with triangular coordinates than regular (*x*,*y*)-coordinates, and I created some Python functions to let me switch between the two coordinate systems.
 
 One shape that's much easier to define in triangular coordinates is the [valknut], a symbol made from three interlocked triangles that appears on a lot of objects from ancient Germanic cultures:

--- a/src/_posts/2020/2020-01-22-uk-stations-map.md
+++ b/src/_posts/2020/2020-01-22-uk-stations-map.md
@@ -93,5 +93,5 @@ If you want to play with it yourself, it's at <https://uk-stations-map.glitch.me
 [the demo]: https://joshuajohnson.co.uk/Choices/
 [a list of stations]: https://github.com/trainline-eu/stations
 [from Wikipedia]: https://en.wikipedia.org/wiki/List_of_railway_stations_in_Ireland
-[Forth]: {% post_url 2019/2019-03-15-forth-bridge %}
+[Forth]: /2019/forth-bridge/
 [on GitHub]: https://github.com/alexwlchan/uk-station-map

--- a/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
+++ b/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
@@ -143,7 +143,7 @@ With these two tools, I can get an image in a range of different colours:
 Using the hue adjustment means I can find something in the right ballpark to match the rest of my slides.
 I might also tweak the saturation/brightness in an image editor if the shade isn't quite right -- and then I have an image to use in my slide deck.
 
-You can see another example of this technique in the slides for [my curb cut effect talk]({% post_url 2019/2019-01-31-monki-gras-the-curb-cut-effect %}).
+You can see another example of this technique in the slides for [my curb cut effect talk](/2019/monki-gras-the-curb-cut-effect/).
 There's a picture of a handle on a purple door, but the [original image](https://pixabay.com/photos/door-handle-doorknob-lock-door-3633943/) had a red door.
 Without a side-by-side comparison, you'd never realise the image had been changed:
 

--- a/src/_posts/2020/2020-02-25-a-remote-controlled-oven-is-a-safety-nightmare.md
+++ b/src/_posts/2020/2020-02-25-a-remote-controlled-oven-is-a-safety-nightmare.md
@@ -30,7 +30,7 @@ When I saw this oven, my first thought was: *how would a terrible flatmate misus
 This is a topic [I've written about in the past][assume_worst_intent] -- even if a product or service is bug-free, a malicious or abusive user could still use it to hurt someone.
 We should always design with abusive personas in mind, and consider how the things we build might be weaponised.
 
-[assume_worst_intent]: {% post_url 2018/2018-09-24-assume-worst-intent %}
+[assume_worst_intent]: /2018/assume-worst-intent/
 
 How could somebody nasty misuse an oven that's controlled by an app?
 Before you read on, you might want to try this exercise yourself.

--- a/src/_posts/2020/2020-03-02-finding-the-size-of-your-s3-buckets.md
+++ b/src/_posts/2020/2020-03-02-finding-the-size-of-your-s3-buckets.md
@@ -20,7 +20,7 @@ Whenever I look at [our AWS bill], one of the biggest costs is always S3 storage
 That's not a surprise -- our account holds, among other things, two copies of Wellcome Collection's [entire digital archive], which is nearly 120TB and growing every day.
 If we ever got a bill and there *wasn't* a big number next to S3, that's a reason to to panic.
 
-[our AWS bill]: {% post_url 2019/2019-11-06-aws-costs-graph %}
+[our AWS bill]: /2019/aws-costs-graph/
 [entire digital archive]: https://stacks.wellcomecollection.org/building-wellcome-collections-new-archival-storage-service-3f68ff21927e
 
 We spend about $25,000 on S3 storage every year.

--- a/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
+++ b/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
@@ -36,7 +36,7 @@ One of the builtin wallpapers that ships with iOS is a black wallpaper with slan
 </figure>
 
 This sort of simple, geometric design is exactly the type of thing you can create in code, not an image editor.
-I've used Pillow, the Python imaging library, to do this sort of thing in the past -- first [tiling the plane]({% post_url 2016/2016-10-21-tiling-the-plane-with-pillow %}), then adding colour to [create low contrast wallpapers]({% post_url 2016/2016-10-22-wallpapers-with-pillow %}).
+I've used Pillow, the Python imaging library, to do this sort of thing in the past -- first [tiling the plane](/2016/tiling-the-plane-with-pillow/), then adding colour to [create low contrast wallpapers](/2016/wallpapers-with-pillow/).
 
 This design is simpler and involves less geometry: I measured the dimensions of the stripes from a JPEG, then used the ImageDraw class in Pillow to create the stripes on the background.
 My metrics are based on the dimensions of an iPhone X-sized phone, but you can adapt the idea to any size of phone.

--- a/src/_posts/2020/2020-04-05-storing-language-vocabulary-as-a-graph.md
+++ b/src/_posts/2020/2020-04-05-storing-language-vocabulary-as-a-graph.md
@@ -26,7 +26,7 @@ Here's an example with English and German:
 </figure>
 
 This is an efficient way to store the data, and it allows for fast lookups if there's a word you don't know.
-(Assuming you know how to [find a word in the list]({% post_url 2019/2019-06-12-reading-a-chinese-dictionary %}).)
+(Assuming you know how to [find a word in the list](/2019/reading-a-chinese-dictionary/).)
 It's how every dictionary and phrase book I've ever read has been laid out.
 
 A vocabulary list treats each word/translation pair as a discrete unit, to be learnt individually.

--- a/src/_posts/2020/2020-04-16-adventures-in-embodiment.md
+++ b/src/_posts/2020/2020-04-16-adventures-in-embodiment.md
@@ -24,7 +24,7 @@ This came up in some recent conversations with friends about embodiment.
 They have better embodiment practices than me, and that makes it easier for them to notice these signals.
 Talking to them persuaded me that embodiment would be a useful skill to try to improve – until recently, I hadn't realised what I was missing.
 
-Alongside this, I've been continuing to explore my feelings [about gender]({% post_url 2019/2019-06-18-regenerating %}) -- experimenting with appearance, presentation, body shape, and so on.
+Alongside this, I've been continuing to explore my feelings [about gender](/2019/regenerating/) -- experimenting with appearance, presentation, body shape, and so on.
 Here's a funny thing I've noticed: when I do things that make my brain think "girl", it gets easier to listen to my body.
 Without trying, I become more aware of when I'm hungry, tired, and thirsty.
 

--- a/src/_posts/2020/2020-04-22-thinking-about-gender.md
+++ b/src/_posts/2020/2020-04-22-thinking-about-gender.md
@@ -16,7 +16,7 @@ I can see where this sentiment comes from: many trans people do think a lot abou
 If you do, it might be a strong indicator that you're trans, or that it's worth considering whether a transition would make you happier -- but it's not an absolute guarantee, and that nuance is often lost in the noise.
 
 I've spent a lot of time thinking about my gender in the last few years.
-I discovered it [wasn't quite right]({% post_url 2019/2019-06-18-regenerating %}), I'm making some changes, and I'm much happier now.
+I discovered it [wasn't quite right](/2019/regenerating/), I'm making some changes, and I'm much happier now.
 This is good.
 
 In another timeline, I might have done the same thinking, decided "male" was okay, made some different changes, and been happier in a different way.

--- a/src/_posts/2020/2020-05-10-make-it-safe-to-admit-mistakes.md
+++ b/src/_posts/2020/2020-05-10-make-it-safe-to-admit-mistakes.md
@@ -34,7 +34,7 @@ I was very apologetic and conciliatory and I felt like I screwed up.
 My coworkers reassured me that it wasn't my fault -- we all make mistakes, and I was just the unlucky one today.
 **They didn't try to blame me or make me feel worse for my mistake.**
 
-Part of this is because they recognise that [complex systems have complex failures]({% post_url 2020/2020-04-19-complex-failures %}), and it's never a single person at fault.
+Part of this is because they recognise that [complex systems have complex failures](/2020/complex-failures/), and it's never a single person at fault.
 Although I was the one who pushed the button, it would have been better if there hadn't been a button for me to press.
 (And indeed, we're changing how we handle bucket policies so at least two people review every future change, making this sort of mistake less likely.)
 

--- a/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
+++ b/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
@@ -763,7 +763,7 @@ Although this sort of dynamic tuple unpacking is terrible and using it in produc
 
 *   Python calls the `__iter__` method on an object when it tries to iterate over it; for example, when it's trying to extract elements to unpack into a tuple.
 
-Learning useful stuff is part of why I experiment with bad ideas (previously: [exhibit A]({% post_url 2020/2020-04-27-using-dynamodb-as-a-calculator %}), [exhibit B]({% post_url 2019/2019-12-11-yaml-impossible %})).
+Learning useful stuff is part of why I experiment with bad ideas (previously: [exhibit A](/2020/using-dynamodb-as-a-calculator/), [exhibit B](/2019/yaml-impossible/)).
 
 Trying to do something like dynamic tuple unpacking forces me to be creative.
 I have to think about how to do something that was never intended to be possible, and I end up learning about things that I'd never have encountered otherwise.

--- a/src/_posts/2020/2020-05-16-moving-messages-between-sqs-queues.md
+++ b/src/_posts/2020/2020-05-16-moving-messages-between-sqs-queues.md
@@ -33,9 +33,9 @@ Although we primarily use this to redrive problematic messages that went to a DL
 
 It uses code I shared two years ago [to dump the contents of an SQS queue][dump_q].
 
-[dump_q]: {% post_url 2018/2018-01-25-downloading-sqs-queues %}
+[dump_q]: /2018/downloading-sqs-queues/
 [send_message_batch]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sqs.html?highlight=sqs#SQS.Client.send_message_batch
-[fixed_chunks]: {% post_url 2018/2018-12-23-iterating-in-fixed-size-chunks %}
+[fixed_chunks]: /2018/iterating-in-fixed-size-chunks/
 
 Be careful running this code -- if the worker is running, and it picks up the messages immediately, they might go back to the DLQ if there's another problem with the worker.
 The script would then resend them to the input queue, and the worker would send them back to the DLQ.

--- a/src/_posts/2020/2020-05-27-getting-every-item-from-a-dynamodb-table-with-python.md
+++ b/src/_posts/2020/2020-05-27-getting-every-item-from-a-dynamodb-table-with-python.md
@@ -179,5 +179,5 @@ if __name__ == "__main__":
 ```
 
 [Parallel Scan]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
-[about using Parallel Scan in Scala]: {% post_url 2018/2018-08-25-parallel-scan-scanamo %}
-[my recipes for concurrent.futures]: {% post_url 2019/2019-10-16-adventures-with-concurrent-futures %}
+[about using Parallel Scan in Scala]: /2018/parallel-scan-scanamo/
+[my recipes for concurrent.futures]: /2019/adventures-with-concurrent-futures/

--- a/src/_posts/2020/2020-06-20-large-things-living-in-cold-places.md
+++ b/src/_posts/2020/2020-06-20-large-things-living-in-cold-places.md
@@ -33,6 +33,6 @@ I also shared [a script for measuring the size of your S3 buckets][buckets], whi
 If you enjoy reading my blog, you might also enjoy the site whose name inspired the title of this post -- [Terrible things happening in cold places][coldplaces].
 
 [stacks]: https://stacks.wellcomecollection.org/large-things-living-in-cold-places-66cbc3603e14
-[transitions]: {% post_url 2020/2020-05-01-illustrating-lifecycle-transitions-in-amazon-s3 %}
-[buckets]: {% post_url 2020/2020-03-02-finding-the-size-of-your-s3-buckets %}
+[transitions]: /2020/illustrating-lifecycle-transitions-in-amazon-s3/
+[buckets]: /2020/finding-the-size-of-your-s3-buckets/
 [coldplaces]: http://www.terriblethingshappeningincoldplaces.com/about

--- a/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
+++ b/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
@@ -31,7 +31,7 @@ It's a fork of an older app called [Notational Velocity], and the icon is a grey
 </figure>
 
 For a while now I've wanted to create versions of the Notational Velocity icon in different colours.
-Adjusting the colour of an image with a single accent colour is [something I've done before]({% post_url 2020/2020-02-23-adjusting-the-dominant-colour-of-an-image %}), and it would be more exciting than a monochrome icon.
+Adjusting the colour of an image with a single accent colour is [something I've done before](/2020/adjusting-the-dominant-colour-of-an-image/), and it would be more exciting than a monochrome icon.
 Given the renewed [sense of fun] in Apple's icons for macOS 11, I spent a couple of hours trying to find a way to play with icon colours.
 
 [nvALT]: https://brettterpstra.com/projects/nvalt/

--- a/src/_posts/2020/2020-07-13-what-does-d-match-in-a-regex.md
+++ b/src/_posts/2020/2020-07-13-what-does-d-match-in-a-regex.md
@@ -34,4 +34,4 @@ No doubt it varies among other programming languages as well.
 How much this distinction matters depends on your use case, and in most cases I imagine the answer is "very little".
 I present it more as an intellectual curiosity than something which needs serious consideration when writing regexes.
 
-This isn't the first time Hypothesis has [exposed one of my faulty assumptions]({% post_url 2016/2016-12-01-strings-are-terrible %}) -- language is incredibly complicated, and I still have a lot to learn.
+This isn't the first time Hypothesis has [exposed one of my faulty assumptions](/2016/strings-are-terrible/) -- language is incredibly complicated, and I still have a lot to learn.

--- a/src/_posts/2020/2020-07-20-running-concurrent-try-functions-in-scala.md
+++ b/src/_posts/2020/2020-07-20-running-concurrent-try-functions-in-scala.md
@@ -71,5 +71,5 @@ val futures: Seq[Future[_]] =
 Now I have five `Future`s running concurrently, each of which calls the `Try` function.
 It's a bit ugly, but it does the trick.
 
-[locking logic]: {% post_url 2019/2019-05-13-creating-a-locking-service-in-a-scala-type-class %}
+[locking logic]: /2019/creating-a-locking-service-in-a-scala-type-class/
 [`Future.fromTry`]: https://www.scala-lang.org/api/current/scala/concurrent/Future$.html#fromTry[T](result:scala.util.Try[T]):scala.concurrent.Future[T]

--- a/src/_posts/2020/2020-07-26-getting-a-markdown-link-to-a-window-in-safari.md
+++ b/src/_posts/2020/2020-07-26-getting-a-markdown-link-to-a-window-in-safari.md
@@ -30,5 +30,5 @@ I use it when the URL doesn't contain much useful information (say, an article I
 This is one of several automations that I have to get URLs from my browser.
 Each of them saves a few clicks, and it means I don't break my writing flow going to the browser to copy/paste a URL.
 
-I wrote about [an automation for getting tweets]({% post_url 2019/2019-11-17-saving-a-copy-of-a-tweet-by-typing-twurl %}) last year, and the original idea I got [from Dr. Drang](https://leancrew.com/all-this/2009/07/safari-tab-urls-via-textexpander/) over a decade ago.
+I wrote about [an automation for getting tweets](/2019/saving-a-copy-of-a-tweet-by-typing-twurl/) last year, and the original idea I got [from Dr. Drang](https://leancrew.com/all-this/2009/07/safari-tab-urls-via-textexpander/) over a decade ago.
 I have it bound to `;mdurl` using Keyboard Maestro, with `;md2url` for the second window (if I'm typing into a text box in Safari).

--- a/src/_posts/2020/2020-08-06-using-fuzzy-string-matching-to-find-duplicate-tags.md
+++ b/src/_posts/2020/2020-08-06-using-fuzzy-string-matching-to-find-duplicate-tags.md
@@ -7,7 +7,7 @@ tags:
 ---
 
 I'm a big fan of [keyword tagging](https://en.wikipedia.org/wiki/Tag_(metadata)) as a way to organise my digital data.
-(For an explanation why, see my post about [how I scan and store my paperwork]({% post_url 2019/2019-11-27-my-scanning-setup %}#how-should-i-organise-my-files).)
+(For an explanation why, see my post about [how I scan and store my paperwork](/2019/my-scanning-setup/#how-should-i-organise-my-files).)
 
 Tags work best if I use them consistently -- same spelling, same wording, same everything.
 In practice, I don't always get that right -- I make typos, mistakes, or I forget that I already have a tag for a particular concept, and I create another tag.

--- a/src/_posts/2020/2020-08-20-s3-prefixes-are-not-directories.md
+++ b/src/_posts/2020/2020-08-20-s3-prefixes-are-not-directories.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 I didn't expect to be writing another post about S3 keys so soon, but life comes at you fast.
-Less than twenty-four hours after posting [S3 keys are not file paths]({% post_url 2020/2020-08-18-s3-keys-are-not-file-paths %}), I hit a *different bug* caused by poor handling of S3 keys.
+Less than twenty-four hours after posting [S3 keys are not file paths](/2020/s3-keys-are-not-file-paths/), I hit a *different bug* caused by poor handling of S3 keys.
 (Yes, really.)
 
 The storage service I work on has to store [different versions of a "bag"](https://stacks.wellcomecollection.org/how-we-store-multiple-versions-of-bagit-bags-e68499815184), and we want those versions to be human-readable.

--- a/src/_posts/2020/2020-09-26-using-qlmanage-to-create-thumbnails-on-macos.md
+++ b/src/_posts/2020/2020-09-26-using-qlmanage-to-create-thumbnails-on-macos.md
@@ -55,6 +55,6 @@ $ qlmanage -t -o thumbnails -s 1000 ~/Downloads/IMG_5494.jpeg
 (Note: the size is "up to", not "exactly".
 My original image is 4032 pixels wide; if I request a thumbnail that's 5000 pixels wide, I only get a 4032px wide thumbnail.)
 
-I've spent a bunch of time writing my own code for generating file thumbnails, including [using pdftocairo for PDFs]({% post_url 2019/2019-07-08-creating-preview-thumbnails-of-pdf-documents %}) and [a Python script for MOBI ebooks]({% post_url 2019/2019-06-04-getting-cover-images-from-mobi-ebooks %}).
+I've spent a bunch of time writing my own code for generating file thumbnails, including [using pdftocairo for PDFs](/2019/creating-preview-thumbnails-of-pdf-documents/) and [a Python script for MOBI ebooks](/2019/getting-cover-images-from-mobi-ebooks/).
 It's a complex problem, and every so often I find a new file that needs some tweak to the code.
 I'm looking forward to replacing it all with some new code that shells out to `qlmanage`, and letting the OS handle thumbnailing for me.

--- a/src/_posts/2020/2020-10-12-a-new-readme-for-docstore.md
+++ b/src/_posts/2020/2020-10-12-a-new-readme-for-docstore.md
@@ -11,7 +11,7 @@ colors:
   index_dark:  "#e5bcc9"
 ---
 
-I've written previously about how I [scan and organise my paperwork]({% post_url 2019/2019-11-27-my-scanning-setup %}).
+I've written previously about how I [scan and organise my paperwork](/2019/my-scanning-setup/).
 I have a paper-feed scanner to scan my paperwork as PDFs, and then I wrote a piece of software called *docstore* to store and organise the PDFs.
 docstore is built around the idea of [keyword tagging](https://en.wikipedia.org/wiki/Tag_(metadata)), because that's a system I find works well for me.
 
@@ -34,7 +34,7 @@ Since my paperwork has a lot of private information (including my address, healt
 I've recently done a complete rewrite.
 Part of it was fixing mistakes in the original version, part of it was taking advantage of the fact that I'm running locally.
 I used to run it on a Linux server; now I'm running it on macOS.
-That means that, for example, I can [use Quick Look to create thumbnails]({% post_url 2020/2020-09-26-using-qlmanage-to-create-thumbnails-on-macos %}).
+That means that, for example, I can [use Quick Look to create thumbnails](/2020/using-qlmanage-to-create-thumbnails-on-macos/).
 
 I don't expect that anybody apart from me will want to use docstore, because it's very specific to my personal context -- but the ideas might be useful elsewhere.
 

--- a/src/_posts/2020/2020-10-30-til-using-git-check-ignore-to-debug-your-gitignore.md
+++ b/src/_posts/2020/2020-10-30-til-using-git-check-ignore-to-debug-your-gitignore.md
@@ -31,7 +31,7 @@ A few examples:
 
     Notice that it looks in .gitignore files that aren't in the root of the repo (the sort of thing I often forget about).
 
-*   It can even look [in your `.git/info/exclude`]({% post_url 2015/2015-06-02-git-info-exclude %}), a place for per-clone ignore rules that you don't want to keep in the repository:
+*   It can even look [in your `.git/info/exclude`](/2015/git-info-exclude/), a place for per-clone ignore rules that you don't want to keep in the repository:
 
     ```
     $ git check-ignore --verbose scripts/alex/downloader.py

--- a/src/_posts/2020/2020-11-01-a-python-function-to-ignore-a-path-with-git-info-exclude.md
+++ b/src/_posts/2020/2020-11-01-a-python-function-to-ignore-a-path-with-git-info-exclude.md
@@ -23,7 +23,7 @@ Nobody else needs to be ignoring these paths, because they haven't downloaded th
 
 I could save the images in a different directory, but that's slightly less convenient.
 
-**I realised this was a good use case [for `.git/info/exclude`]({% post_url 2015/2015-06-02-git-info-exclude %}) -- a place for gitignore rules that shouldn't tracked as part of the repo history.**
+**I realised this was a good use case [for `.git/info/exclude`](/2015/git-info-exclude/) -- a place for gitignore rules that shouldn't tracked as part of the repo history.**
 Each clone can have different rules in this file.
 If I ignore the downloaded images in this file, they won't show up in `git status`, but nor will the ignore rules be shared with anyone else.
 
@@ -41,7 +41,7 @@ def ignore_path_locally(path):
 
     This function instead adds paths to .git/info/exclude.
 
-    See https://alexwlchan.net{% post_url 2015/2015-06-02-git-info-exclude %}
+    See https://alexwlchan.net/2015/git-info-exclude/
     """
     # Get the absolute path to the root of the repo.
     # See https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---show-toplevel

--- a/src/_posts/2021/2021-02-15-screaming-in-the-cloud.md
+++ b/src/_posts/2021/2021-02-15-screaming-in-the-cloud.md
@@ -12,7 +12,7 @@ colors:
   index_dark:  "#4597b4"
 ---
 
-Early last year, in a fit of lockdown-induced ridiculousness, I wrote some [code that turned DynamoDB into a calculator]({% post_url 2020/2020-04-27-using-dynamodb-as-a-calculator %}).
+Early last year, in a fit of lockdown-induced ridiculousness, I wrote some [code that turned DynamoDB into a calculator](/2020/using-dynamodb-as-a-calculator/).
 
 This caught the attention of [Corey Quinn](https://twitter.com/quinnypig), another lover of ridiculous ideas, and he invited me on his podcast, *Screaming in the Cloud*, to talk about what I'd done.
 We had a fun conversation about how I wrote the calculator, some of the digital preservation work I do at Wellcome, and how the cloud factors into both of those.

--- a/src/_posts/2021/2021-03-07-rainbow-hearts.md
+++ b/src/_posts/2021/2021-03-07-rainbow-hearts.md
@@ -78,7 +78,7 @@ Here's a few examples:
 This idea came from a [similar graphic I made for Valentine's Day](https://twitter.com/alexwlchan/status/1360919253738790915).
 I used several tools to make it, and I had to assemble the final result by hand -- I wanted to see if I could create a pair of interlocked hearts as a single SVG.
 
-Last year, I made an app for generating [rainbow Norse Valknuts]({% post_url 2020/2020-01-16-pride-valknuts %}), and I was able to reuse some of the code -- although those were easier to draw then hearts.
+Last year, I made an app for generating [rainbow Norse Valknuts](/2020/pride-valknuts/), and I was able to reuse some of the code -- although those were easier to draw then hearts.
 Valknuts use all straight lines, so I could calculate exactly where each stripe should start/end.
 Because hearts have curved sides, I had to do a bit more work to draw the overlaps.
 

--- a/src/_posts/2021/2021-03-12-inner-outer-strokes-svg.md
+++ b/src/_posts/2021/2021-03-12-inner-outer-strokes-svg.md
@@ -67,7 +67,7 @@ This seems like something I might use again, and it helped me understand both fe
 
 
 [SVGs]: https://en.wikipedia.org/wiki/Scalable_Vector_Graphics
-[interlocking rainbow hearts]: {% post_url 2021/2021-03-07-rainbow-hearts %}
+[interlocking rainbow hearts]: /2021/rainbow-hearts/
 [clipping and masking]: https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Clipping_and_masking
 
 

--- a/src/_posts/2021/2021-04-18-detect-private-browsing.md
+++ b/src/_posts/2021/2021-04-18-detect-private-browsing.md
@@ -8,7 +8,7 @@ tags:
   - macos:safari
 ---
 
-Last year, I wrote an AppleScript function that [opens a URL in a Private Browsing window in Safari]({% post_url 2020/2020-06-24-using-applescript-to-open-a-url-in-private-browsing-in-safari %}).
+Last year, I wrote an AppleScript function that [opens a URL in a Private Browsing window in Safari](/2020/using-applescript-to-open-a-url-in-private-browsing-in-safari/).
 I got an email from a reader asking if I knew how to open a URL in a Private Browsing *tab* – either adding it to an existing private window, or creating a new private window if not.
 
 The difficult part is working out if a given window is using Private Browsing.
@@ -64,7 +64,7 @@ on isFrontmostSafariWindowPrivateBrowsing()
 end isFrontmostSafariWindowPrivateBrowsing
 ```
 
-As I explained at the end of [my previous post]({% post_url 2020/2020-06-24-using-applescript-to-open-a-url-in-private-browsing-in-safari %}), you'll need to give *Accessibility* permissions to whatever app uses this code.
+As I explained at the end of [my previous post](/2020/using-applescript-to-open-a-url-in-private-browsing-in-safari/), you'll need to give *Accessibility* permissions to whatever app uses this code.
 Apps can't just inspect the menu items of other processes – that would open up all sorts of weird security holes.
 
 This code has a couple of limitations:

--- a/src/_posts/2021/2021-04-29-coloured-squares.md
+++ b/src/_posts/2021/2021-04-29-coloured-squares.md
@@ -111,7 +111,7 @@ Now I have, it's a single copy/paste to start reaping the benefits, so I'm much 
 [tweet]: https://twitter.com/alexwlchan/status/1387544124807593989
 [emoji]: https://emojipedia.org/thread/
 [Emojipedia]: https://emojipedia.org/thread/
-[dominant_colours]: {% post_url 2019/2019-08-19-finding-tint-colours-with-k-means %}
+[dominant_colours]: /2019/finding-tint-colours-with-k-means/
 [Perl function]: https://unix.stackexchange.com/a/482782/43183
 [ANSI escape codes]: https://en.wikipedia.org/wiki/ANSI_escape_code
 [Wikipedia entry]: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters

--- a/src/_posts/2021/2021-10-01-how-do-you-work-with-non-engineers.md
+++ b/src/_posts/2021/2021-10-01-how-do-you-work-with-non-engineers.md
@@ -42,4 +42,4 @@ Those goals are what they actually care about; they're what should be driving ou
 Wellcome is a museum and library, not a software factory.
 Technology should be led by the organisation's needs, not the other way round.
 
-[non_technical]: {% post_url 2020/2020-11-24-non-technical-users %}
+[non_technical]: /2020/non-technical-users/

--- a/src/_posts/2021/2021-10-06-readmes-for-open-science.md
+++ b/src/_posts/2021/2021-10-06-readmes-for-open-science.md
@@ -22,7 +22,7 @@ This is my second talk for OLS -- last year I talked about how [inclusion can't 
 
 [openlife]: https://openlifesci.org/
 [pdfslides]: /files/2021/ols-readme.pdf
-[inclusion]: {% post_url 2020/2020-03-25-inclusion-cant-be-an-afterthought %}
+[inclusion]: /2020/inclusion-cant-be-an-afterthought/
 
 <style>
   .slide img {

--- a/src/_posts/2021/2021-11-30-dominant-colours.md
+++ b/src/_posts/2021/2021-11-30-dominant-colours.md
@@ -141,9 +141,9 @@ I don't want any more features, and I'm not aware of any bugs, so don't expect t
 It's one of the nice things about writing small, single-purpose tools: you can finish them.
 
 [dominant_colours]: https://github.com/alexwlchan/dominant_colours
-[kmeans]: {% post_url 2019/2019-08-19-finding-tint-colours-with-k-means %}
+[kmeans]: /2019/finding-tint-colours-with-k-means/
 [kmeans_lib]: https://github.com/okaneco/kmeans-colors
 [do_one_thing]: https://en.wikipedia.org/wiki/Unix_philosophy#Do_One_Thing_and_Do_It_Well
 [clap]: https://crates.io/crates/clap
-[ansi]: {% post_url 2021/2021-04-29-coloured-squares %}
+[ansi]: /2021/coloured-squares/
 [esteban]: https://www.youtube.com/watch?v=Z6X7Ada0ugE

--- a/src/_posts/2021/2021-12-10-rust-errors.md
+++ b/src/_posts/2021/2021-12-10-rust-errors.md
@@ -8,7 +8,7 @@ tags:
   - error-messages
 ---
 
-In [my last-but-one post]({% post_url 2021/2021-11-30-dominant-colours %}), I mentioned the quality of Rust's compiler errors.
+In [my last-but-one post](/2021/dominant-colours/), I mentioned the quality of Rust's compiler errors.
 I encountered another compiler error today that I thought was less-than-optimal, I was going to file an issue for it… then I discovered it's been fixed in a newer version of Rust.
 Nice!
 

--- a/src/_posts/2021/2021-12-31-2021-in-reading.md
+++ b/src/_posts/2021/2021-12-31-2021-in-reading.md
@@ -35,7 +35,7 @@ I'd recommend any of them.
 [herts]: https://www.hertfordshire.gov.uk/services/libraries-and-archives/books-and-reading/ebooks-and-audiobooks/ebooks-and-audiobooks.aspx
 [app]: https://twitter.com/alexwlchan/status/1418827399702224896
 [books]: https://books.alexwlchan.net/reviews/#books_by_year_2021
-[notes]: {% post_url 2020/2020-11-16-how-i-read-non-fiction-books %}
+[notes]: /2020/how-i-read-non-fiction-books/
 
 <style type="x-text/scss">
   @import "posts/_end_of_year_books.scss";

--- a/src/_posts/2022/2022-01-07-rusty-shelves.md
+++ b/src/_posts/2022/2022-01-07-rusty-shelves.md
@@ -32,7 +32,7 @@ In this post, I'm going to explain how the new code works.
 
 You may not want to generate these exact images, but the ability to generate graphics like this has been useful in lots of projects – consider this a primer in creating simple images.
 
-[last post]: {% post_url 2021/2021-12-31-2021-in-reading %}
+[last post]: /2021/2021-in-reading/
 [books.alexwlchan.net]: https://books.alexwlchan.net/
 [red]: https://books.alexwlchan.net/reviews/trains
 [yellow]: https://books.alexwlchan.net/reviews/your-computer-is-on-fire/
@@ -52,7 +52,7 @@ That gets me a primary colour, like <code><span style="color: #917546">█</span
 Once I have that colour, I generate lots of colours that look similar – I'll explain how that works later.
 
 [dominant_colours]: https://github.com/alexwlchan/dominant_colours
-[explainer]: {% post_url 2019/2019-08-19-finding-tint-colours-with-k-means %}
+[explainer]: /2019/finding-tint-colours-with-k-means/
 
 
 

--- a/src/_posts/2022/2022-05-07-dominant-web-colours.md
+++ b/src/_posts/2022/2022-05-07-dominant-web-colours.md
@@ -46,6 +46,6 @@ If you'd like to try it, it's available at <https://dominant-colours.glitch.me/>
 
 If you want to read the source code, it's [on GitHub][github].
 
-[cli]: {% post_url 2021/2021-11-30-dominant-colours %}
-[recompiling]: {% post_url 2022/2022-05-05-rust-on-glitch %}
+[cli]: /2021/dominant-colours/
+[recompiling]: /2022/rust-on-glitch/
 [github]: https://github.com/alexwlchan/dominant_colours/tree/main/webapp

--- a/src/_posts/2022/2022-06-03-new-archive.md
+++ b/src/_posts/2022/2022-06-03-new-archive.md
@@ -169,7 +169,7 @@ It's still quite a few, but substantially fewer than the "all posts" page -- and
 
 [dominant_colours]: https://github.com/alexwlchan/dominant_colours
 [grid]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout
-[layout]: {% post_url 2022/2022-04-23-supposedly-simple-image-layout %}
+[layout]: /2022/supposedly-simple-image-layout/
 
 
 

--- a/src/_posts/2022/2022-08-01-screenshots-go-gangbusters.md
+++ b/src/_posts/2022/2022-08-01-screenshots-go-gangbusters.md
@@ -36,7 +36,7 @@ Most of the comments I saw were constructive and thoughtful, and many people sha
 It was also relatively stress-free.
 These are a few notes on what it was like to be (briefly) popular.
 
-[screenshots]: {% post_url 2022/2022-07-23-screenshots %}
+[screenshots]: /2022/screenshots/
 
 ---
 

--- a/src/_posts/2022/2022-08-03-no-cute.md
+++ b/src/_posts/2022/2022-08-03-no-cute.md
@@ -46,7 +46,7 @@ Will they appreciate your attempt at humour?
 There's a place for humour and levity in software, and my code has plenty -- but error messages are rarely it.
 **If somebody hits an error, they're some mix of anxious, angry, or confused, and cute or unclear language does nothing to help.**
 
-Error messages are [incredibly important]({% post_url 2020/2020-10-12-the-importance-of-good-error-messages %}), and the software industry generally does a bad job of writing them.
+Error messages are [incredibly important](/2020/the-importance-of-good-error-messages/), and the software industry generally does a bad job of writing them.
 Good error messages explain what's gone wrong, and give clear instructions for what to do next -- and being cutesy rarely helps.
 
 *This post was adapted from [a thread on Twitter](https://twitter.com/alexwlchan/status/1554723537562357760).*

--- a/src/_posts/2022/2022-09-13-graph-generative-art.md
+++ b/src/_posts/2022/2022-09-13-graph-generative-art.md
@@ -543,7 +543,7 @@ The thin yellow line is one of my favourites, because it reminds me of a key hol
 
 Once again, I think some of the most striking images are those with just a few spokes and rings.
 
-[curved_arcs]: {% post_url 2022/2022-08-10-circle-party %}
+[curved_arcs]: /2022/circle-party/
 
 
 

--- a/src/_posts/2022/2022-10-05-circle-experiments.md
+++ b/src/_posts/2022/2022-10-05-circle-experiments.md
@@ -247,9 +247,9 @@ One of the things I enjoy about Python and its drawing libraries is how fast I c
 I thought about this on the walk home from the station, and within ten minutes of walking through my door I had the final set of images.
 It's a fun creative outlet -- and unlike other forms of computer-based art, my randomly generated graphics don't have any ethical quagmires.
 
-[screenshot library]: {% post_url 2022/2022-07-23-screenshots %}
+[screenshot library]: /2022/screenshots/
 [border-radius property]: https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
-[the blog post]: {% post_url 2016/2016-10-22-wallpapers-with-pillow %}
+[the blog post]: /2016/wallpapers-with-pillow/
 [Pillow]: https://python-pillow.org/
 [ImageDraw]: https://pillow.readthedocs.io/en/stable/reference/ImageDraw.html
 [kirsten]: https://twitter.com/Kirsten3531/status/1575789943565131776

--- a/src/_posts/2022/2022-11-12-tin-anniversary.md
+++ b/src/_posts/2022/2022-11-12-tin-anniversary.md
@@ -72,24 +72,24 @@ I can do wacky and weird things that just aren't possible on big social media si
 Everything on the site is something I find fun or interesting.
 These are a few of my favourites:
 
-*   2016: [Tiling the plane with Pillow]({% post_url 2016/2016-10-21-tiling-the-plane-with-pillow %}) -- the first time I used programming to draw pictures, but definitely not the last.
+*   2016: [Tiling the plane with Pillow](/2016/tiling-the-plane-with-pillow/) -- the first time I used programming to draw pictures, but definitely not the last.
 
-*   2017: [A visit to the Crossness pumping station]({% post_url 2017/2017-06-07-crossness-pumping-station %})
+*   2017: [A visit to the Crossness pumping station](/2017/crossness-pumping-station/)
 
-*   2017: [Adventures in Python with concurrent.futures]({% post_url 2019/2019-10-16-adventures-with-concurrent-futures %}) – I write a lot of posts to help me understand a tricky concept, and this is one I revisit regularly.
+*   2017: [Adventures in Python with concurrent.futures](/2019/adventures-with-concurrent-futures/) – I write a lot of posts to help me understand a tricky concept, and this is one I revisit regularly.
 
-*   2019: [Reading a Chinese dictionary / 读一本中文字典]({% post_url 2019/2019-06-12-reading-a-chinese-dictionary %})
+*   2019: [Reading a Chinese dictionary / 读一本中文字典](/2019/reading-a-chinese-dictionary/)
 
-*   2019: [Getting a tint colour from an image with Python and *k*‑means]({% post_url 2019/2019-08-19-finding-tint-colours-with-k-means %})
+*   2019: [Getting a tint colour from an image with Python and *k*‑means](/2019/finding-tint-colours-with-k-means/)
 
-*   2020: [Illustrating lifecycle transitions in Amazon S3]({% post_url 2020/2020-05-01-illustrating-lifecycle-transitions-in-amazon-s3 %}) – which includes an idea which went on to be used in the official AWS documentation (!).
+*   2020: [Illustrating lifecycle transitions in Amazon S3](/2020/illustrating-lifecycle-transitions-in-amazon-s3/) – which includes an idea which went on to be used in the official AWS documentation (!).
 
-*   2020: [Maths is about facing ambiguity, not avoiding it]({% post_url 2020/2020-11-15-maths-is-about-facing-ambiguity-not-avoiding-it %})
+*   2020: [Maths is about facing ambiguity, not avoiding it](/2020/maths-is-about-facing-ambiguity-not-avoiding-it/)
 
-*   2021: [Drawing inner/outer strokes in SVG (clips and masks)]({% post_url 2021/2021-03-12-inner-outer-strokes-svg %}) – another post where I was writing to help me understand something.
+*   2021: [Drawing inner/outer strokes in SVG (clips and masks)](/2021/inner-outer-strokes-svg/) – another post where I was writing to help me understand something.
     I'm particularly pleased with the examples.
 
-*   2022: [“Fixing” the rules of division]({% post_url 2022/2022-09-23-moomin-mathematics %}) – I enjoyed drawing the Moomin illustrations.
+*   2022: [“Fixing” the rules of division](/2022/moomin-mathematics/) – I enjoyed drawing the Moomin illustrations.
 
 Making this site brings me joy, so I'm going to keep doing it.
 Let's see if I make it another ten years.

--- a/src/_posts/2022/2022-12-20-prismic-validation.md
+++ b/src/_posts/2022/2022-12-20-prismic-validation.md
@@ -178,7 +178,7 @@ I [fetch every page][curl] from a local copy of the site, check for errors, and 
 
 We get alerts for errors on the public site, and now we test a sample of URLs as part of deployment -- and testing everything helped find the "interesting" examples that went into that sample.
 
-[curl]: {% post_url 2022/2022-04-02-checking-with-curl %}
+[curl]: /2022/checking-with-curl/
 
 
 

--- a/src/_posts/2022/2022-12-31-2022-in-reading.md
+++ b/src/_posts/2022/2022-12-31-2022-in-reading.md
@@ -33,8 +33,8 @@ I've also been writing private notes on fiction books, usually the characters an
 These are my favourites from 2022, in the order I read them.
 They all get a strong recommendation from me.
 
-[library_lookup]: {% post_url 2022/2022-10-10-library-lookup %}
-[2021]: {% post_url 2021/2021-12-31-2021-in-reading %}
+[library_lookup]: /2022/library-lookup/
+[2021]: /2021/2021-in-reading/
 [books]: https://books.alexwlchan.net/
 
 <style type="x-text/scss">
@@ -111,7 +111,7 @@ He brought a lot of depth to the character, and I think I enjoyed it more than i
   %}
 </div>
 
-This is the sequel to *Written in the Stars*, which was one of my favourite books <a href="{% post_url 2021/2021-12-31-2021-in-reading %}#alexandria_bellefleur">last year</a>.
+This is the sequel to *Written in the Stars*, which was one of my favourite books <a href="/2021/2021-in-reading/#alexandria_bellefleur">last year</a>.
 
 It’s a romance novel, this time between Darcy’s brother Brendon and her best friend Annie.
 Where the first book used the fake dating trope, this one leans into big romantic gestures.

--- a/src/_posts/2022/2022-12-31-live-text-script.md
+++ b/src/_posts/2022/2022-12-31-live-text-script.md
@@ -23,7 +23,7 @@ This is the promise of "it just works": I [open an image in Preview][preview], h
     class="screenshot"
   %}
   <figcaption>
-    Staying off the tracks at <a href="{% post_url 2022/2022-11-28-bure-valley %}">the Bure Valley Railway</a>.
+    Staying off the tracks at <a href="/2022/bure-valley/">the Bure Valley Railway</a>.
   </figcaption>
 </figure>
 
@@ -60,6 +60,6 @@ I've tried and failed to install command-line OCR in the past; getting this work
 [preview]: https://support.apple.com/en-gb/guide/preview/prvw625a5b2c/mac
 [docs]: https://developer.apple.com/documentation/vision/recognizing_text_in_images#3601255
 [script]: https://github.com/alexwlchan/pathscripts/blob/main/macos/get_live_text
-[screenshots]: {% post_url 2022/2022-07-23-screenshots %}
+[screenshots]: /2022/screenshots/
 [second]: https://github.com/alexwlchan/pathscripts/blob/main/macos/get_all_live_text
 [Shortcuts app]: https://support.apple.com/en-gb/guide/shortcuts-mac/apdf22b0444c/mac

--- a/src/_posts/2023/2023-01-15-check-for-transparency.md
+++ b/src/_posts/2023/2023-01-15-check-for-transparency.md
@@ -35,7 +35,7 @@ But the big discovery for me was modern image formats like WebP and AVIF, which 
 WebP is good, AVIF is unbelievably good – literally.
 When I first enabled AVIF support, I thought I'd broken something, because a 5x compression ratio over WebP (which is what I'm seeing for some images) seemed impossible.
 
-I had it all tested and working, so imagine my dismay when I opened [my latest post]({% post_url 2023/2023-01-13-upward-assignment %}) on my phone and discovered the images were broken:
+I had it all tested and working, so imagine my dismay when I opened [my latest post](/2023/upward-assignment/) on my phone and discovered the images were broken:
 
 <style type="x-text/scss">
   #avif_comparison {

--- a/src/_posts/2023/2023-02-15-school-stuff.md
+++ b/src/_posts/2023/2023-02-15-school-stuff.md
@@ -36,7 +36,7 @@ I've recycled kilograms and kilograms of paper.
 
 What used to be six large crates is now four small boxes.
 
-[scanning and digitising]: {% post_url 2019/2019-11-27-my-scanning-setup %}
+[scanning and digitising]: /2019/my-scanning-setup/
 
 ---
 

--- a/src/_posts/2023/2023-02-16-css-formatting-in-the-console.md
+++ b/src/_posts/2023/2023-02-16-css-formatting-in-the-console.md
@@ -59,6 +59,6 @@ A few years ago, at a JavaScript meetup, I made a joke that *"my web development
 On days like today, it's clear that I still have more to learn.
 
 [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console#styling_console_output
-[bulb]: {% post_url 2023/2023-01-22-changing-the-bulb-in-a-meridian-lighting-cir100b-ceiling-light %}
+[bulb]: /2023/changing-the-bulb-in-a-meridian-lighting-cir100b-ceiling-light/
 [self-xss]: https://en.wikipedia.org/wiki/Self-XSS
 [printf]: https://en.wikipedia.org/wiki/Printf_format_string

--- a/src/_posts/2023/2023-02-20-testing-javascript-without-a-framework.md
+++ b/src/_posts/2023/2023-02-20-testing-javascript-without-a-framework.md
@@ -200,7 +200,7 @@ Here's an example of what a successful/failed test look like in the HTML it crea
 </p>
 ```
 
-The reason I'm inserting HTML instead of using console logging (even though I can do [formatting in the console]({% post_url 2023/2023-02-16-css-formatting-in-the-console %})) is that it's just a bit easier to see -- I only need a browser, I don't access to dev tools.
+The reason I'm inserting HTML instead of using console logging (even though I can do [formatting in the console](/2023/css-formatting-in-the-console/)) is that it's just a bit easier to see -- I only need a browser, I don't access to dev tools.
 I haven't written much JavaScript on my phone, but it is occasionally useful.
 
 I've also written a couple of assertion helpers, like you get in a proper test framework.

--- a/src/_posts/2023/2023-03-02-dictionaries-and-userdict.md
+++ b/src/_posts/2023/2023-03-02-dictionaries-and-userdict.md
@@ -34,7 +34,7 @@ What I wanted was a dictionary where `pairs[('Alice', 'Bryony')]` and `pairs[('B
 
 As I tried to actually implement this, I learnt a couple of new things about the collections module.
 
-[groups]: {% post_url 2023/2023-03-02-balancing-act %}
+[groups]: /2023/balancing-act/
 
 ---
 

--- a/src/_posts/2023/2023-03-13-cats-cross-stitch-and-copyright.md
+++ b/src/_posts/2023/2023-03-13-cats-cross-stitch-and-copyright.md
@@ -50,7 +50,7 @@ Here are a few of the pages:
 
 I don't remember a lot else from this time, but this project and the fact about cheetahs have a distinctive black "tear mark" has always stuck in my brain.
 
-[some old papers]: {% post_url 2023/2023-02-15-school-stuff %}
+[some old papers]: /2023/school-stuff/
 
 ---
 

--- a/src/_posts/2023/2023-05-11-redecorating-my-bedroom.md
+++ b/src/_posts/2023/2023-05-11-redecorating-my-bedroom.md
@@ -151,7 +151,7 @@ I did the same thing when I redecorated my office last year, and it made a big d
 I've lived with the new wall colours and furniture layout for about six weeks, and I'm really enjoying it.
 My bedroom has gone from drab and uninspiring, to warm and inviting.
 
-This is how my bed looks now (and yes, those are [cheetahs on the bedding]({% post_url 2023/2023-03-13-cats-cross-stitch-and-copyright %})):
+This is how my bed looks now (and yes, those are [cheetahs on the bedding](/2023/cats-cross-stitch-and-copyright/)):
 
 {%
   picture
@@ -185,7 +185,7 @@ My clothes have a lot of bright colours, and I like having them on display, wher
 Next to it, the door is hiding my messy laundry basket and waste bin.
 I can still get to them in a jiffy, but they're invisible most of the time.
 
-You'll also notice my [cheetah cross-stitch]({% post_url 2023/2023-03-13-cats-cross-stitch-and-copyright %}) on the wall – the yellow frame is a perfect match for my feature wall, which was a happy coincidence.
+You'll also notice my [cheetah cross-stitch](/2023/cats-cross-stitch-and-copyright/) on the wall – the yellow frame is a perfect match for my feature wall, which was a happy coincidence.
 The picture was being framed while I was doing the painting, and I'd forgotten I had it on order.
 
 I'll keep tweaking, including some photos on the wall, but in the meantime this has been a nice improvement to the room where I spend every not-waking hour.

--- a/src/_posts/2023/2023-05-25-managing-albums-in-photos.md
+++ b/src/_posts/2023/2023-05-25-managing-albums-in-photos.md
@@ -213,5 +213,5 @@ I doubt the Photos–AppleScript integration will ever change again, but PhotoKi
 This isn't the [first][appearance] [time][live_text] I've used Swift for scripting, and I doubt it'll be the last -- having easy access to Apple's frameworks makes it a very appealing choice.
 I haven't seen many other people using it yet, but I think Swift could be a big thing in Mac automation.
 
-[appearance]: {% post_url 2022/2022-11-17-changing-the-macos-accent-colour %}
-[live_text]: {% post_url 2022/2022-12-31-live-text-script %}
+[appearance]: /2022/changing-the-macos-accent-colour/
+[live_text]: /2022/live-text-script/

--- a/src/_posts/2023/2023-07-15-picture-plugin.md
+++ b/src/_posts/2023/2023-07-15-picture-plugin.md
@@ -235,7 +235,7 @@ When I first enabled AVIF support, I thought something was broken -- the files w
 
 [WebP]: https://en.wikipedia.org/wiki/WebP
 [AVIF]: https://en.wikipedia.org/wiki/AVIF
-[transparency]: {% post_url 2023/2023-01-15-check-for-transparency %}
+[transparency]: /2023/check-for-transparency/
 
 ---
 

--- a/src/_posts/2023/2023-07-28-cloudfront-logs.md
+++ b/src/_posts/2023/2023-07-28-cloudfront-logs.md
@@ -181,7 +181,7 @@ for log_entry in get_cloudfront_logs_from_dir("cf"):
     print(log_entry)
 ```
 
-[snake-walker]: {% post_url 2023/2023-07-26-snake-walker %}
+[snake-walker]: /2023/snake-walker/
 
 ---
 
@@ -245,4 +245,4 @@ I think the benefits of this abstraction will become apparent in another post I'
 The post will jump straight into a `for` loop of CloudFront log events, and it won't have to worry about exactly where those events come from.
 
 [Loop Like A Native]: https://nedbatchelder.com/text/iter.html
-[previous post]: {% post_url 2023/2023-07-26-snake-walker %}
+[previous post]: /2023/snake-walker/

--- a/src/_posts/2023/2023-08-19-hester.md
+++ b/src/_posts/2023/2023-08-19-hester.md
@@ -108,6 +108,6 @@ It's not a garden or a grand royal park, but I hope Hester would like it all the
 [tweet]: https://twitter.com/spitlip/status/1667806430831734784
 [fandom]: https://www.independent.co.uk/voices/world-war-operation-mincemeat-musical-theatre-b2371745.html
 [blue plaque]: https://en.wikipedia.org/wiki/Blue_plaque
-[sv]: {% post_url 2022/2022-07-02-saturn-v %}
+[sv]: /2022/saturn-v/
 [Fancy Alphabet]: https://www.wonderfulstitches.com/fancy-alphabet
 [Monaco]: https://stitchpoint.com/eng/tool/alph/cross-stitch-writer.php

--- a/src/_posts/2023/2023-08-26-iam-keys.md
+++ b/src/_posts/2023/2023-08-26-iam-keys.md
@@ -111,5 +111,5 @@ I was expecting I'd have to loop through every account, every user, every access
 Using these APIs was much simpler and quicker!
 
 [script]: https://github.com/wellcomecollection/aws-account-infrastructure/blob/f06cb97094ddeab27c58ca2a6123de2b90511651/scripts/describe_iam_access_key.py
-[tagging]: {% post_url 2023/2023-08-18-tag-iac-resources %}
+[tagging]: /2023/tag-iac-resources/
 [cloudtrail]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_access-keys-audit

--- a/src/_posts/2023/2023-09-19-obsidian-setup.md
+++ b/src/_posts/2023/2023-09-19-obsidian-setup.md
@@ -173,4 +173,4 @@ At least to me, it's always obvious which of these folders a note belongs in.
 This has been a constant feature of all my folder setups – I want to be able to file notes immediately, without thinking.
 I don't want to be wondering where a particular note should be stored on a day-to-day basis.
 
-[image gallery plugin]: {% post_url 2022/2022-11-04-obsidian-plugin %}
+[image gallery plugin]: /2022/obsidian-plugin/

--- a/src/_posts/2023/2023-09-28-spotting-spam-in-our-cloudfront-logs.md
+++ b/src/_posts/2023/2023-09-28-spotting-spam-in-our-cloudfront-logs.md
@@ -32,8 +32,8 @@ Over time, the load from the spam was starting to add up, and starting to crowd 
 We wanted to find a way to identify the spam, so we could return a "no results page" ASAP, without actually sending the query to our Elasticsearch cluster.
 It was usually "obvious" if you read the queries as a human, but how could we teach the computer to make the same distinction?
 
-[python]: {% post_url 2023/2023-07-28-cloudfront-logs %}
-[wp]: {% post_url 2023/2023-03-05-filtering-netlify-analytics %}
+[python]: /2023/cloudfront-logs/
+[wp]: /2023/filtering-netlify-analytics/
 [catalogue API]: https://developers.wellcomecollection.org/docs/catalogue
 
 ---

--- a/src/_posts/2023/2023-10-15-finding-big-photos.md
+++ b/src/_posts/2023/2023-10-15-finding-big-photos.md
@@ -112,7 +112,7 @@ Honestly, I think it's unlikely I'll ever watch these again -- I'm keeping them 
 I don't know if I'll use this exact script again, but it was a good opportunity to practice using Swift and PhotoKit.
 I'm gradually building a little collection of scripts and tools I can use to do stuff with photos, and this is another pebble on that pile.
 
-[blink]: {% post_url 2023/2023-06-18-blink %}
+[blink]: /2023/blink/
 [fetchAssets]: https://developer.apple.com/documentation/photokit/phasset/1624783-fetchassets
 [assetResources]: https://developer.apple.com/documentation/photokit/phassetresource/1623988-assetresources
 [head]: https://en.wikipedia.org/wiki/Head_(Unix)

--- a/src/_posts/2023/2023-12-07-mechanize-ssl.md
+++ b/src/_posts/2023/2023-12-07-mechanize-ssl.md
@@ -59,7 +59,7 @@ That seemed to work, and my mechanize browser was once again able to browse the 
 If you use popular HTTP libraries like [httpx] or [requests], they install and load SSL certificates from certifi automatically.
 I don't know why mechanize doesn't do the same, but it was just a one-line change to get it working correctly.
 
-[my library lookup tool]: {% post_url 2022/2022-10-10-library-lookup %}
+[my library lookup tool]: /2022/library-lookup/
 [mechanize]: https://pypi.org/project/mechanize/
 [about changing the certificates]: https://mechanize.readthedocs.io/en/latest/advanced.html#using-custom-ca-certificates
 [a quickstart example]: https://mechanize.readthedocs.io/en/latest/index.html

--- a/src/_posts/2023/2023-12-30-2023-in-reading.md
+++ b/src/_posts/2023/2023-12-30-2023-in-reading.md
@@ -34,7 +34,7 @@ card_attribution: |
   #the_hard_road_out       { @include book_styles(#f96970);}
 </style>
 
-I read 75 books this year, which is slightly up on previous years ([2022]({% post_url 2022/2022-12-31-2022-in-reading %}), [2021]({% post_url 2021/2021-12-31-2021-in-reading %})).
+I read 75 books this year, which is slightly up on previous years ([2022](/2022/2022-in-reading/), [2021](/2021/2021-in-reading/)).
 I’m pleased with that number, although overall I found it a slightly disappointing year for reading.
 Although I read more books, there were less that I really loved – less of the sort of book that changes my view on the world, that I’m still thinking about weeks later.
 

--- a/src/_posts/2024/2024-01-07-best-age-picker.md
+++ b/src/_posts/2024/2024-01-07-best-age-picker.md
@@ -322,10 +322,10 @@ Animation is one of those topics that's always been just beyond what I can do â€
 Now I have!
 
 [animate]: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/animate
-[SVG masks]: {% post_url 2021/2021-03-12-inner-outer-strokes-svg %}
-[circular arcs]: {% post_url 2022/2022-08-10-circle-party %}
+[SVG masks]: /2021/inner-outer-strokes-svg/
+[circular arcs]: /2022/circle-party/
 [rx]: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx
 [border-radius]: https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius
 [oldest humans]: https://en.wikipedia.org/wiki/Oldest_people
 [calcMode]: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/calcMode
-[hyperfocus]: {% post_url 2023/2023-10-20-hyperfocus-and-hobbies %}
+[hyperfocus]: /2023/hyperfocus-and-hobbies/

--- a/src/_posts/2024/2024-03-15-step-step-step.md
+++ b/src/_posts/2024/2024-03-15-step-step-step.md
@@ -31,7 +31,7 @@ This is the key message: *being a good user of AI is about both technical skills
 You need to know the mechanics of prompt engineering, what text you type in the box, yes.
 But you also need to know how much you trust the tool, and whether you can rely on its results -- if you don't, the output is useless.
 
-[curbcut]: {% post_url 2019/2019-01-31-monki-gras-the-curb-cut-effect %}
+[curbcut]: /2019/monki-gras-the-curb-cut-effect/
 
 ## What a lovely sense of ~gender~
 

--- a/src/_posts/2024/2024-04-02-commons-explorer.md
+++ b/src/_posts/2024/2024-04-02-commons-explorer.md
@@ -91,7 +91,7 @@ You can try the new Commons Explorer at [commons.flickr.org](https://commons.fli
   %}
 </div>
 
-[Monki Gras talk]: {% post_url 2024/2024-03-15-step-step-step %}
+[Monki Gras talk]: /2024/step-step-step/
 [search]: https://commons.flickr.org/search?query=dance
 [Commons Explorer]: https://commons.flickr.org/
 [conversations page]: https://commons.flickr.org/conversations/

--- a/src/about-the-site.md
+++ b/src/about-the-site.md
@@ -45,7 +45,7 @@ Feast your eyes on my evolving skills in web design.
 ## Mid 2022 to present: Cards for browsing the archive
 
 Most of the design is the same as in 2018, barring minor tweaks to spacing and text styles.
-I did add cards to the homepage to link to blog posts, as part of [a design refresh]({% post_url 2022/2022-06-03-new-archive %}) to make it easier for new visitors to find posts they might like in the backlog.
+I did add cards to the homepage to link to blog posts, as part of [a design refresh](/2022/new-archive/) to make it easier for new visitors to find posts they might like in the backlog.
 
 I also used this design on the "best of" posts page, because at nearly 350&nbsp;posts it was impossible for anybody who wasn't me to navigate the archive.
 

--- a/src/exams.md
+++ b/src/exams.md
@@ -6,7 +6,7 @@ title: Exam advice
 
 This is some advice that I originally gave to some [first-year maths students][1] while I was at university. But this advice isn't just useful for maths students at Cambridge: I believe this is applicable to technical subjects at many different levels. This is just a tidied-up version of my original advice.
 
-[1]: {% post_url 2014/2014-05-14-part-ia-exams %}
+[1]: /2014/part-ia-exams/
 
 This is my *personal* advice, and other people may say different things. Everybody learns and revises differently. Think about what will work best for you; don't just do something because I said so.
 

--- a/src/maths.md
+++ b/src/maths.md
@@ -32,7 +32,7 @@ I include the compiled PDF, and a link to the source code on Github.
 
 I've written a handful of essays on maths at different levels. They're not all online yet.
 
-* <a href="{% post_url 2013/2013-01-10-zero %}"><strong>Zero</strong></a>: an essay for a Sixth Form discussion group about the historical and mathematical significance of the number zero, and why it took so long to be accepted as a "real" number.
+* <a href="/2013/zero/"><strong>Zero</strong></a>: an essay for a Sixth Form discussion group about the historical and mathematical significance of the number zero, and why it took so long to be accepted as a "real" number.
 
 [latex]: http://www.latex-project.org/
 [groj]: https://www.dpmms.cam.ac.uk/~groj/

--- a/src/projects.md
+++ b/src/projects.md
@@ -228,7 +228,7 @@ If you'd like me to speak at your event, [get in touch](/#contact) for details.
 These are a few of my favourites:
 
 <dl>
-  <dt><a href="{% post_url 2019/2019-01-31-monki-gras-the-curb-cut-effect %}">The Curb Cut Effect</a></dt>
+  <dt><a href="/2019/monki-gras-the-curb-cut-effect/">The Curb Cut Effect</a></dt>
   <dd>
     A collection of stories about the “curb cut effect”: the idea that making something better for disabled people can make it better for everyone.
   </dd>
@@ -245,13 +245,13 @@ These are a few of my favourites:
     A fun lightning talk about the unexpected consequences of build automation.
   </dd>
 
-  <dt><a href="{% post_url 2018/2018-09-24-assume-worst-intent %}">Assume worst intent</a></dt>
+  <dt><a href="/2018/assume-worst-intent/">Assume worst intent</a></dt>
   <dd>
     If you’re designing services, it’s important to think about how they might be misused to hurt people.
     If you don’t think about this upfront, your users will find out the hard way.
   </dd>
 
-  <dt><a href="{% post_url 2019/2019-10-14-sans-io-programming %}">Sans I/O programming patterns: what, why, and how</a></dt>
+  <dt><a href="/2019/sans-io-programming/">Sans I/O programming patterns: what, why, and how</a></dt>
   <dd>
     I make my case for an approach to programming that gives you code which is dramatically simpler and easier to test.
   </dd>
@@ -405,7 +405,7 @@ I'm not currently taking an active maintainer role in anything, but these are a 
       </dt>
       <dd>
         Create pairs of interlocking hearts in a variety of Pride flags.
-        They use some SVG masking techniques I wrote about <a href="{% post_url 2021/2021-03-12-inner-outer-strokes-svg %}">in a blog post</a>.
+        They use some SVG masking techniques I wrote about <a href="/2021/inner-outer-strokes-svg/">in a blog post</a>.
       </dd>
     </dl>
 
@@ -461,7 +461,7 @@ I'm not currently taking an active maintainer role in anything, but these are a 
       <dd>
         Turning the fifteenth-century book <em>The Imitation of Christ</em> into a Twitter thread.
         This was my friend Jay’s idea.
-        You can read his post about <a href="https://jayhulme.com/blog/kempisbot">why we did it</a>, and my post about <a href="{% post_url 2021/2021-01-31-kempisbot %}">how we did it</a>.
+        You can read his post about <a href="https://jayhulme.com/blog/kempisbot">why we did it</a>, and my post about <a href="/2021/kempisbot/">how we did it</a>.
       </dd>
     </dl>
     
@@ -489,7 +489,7 @@ I'm not currently taking an active maintainer role in anything, but these are a 
       </dt>
       <dd>
         Create sets of interlocking Valknuts in a variety of Pride flags.
-        This is based on an idea by <a href="https://twitter.com/KlezmerGryphon/status/1173897515843735553">@KlezmerGryphon</a>, and it uses some code I wrote for <a href="{% post_url 2019/2019-09-23-triangular-coordinates-in-svg %}">drawing in triangular coordinates</a>.
+        This is based on an idea by <a href="https://twitter.com/KlezmerGryphon/status/1173897515843735553">@KlezmerGryphon</a>, and it uses some code I wrote for <a href="/2019/triangular-coordinates-in-svg/">drawing in triangular coordinates</a>.
       </dd>
     </dl>
 
@@ -571,7 +571,7 @@ I'm not currently taking an active maintainer role in anything, but these are a 
       </dt>
       <dd>
         Create simple geometric wallpapers from regular tilings of the plane.
-        I’ve written <a href="{% post_url 2016/2016-10-21-tiling-the-plane-with-pillow %}">blog</a> <a href="{% post_url 2016/2016-10-22-wallpapers-with-pillow %}">posts</a> about how this works.
+        I’ve written <a href="/2016/tiling-the-plane-with-pillow/">blog</a> <a href="/2016/wallpapers-with-pillow/">posts</a> about how this works.
       </dd>
     </dl>
     

--- a/src/skeletor.md
+++ b/src/skeletor.md
@@ -4,7 +4,7 @@ summary: A chart to track the progress of the Incomparable's Skeletor clip loop.
 title: Skeletor
 ---
 
-This is a page to track the latest version of my [recursive clip loop chart]({% post_url 2014/2014-06-29-skeletor %}) for *The Incomparable* podcast.
+This is a page to track the latest version of my [recursive clip loop chart](/2014/skeletor/) for *The Incomparable* podcast.
 
 Here's a high-resolution PNG:
 

--- a/src/writing.md
+++ b/src/writing.md
@@ -5,7 +5,7 @@ summary: My posts cover a range of topics, from programming to photography, from
 card_image: /theme/all_posts_card.png
 ---
 
-I write posts about a variety of non-fiction topics, from [books]({% post_url 2022/2022-12-31-2022-in-reading %}) to [braille]({% post_url 2019/2019-07-01-ten-braille-facts %}), from programming to photography, from [colour theory]({% post_url 2019/2019-08-19-finding-tint-colours-with-k-means %}) to [Chinese dictionaries]({% post_url 2019/2019-06-12-reading-a-chinese-dictionary %}).
+I write posts about a variety of non-fiction topics, from [books](/2022/2022-in-reading/) to [braille](/2019/ten-braille-facts/), from programming to photography, from [colour theory](/2019/finding-tint-colours-with-k-means/) to [Chinese dictionaries](/2019/reading-a-chinese-dictionary/).
 
 If you're new to the site, this page should give you an idea of the sort of thing I write, and help you find posts you might like [in the full archive](/all-posts/).
 I've tried to pick out examples of each category of post -- I think you'll find more to like here than trying to browse the archive chronologically.


### PR DESCRIPTION
This will make things easier when I move my posts into a new 'articles' collection, and the `{% post_url %}` tag stops working.  Also, this URL structure doesn't change very often, so this is a bit more portable.

This is some early refactoring before I introduce the "articles" collection in #741.