### PR TITLE
Make a few small tweaks to CSS and visual appearance

### DIFF
--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -26,7 +26,7 @@
   {% endif %}
 
   {% if page.visible_tags.size > 0 %}
-  <li>
+  <li class="tags">
     Tagged with
     {% assign tags = page.visible_tags | sort %}
     {% for t in tags %}

--- a/src/_scss/base/layout.scss
+++ b/src/_scss/base/layout.scss
@@ -62,12 +62,6 @@ img.screenshot {
 
 
 @media (prefers-color-scheme: dark) {
-  body {
-    /* Pattern from https://www.toptal.com/designers/subtlepatterns/white-waves-pattern/,
-       then contrast dropped and colours flipped. */
-    background-image: url('/theme/black-waves-transparent.png');
-  }
-
   // see https://web.dev/prefers-color-scheme/#re-colorize-and-darken-photographic-images
   img:not([src*='.svg']):not(.dark_aware) {
     filter: grayscale(10%);

--- a/src/_scss/base/layout.scss
+++ b/src/_scss/base/layout.scss
@@ -7,13 +7,9 @@ body {
   /* This causes the footer to be pushed to the bottom of the viewport,
    * regardless of the size of the content.
    * See https://stackoverflow.com/q/643879/1558022 */
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   min-height: 100vh;
-
-  main {
-    flex: 1;
-  }
 }
 
 main, footer > *, nav > *, #editing-toolbar_inner {

--- a/src/_scss/base/layout.scss
+++ b/src/_scss/base/layout.scss
@@ -26,7 +26,7 @@ main, footer > *, nav > *, #editing-toolbar_inner {
 }
 
 img, video, svg, iframe, figure, article {
-  margin-left: auto;
+  margin-left:  auto;
   margin-right: auto;
 }
 

--- a/src/_scss/components/tags.scss
+++ b/src/_scss/components/tags.scss
@@ -1,0 +1,3 @@
+.tags a:hover {
+  color: var(--primary-color);
+}

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -67,6 +67,13 @@ $body-text-dark:  #c7c7c7;
     --screenshot-border-color: #3f3f3f;
 
     --article-card-background: #0d0d0d;
+
+    /* Background image for the page.
+     * This is "White Waves Pattern" by Stas Pimenov, with the colours
+     * flipped -- it's the same as the light background, but inverted.
+     * From https://www.toptal.com/designers/subtlepatterns/white-waves-pattern/
+     */
+    --background: url('/theme/black-waves-transparent.png');
   }
 }
 

--- a/src/static/style.scss
+++ b/src/static/style.scss
@@ -26,6 +26,7 @@
 @import "components/skip_to_main";
 @import "components/slides";
 @import "components/syntax_highlighting.scss";
+@import "components/tags.scss";
 @import "components/til.scss";
 
 $primary-color-light: #d01c11;


### PR DESCRIPTION
These are some changes extracted from #904 that aren't blocking, so I'm going to merge and deploy these immediately.

Some CSS refactoring, and two user-visible changes:

* When you hover over tags in the title of a post, the link is now highlighted with the tint colour
* Previously the publication date was the first item in the post meta, but now I've put tags there instead