### PR TITLE
Remove the top-level /exams/ page; make it a hidden post

### DIFF
--- a/src/_posts/2014/2014-05-14-part-ia-exams.md
+++ b/src/_posts/2014/2014-05-14-part-ia-exams.md
@@ -6,11 +6,10 @@ tags:
   - cambridge
   - maths
 title: Some Part IA exam advice
+index:
+  exclude: true
 ---
-
-{% update 2015-03-29 %}
-  A lot of this advice is applicable to people who aren't in the first-year Maths Tripos at Cambridge, so I've tidied it up, and made a <a href="/exams">new page</a> for my updated advice. Corrections, fixes and updates will go there, not here.
-{% endupdate %}
+[**Update, 29 March 2015:** A lot of this advice is applicable to people who aren't in the first-year Maths Tripos at Cambridge, so I've tidied it up, and made a <a href="/2015/technical-exams/">new page</a> for my updated advice.]
 
 About a fortnight ago, I gave a talk to the first-year maths students[^1] as part of a session about preparing for exams. For the benefit of anybody who missed the session, didn't take notes, or future students, I decided to post my notes here.
 

--- a/src/_posts/2015/2015-03-29-technical-exams.md
+++ b/src/_posts/2015/2015-03-29-technical-exams.md
@@ -1,9 +1,15 @@
 ---
-layout: page
+layout: post
+date: 2015-03-29
+summary: Some advice for students doing exams in technical subjects
+tags:
+  - cambridge
+  - maths
+title: Some Part IA exam advice
 summary: Some advice for students sitting technical exams.
-title: Exam advice
+index:
+  exclude: true
 ---
-
 This is some advice that I originally gave to some [first-year maths students][1] while I was at university. But this advice isn't just useful for maths students at Cambridge: I believe this is applicable to technical subjects at many different levels. This is just a tidied-up version of my original advice.
 
 [1]: /2014/part-ia-exams/
@@ -87,5 +93,3 @@ Your health is far more important than any exam revision. It's easy to just focu
 ## Finally…
 
 I wish you the best of luck in whatever exam you're taking.
-
-Comments and feedback [are welcome](/contact/).

--- a/src/_redirects
+++ b/src/_redirects
@@ -1186,6 +1186,8 @@
 /2015/kings-cross-problems/                                     /410/ 410
 /2014/war-on-christmas/                                         /410/ 410
 
+/exams/                                                         /2015/technical-exams/
+
 # === #
 
 

--- a/src/maths.md
+++ b/src/maths.md
@@ -9,7 +9,7 @@ Now I've graduated, this page serves as a collection of all my mathematical cont
 
 I was the Part II Student Rep to the [Faculty Teaching Committee][tc] for the academic year 2013&ndash;14.
 
-I've posted my [exam advice for maths students](/exams) (and indeed, any other technical subject).
+I've posted my [exam advice for maths students](/2015/technical-exams/) (and indeed, any other technical subject).
 
 ## Lecture notes
 


### PR DESCRIPTION
This is a page tidy for #741 

I want to have less top-level pages, most of which I'm not maintaining in practice. This moves an old "exams" page into a dated post, and gets it out of the way.