### PR TITLE
Profile the performance of `jekyll build` in CI

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -74,7 +74,7 @@ jobs:
           restore-keys: "jekyll-cache-"
 
       - name: "Build the site"
-        run: bundle exec jekyll build --drafts
+        run: bundle exec jekyll build --drafts --profile
 
       - name: "Run linting"
         run: bundle exec ruby scripts/linter.rb


### PR DESCRIPTION
On a recent run, the overall time was 241s, of which I spent 73s in the site build – even though it already has a warm cache and shouldn't need to be doing much. Locally the same build takes ~2s.

Where's all the time going in CI?