### PR TITLE
Fix a bunch of deprecation warnings from the Sass converter

### DIFF
--- a/src/_scss/base/text.scss
+++ b/src/_scss/base/text.scss
@@ -37,6 +37,7 @@ sup {
 .title {
   font-size: 1.9em;
   line-height: 1.45em;
+  margin-bottom: -6px;
   a {
     text-decoration: none;
   }
@@ -51,7 +52,6 @@ sup {
       content: "→";
     }
   }
-  margin-bottom: -6px;
 }
 
 .visually-hidden {

--- a/src/_scss/components/article_cards.scss
+++ b/src/_scss/components/article_cards.scss
@@ -12,14 +12,14 @@
     background: var(--article-card-background);
     border: 2px var(--border-style) var(--c-color);
 
-    &:hover .c_title {
-      text-decoration-thickness: 4px;
-    }
-
     --c-color: #d01c11;
 
     @media (prefers-color-scheme: dark) {
       --c-color: #ff4242;
+    }
+
+    &:hover .c_title {
+      text-decoration-thickness: 4px;
     }
   }
 
@@ -78,32 +78,35 @@
       font-size: 75%;
     }
   }
+}
 
-  /* This changes the number of columns based on the width of the
-   * screen:
-   *
-   *             width <=  450px   ~> one column, for mobile devices
-   *     450px < width <= 1000px   ~> two columns
-   *    1000px < width             ~> three columns, ultra-width screens
-   *
-   * I'm using minimax(0, 1fr) to ensure the columns are the exact
-   * same width, even if there's only one card in a collection.
-   * See https://stackoverflow.com/q/47601564/1558022
-   */
-
-  @media screen and (max-width: 450px) {
-    & {
-      grid-template-columns: auto;
-    }
+/* This changes the number of columns based on the width of the
+ * screen:
+ *
+ *             width <=  450px   ~> one column, for mobile devices
+ *     450px < width <= 1000px   ~> two columns
+ *    1000px < width             ~> three columns, ultra-width screens
+ *
+ * I'm using minimax(0, 1fr) to ensure the columns are the exact
+ * same width, even if there's only one card in a collection.
+ * See https://stackoverflow.com/q/47601564/1558022
+ */
+@media screen and (max-width: 450px) {
+  .article_cards {
+    grid-template-columns: auto;
   }
+}
 
+.article_cards {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+}
 
-  @media screen and (min-width: 1000px) {
-    & {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      margin-left: -100px;
-      margin-right: -100px;
-    }
+
+
+@media screen and (min-width: 1000px) {
+  .article_cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-left: -100px;
+    margin-right: -100px;
   }
 }

--- a/src/_scss/components/footer.scss
+++ b/src/_scss/components/footer.scss
@@ -76,12 +76,7 @@ footer {
     .background { fill: white; }
     .accent     { fill: none;  }
 
-    &:hover {
-      .accent { fill: white; }
-
-      /* Disable the default link hover styles */
-      background: none;
-    }
+    &:hover .accent { fill: white; }
 
     &[href="mailto:alex@alexwlchan.net"]:hover              .background { fill: #0067B9; }
     &[href="https://books.alexwlchan.net"]:hover            .background { fill: #333; }

--- a/src/_scss/components/nav.scss
+++ b/src/_scss/components/nav.scss
@@ -1,6 +1,13 @@
 nav {
   padding-top: calc(1px + env(safe-area-inset-top));
   padding-bottom: 1px;
+  
+  /* The nav gets the primary accent colour as background, with white text.
+   *
+   * It looks the same in light/dark mode.
+   */
+  background: var(--nav-background-url) var(--primary-color-light);
+  background-size: auto 100%;
 
   h1 {
     margin-bottom: -5px;
@@ -16,13 +23,6 @@ nav {
     padding-bottom: 0;
     margin-bottom: 14px;
   }
-
-  /* The nav gets the primary accent colour as background, with white text.
-   *
-   * It looks the same in light/dark mode.
-   */
-  background: var(--nav-background-url) var(--primary-color-light);
-  background-size: auto 100%;
 
   &, a, a:visited {
     color: white;

--- a/src/_scss/components/pretty_hr.scss
+++ b/src/_scss/components/pretty_hr.scss
@@ -8,15 +8,10 @@
   @return str-replace($output, '"', '%22');
 }
 
+/* In light mode, these squares are lighter than the text.
+ * In dark mode, they're the same colour.
+ */
 hr {
-  width:  105px;
-  height: 5px;
-  border: 0;
-  margin: 3.5em auto;
-
-  /* In light mode, these squares are lighter than the text.
-   * In dark mode, they're the same colour.
-   */
   $light-svg-url: create_svg(#ccc);
   $dark-svg-url:  create_svg($body-text-dark);
 
@@ -25,6 +20,13 @@ hr {
   @media (prefers-color-scheme: dark) {
     --hr-background-image: url("data:image/svg+xml;charset=UTF-8,#{$dark-svg-url}");
   }
+}
+
+hr {
+  width:  105px;
+  height: 5px;
+  border: 0;
+  margin: 3.5em auto;
 
   background-image:  var(--hr-background-image);
   background-size:   contain;


### PR DESCRIPTION
I'm getting warnings when I have rules after a nested selector – moving a few rules around fixes it.

I looked for a way to get warnings-as-errors in the Sass converter, but I couldn't find it.