### PR TITLE
What if I rely on Nokogiri from Bundler?

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -50,7 +50,7 @@ jobs:
         #     `require': cannot load such file -- json-schema (LoadError)
         #
         # Try installing them manually instead.
-      - run: gem install html-proofer json-schema nokogiri
+      - run: gem install html-proofer json-schema
 
       - name: "Set up Python"
         uses: actions/setup-python@v5

--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -44,14 +44,6 @@ jobs:
           bundler-cache: true
           cache-version: 1
 
-        # Not all the gems get installed properly for some reason, and
-        # I get errors like:
-        #
-        #     `require': cannot load such file -- json-schema (LoadError)
-        #
-        # Try installing them manually instead.
-      - run: gem install html-proofer
-
       - name: "Set up Python"
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -50,7 +50,7 @@ jobs:
         #     `require': cannot load such file -- json-schema (LoadError)
         #
         # Try installing them manually instead.
-      - run: gem install html-proofer json-schema
+      - run: gem install html-proofer
 
       - name: "Set up Python"
         uses: actions/setup-python@v5


### PR DESCRIPTION
Cleaning up a bit of lingering CI weirdness from #741.

It's meant to fix the issues with unpinned gems that I described and fixed in https://github.com/alexwlchan/alexwlchan.net/pull/777#issuecomment-2044379800. As a bonus, I suspect it will make the site quite a bit faster, because now all my installed Gems come from a Bundler cache. 💪 