### PR TITLE
De-emphasise dates throughout the site

### DIFF
--- a/src/_includes/article_card.html
+++ b/src/_includes/article_card.html
@@ -24,13 +24,5 @@
         </p>
       {% endif %}
     </div>
-
-    {% if include.hide_date != "true" %}
-    <div class="c_date">
-      <p>
-        {{- article.date | date: "%-d %B&nbsp;%Y" -}}
-      </p>
-    </div>
-    {% endif %}
   </a>
 </li>

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -18,13 +18,6 @@
       page.date_updated or
       page.link %}
 <ul class="dot_list meta">
-  {% if page.date %}
-  <li>
-    Posted
-    {% include timestamp.html date = page.date %}
-  </li>
-  {% endif %}
-
   {% if page.visible_tags.size > 0 %}
   <li class="tags">
     Tagged with
@@ -32,6 +25,13 @@
     {% for t in tags %}
       <a href="{{ include.index_page }}?tag={{ t }}">{{ t }}</a>{% unless forloop.last %}, {% endunless %}
     {% endfor %}
+  </li>
+  {% endif %}
+
+  {% if page.date %}
+  <li>
+    Posted
+    {% include timestamp.html date = page.date %}
   </li>
   {% endif %}
 

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -24,6 +24,13 @@ layout: compress
     <script>
       window.addEventListener("DOMContentLoaded", function() {
         document.querySelectorAll("img").forEach(function(img) {
+
+          // We don't need to show the alt text wrapper on card images, which
+          // never have alt text, and intentionally so.
+          if (img.classList.contains('c_image')) {
+            return;
+          }
+
           img.parentElement.innerHTML +=
             img.getAttribute('alt') !== null
               ? `<div style="background: yellow; font-family: monospace; padding: 5px;">Alt text: ${img.getAttribute("alt")}</div>`

--- a/src/_posts/2024/2024-09-13-digital-decluttering.md
+++ b/src/_posts/2024/2024-09-13-digital-decluttering.md
@@ -7,7 +7,7 @@ tags:
   - personal
   - digital-preservation
 colors:
-  css_dark:  "#78a2c2"
+  css_dark:  "#8ec0e6"
   css_light: "#3351a3"
 index:
   feature: true

--- a/src/_scss/components/article_cards.scss
+++ b/src/_scss/components/article_cards.scss
@@ -26,35 +26,24 @@
   .card a {
     text-decoration: none;
     height: 100%;
+  }
 
-    /* These styles ensure that the small "Posted" date on the bottom of the
-     * cards always sits at the bottom of each card, even if there's a
-     * different amount of text in each card.
-     *
-     * See https://stackoverflow.com/a/48406917/1558022
-     */
-    display: flex;
-    flex-direction: column;
+  .c_meta {
+    padding: 1em;
+  }
 
-    .c_title {
-      color: var(--c-color);
-      text-decoration: underline;
-      margin-top: 1em;
-      margin-bottom: 0.5em;
-      font-weight: normal;
-    }
+  .c_title {
+    color: var(--c-color);
+    text-decoration: underline;
+    margin-top: 0;
+    margin-bottom: 0.5em;
+    font-weight: normal;
   }
 
   .c_image {
     margin-top: 0;
     margin-bottom: 0;
     aspect-ratio: 2 / 1;
-  }
-
-  .c_meta {
-    padding-left:   1em;
-    padding-right:  1em;
-    padding-bottom: 1em;
   }
 
   .c_desc {

--- a/src/_scss/components/article_cards.scss
+++ b/src/_scss/components/article_cards.scss
@@ -51,32 +51,19 @@
     aspect-ratio: 2 / 1;
   }
 
-  .c_meta, .c_date {
-    padding-left:  1em;
-    padding-right: 1em;
+  .c_meta {
+    padding-left:   1em;
+    padding-right:  1em;
+    padding-bottom: 1em;
   }
 
   .c_desc {
     color: var(--body-text);
-    margin-top: 0.5em;
+    margin-top:    0.5em;
+    margin-bottom: 0;
+
     font-size: 85%;
     line-height: 1.45em;
-
-    // This means there's not too much of a gap between description/date,
-    // but in eggboxes the date gets hidden, so we skip this style.
-    &:not(:last-child) {
-      margin-bottom: 0;
-    }
-  }
-
-  .c_date {
-    margin-top: auto;
-
-    p {
-      color: var(--accent-grey);
-      margin-top: 0.5em;
-      font-size: 75%;
-    }
   }
 }
 

--- a/src/index.md
+++ b/src/index.md
@@ -117,7 +117,7 @@ Here are a few of my favourites:
   const featuredArticles = [
     {% for article in featured_articles %}
       {% capture articleHtml %}
-        {% include article_card.html hide_date="true" %}
+        {% include article_card.html %}
       {% endcapture %}
       {{ articleHtml | strip | jsonify }},
     {% endfor %}
@@ -134,7 +134,7 @@ Here are a few of my favourites:
 
 <ul class="article_cards" id="featured_articles">
 {% for article in sample_of_articles %}
-  {% include article_card.html hide_date="true" %}
+  {% include article_card.html %}
 {% endfor %}
 </ul>
 

--- a/src/til.md
+++ b/src/til.md
@@ -90,10 +90,6 @@ If you want to follow along, these posts have [their own RSS feed](/til/atom.xml
     <h4><a href="{{ til.url }}">{{ til.title | markdownify_oneline }}</a></h4>
 
     <ul class="dot_list meta">
-      <li>
-        Posted {% include timestamp.html date = til.date %}
-      </li>
-
       {% if til.visible_tags.size > 0 %}
       <li>
         Tagged with


### PR DESCRIPTION
Another piece extracted from #904; based on ideas in #827

The date when I wrote a piece is interesting… sometimes. Some of what I write is very timely, if it's about current affairs or a very particular version of a software tool. Then you want to know when I wrote it, because it might be out-of-date. Other times it's more timeless, and could be read and written at any time. For example, "Mountaintop moments" and "Digital decluttering".

Date is easy to sort on, but it's not an especially useful way to search the site. Nobody arrives to ask "what did Alex write on 22 July 2018", because it's not a current affairs site.

Dates are still visible on individual pages, but not on the index pages.