### PR TITLE
Crank down the max line length; remove an old-style command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,7 +14,7 @@ AllCops:
     - 'vendor/**/*'
 
 Layout/LineLength:
-  Max: 170
+  Max: 140
 
 Metrics/AbcSize:
   Enabled: false

--- a/scripts/linting/check_all_urls_are_hackable.rb
+++ b/scripts/linting/check_all_urls_are_hackable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Check that every URL is "hackable".
 #
 # Quoting the slightly formal language of Nielsen Norman [1]:

--- a/scripts/linting/check_with_html_proofer.rb
+++ b/scripts/linting/check_with_html_proofer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'html-proofer'
 
 class LocalhostLinks < HTMLProofer::Check

--- a/scripts/linting/logging.rb
+++ b/scripts/linting/logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rainbow'
 
 # These commands are based on the logging in html-proofer; see

--- a/scripts/linting/netlify_redirects.rb
+++ b/scripts/linting/netlify_redirects.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Parse the Netlify `_redirects` file.
 #
 # See https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file

--- a/scripts/publish_drafts.rb
+++ b/scripts/publish_drafts.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This command does some automation with the _drafts folder.  Specifically,
 # when run, it:
 #

--- a/src/_plugins/article_cards.rb
+++ b/src/_plugins/article_cards.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Creates the images used in the cards, which appear on the site-wide index
 # and in social media previews.
 #

--- a/src/_plugins/css_fingerprint.rb
+++ b/src/_plugins/css_fingerprint.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Create a "fingerprint" of the CSS files.
 #
 # We want to be able to cache the CSS file for a long time, but we need

--- a/src/_plugins/filter_cleanup_text.rb
+++ b/src/_plugins/filter_cleanup_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Provides a filter that "cleans up" text.
 #
 # In particular this inserts HTML entities to prevent text wrapping

--- a/src/_plugins/filter_fix_kramdown.rb
+++ b/src/_plugins/filter_fix_kramdown.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This works around a few weirdnesses in Kramdown, where it "helpfully" adds
 # a closing slash to <img> and <source> tags in my <picture> blocks,
 # which get flagged as errors by HTML validators.

--- a/src/_plugins/static_file_generator.rb
+++ b/src/_plugins/static_file_generator.rb
@@ -7,6 +7,8 @@
 # in `_config.yml`.
 #
 
+require 'open3'
+
 module Jekyll
   class StaticFileGenerator < Generator
     def generate(site)
@@ -18,9 +20,10 @@ module Jekyll
 
       site.keep_files.each do |dir|
         next unless File.directory? "#{src}/_#{dir}"
-        unless system("rsync --archive #{src}/_#{dir}/ #{dst}/#{dir}/ --exclude=twitter/avatars --exclude=cards --exclude=icons --exclude=*.svg")
-          raise "Error running the static file rsync for #{dir}!"
-        end
+
+        _, status = Open3.capture2('rsync', '--archive', "#{src}/_#{dir}/", "#{dst}/#{dir}/", '--exclude=twitter/avatars',
+                                   '--exclude=cards', '--exclude=icons', '--exclude=*.svg')
+        raise 'Unable to run static file rsync' unless status.success?
       end
     end
   end


### PR DESCRIPTION
Running the entire command as one massive string is bad practice anyway; better to pass it as a structured series of arguments.

For #807