### PR TITLE
Make a couple of improvements to tags

### DIFF
--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -23,7 +23,13 @@
     Tagged with
     {% assign tags = page.visible_tags | sort %}
     {% for t in tags %}
-      <a href="/tags/{{ t }}/">{{ t }}</a>{% unless forloop.last %}, {% endunless %}
+      {% if t contains ":" %}
+        {% assign parts = t | split: ":" %}
+        <a href="/tags/{{ parts[0] }}/{{ parts[1] }}/">{{ t }}</a>
+      {%- else %}
+        <a href="/tags/{{ t }}/">{{ t }}</a>
+      {%- endif %}
+      {%- unless forloop.last %}, {% endunless %}
     {% endfor %}
   </li>
   {% endif %}

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -22,14 +22,9 @@
   <li class="tags">
     Tagged with
     {% assign tags = page.visible_tags | sort %}
-    {% for t in tags %}
-      {% if t contains ":" %}
-        {% assign parts = t | split: ":" %}
-        <a href="/tags/{{ parts[0] }}/{{ parts[1] }}/">{{ t }}</a>
-      {%- else %}
-        <a href="/tags/{{ t }}/">{{ t }}</a>
-      {%- endif %}
-      {%- unless forloop.last %}, {% endunless %}
+    {% for tag_name in tags %}
+      {% include tag_link.html -%}
+{%- unless forloop.last %}, {% endunless %}
     {% endfor %}
   </li>
   {% endif %}

--- a/src/_includes/tag_link.html
+++ b/src/_includes/tag_link.html
@@ -1,0 +1,6 @@
+{% if tag_name contains ":" %}
+  {% assign parts = tag_name | split: ":" %}
+  <a href="/tags/{{ parts[0] }}/{{ parts[1] }}/">{{ tag_name }}</a>
+{%- else -%}
+  <a href="/tags/{{ tag_name }}/">{{ tag_name }}</a>
+{%- endif -%}

--- a/src/_layouts/tag.html
+++ b/src/_layouts/tag.html
@@ -17,7 +17,11 @@ layout: default
 
 <article>
   <h1 class="title">
-    <a href="/tags/">Tags</a> » {{ page.tag }}
+    <a href="/tags/">Tags</a>
+    {% if page.namespace != "" %}
+    » <a href="/tags/{{ page.namespace }}/">{{ page.namespace }}</a>
+    {% endif %}
+    » {{ page.tag_name }}
   </h1>
 
   {% if page.featured_posts.size > 0 %}

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -3,10 +3,8 @@
 def visible?(tag_name, count)
   if tag_name.include?(':') && (count >= 3)
     true
-  elsif tag_name.include? ':'
-    false
   else
-    true
+    !tag_name.include? ':'
   end
 end
 

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -5,11 +5,7 @@ def visible?(tag_name, count)
     true
   end
 
-  if tag_name.include? ':'
-    false
-  else
-    true
-  end
+  !tag_name.include? ':'
 end
 
 Jekyll::Hooks.register :site, :post_read do |site|

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -5,11 +5,11 @@ def visible?(tag_name, count)
     true
   end
 
-  unless tag_name.include? ':'
+  if tag_name.include? ':'
+    false
+  else
     true
   end
-
-  false
 end
 
 Jekyll::Hooks.register :site, :post_read do |site|

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -105,7 +105,15 @@ module TagNavigation
     def initialize(site, visible_posts, tag)
       @site = site
       @base = site.source
-      @dir  = "tags/#{tag}"
+
+      if tag.include? ':'
+        namespace, tag_name = tag.split(':')
+        @dir = "tags/#{namespace}/#{tag_name}"
+      else
+        namespace = ''
+        tag_name = tag
+        @dir = "tags/#{tag}"
+      end
 
       @basename = 'index'
       @ext      = '.html'
@@ -122,7 +130,8 @@ module TagNavigation
 
       @data = {
         'layout' => 'tag',
-        'tag' => tag,
+        'namespace' => namespace,
+        'tag_name' => tag_name,
         'title' => "Tagged with ‘#{tag}’",
         'featured_posts' => featured_posts,
         'remaining_posts' => remaining_posts

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -1,5 +1,17 @@
 # This plugin contains a bunch of logic for the way I do tagging.
 
+def visible?(tag_name, count)
+  if tag_name.include?(':') && (count >= 3)
+    true
+  end
+
+  unless tag_name.include? ':'
+    true
+  end
+
+  false
+end
+
 Jekyll::Hooks.register :site, :post_read do |site|
   # This hook runs before the site is built, and adds the following fields
   # to the `site` object:
@@ -33,7 +45,7 @@ Jekyll::Hooks.register :site, :post_read do |site|
 
   site.data['visible_tags'] =
     site.data['tag_tally']
-        .filter { |_, count| count >= 3 }
+        .filter { |tag_name, count| visible?(tag_name, count) }
         .keys
 
   visible_posts.each do |doc|

--- a/src/_plugins/tagging.rb
+++ b/src/_plugins/tagging.rb
@@ -3,9 +3,11 @@
 def visible?(tag_name, count)
   if tag_name.include?(':') && (count >= 3)
     true
+  elsif tag_name.include? ':'
+    false
+  else
+    true
   end
-
-  !tag_name.include? ':'
 end
 
 Jekyll::Hooks.register :site, :post_read do |site|

--- a/src/_posts/2017/2017-02-11-backup-your-instapaper.md
+++ b/src/_posts/2017/2017-02-11-backup-your-instapaper.md
@@ -6,6 +6,8 @@ tags:
   - python
   - instapaper
 title: A script for backing up your Instapaper bookmarks
+index:
+  exclude: true
 ---
 
 About three days ago, there was [an extended outage][outage] at Instapaper.

--- a/src/_posts/2018/2018-05-14-google-duplex.md
+++ b/src/_posts/2018/2018-05-14-google-duplex.md
@@ -7,6 +7,8 @@ tags:
   - accessibility
   - ableism
   - inclusion
+index:
+  exclude: true
 ---
 
 Last week was Google I/O, and there was a lot of discussion around one of their keynote demos: Google Duplex.

--- a/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
+++ b/src/_posts/2018/2018-08-07-finding-slow-builds-in-travis.md
@@ -7,6 +7,8 @@ tags:
   - travis
   - python
   - builds-and-ci
+index:
+  exclude: true
 ---
 
 For a while, I've been whinging on Twitter about Scala compile times -- mostly driven by the ever-increasing length of the Travis builds at work.

--- a/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
+++ b/src/_posts/2020/2020-07-06-changing-the-accent-colour-of-icns-icons.md
@@ -85,7 +85,7 @@ I started writing about how to work with ICNS files in Pillow, and it got quite 
 I remembered the [Zen of Python][zen] -- *"If the implementation is hard to explain, it's a bad idea"* -- and I went back to the drawing board.
 
 [Pillow]: https://pillow.readthedocs.io/
-[pillow_posts]: /tags/python:pillow/
+[pillow_posts]: /tags/python/pillow/
 [pillow_icns]: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html?highlight=icns#icns
 [zen]: https://www.python.org/dev/peps/pep-0020/
 

--- a/src/_til/2024/2024-01-22-beware-of-test-n-with-command-expansion.md
+++ b/src/_til/2024/2024-01-22-beware-of-test-n-with-command-expansion.md
@@ -3,7 +3,7 @@ layout: til
 title: "Beware of using `test -n` with command expansion"
 date: 2024-01-22 10:16:06 +0000
 tags:
-  - fish
+  - fish-shell
 ---
 I'd written a fish script that used `test -n` (check for an empty string) and a command substitution, but I was seeing unexpected results:
 

--- a/src/_til/2024/2024-02-22-how-to-check-when-a-cert-expires.md
+++ b/src/_til/2024/2024-02-22-how-to-check-when-a-cert-expires.md
@@ -3,7 +3,7 @@ layout: til
 date: 2024-02-22 12:33:03 +0000
 title: How to check when an HTTPS certificate expires
 tags:
-  - https
+  - http
   - curl
 ---
 You can check whether a certificate is about to expire using the following `openssl` command:

--- a/src/index.md
+++ b/src/index.md
@@ -140,8 +140,8 @@ Here are some of my favourite things [that I've written](/articles/):
 Here are some of the topics I write about:
 
 <ul class="dot_list">
-  {% for tag in site.data['popular_tags'] %}
-  <li><a href="/tags/{{ tag }}/">{{ tag }}</a></li>
+  {% for tag_name in site.data['popular_tags'] %}
+    <li>{% include tag_link.html %}</li>
   {% endfor %}
 </ul>
 

--- a/src/tags.md
+++ b/src/tags.md
@@ -28,12 +28,7 @@ title: Tags
 <ul id="tags">
   {% for tag_name in visible_tags %}
     <li>
-      {% if tag_name contains ":" %}
-        {% assign parts = tag_name | split: ":" %}
-        <a href="/tags/{{ parts[0] }}/{{ parts[1] }}/">{{ tag_name }}</a>
-      {% else %}
-        <a href="/tags/{{ tag_name }}/">{{ tag_name }}</a>
-      {% endif %}
+      {% include tag_link.html %}
       ({{ site.data['tag_tally'][tag_name] }})
     </li>
   {% endfor %}

--- a/src/tags.md
+++ b/src/tags.md
@@ -28,7 +28,12 @@ title: Tags
 <ul id="tags">
   {% for tag_name in visible_tags %}
     <li>
-      <a href="/tags/{{ tag_name }}/">{{ tag_name }}</a>
+      {% if tag_name contains ":" %}
+        {% assign parts = tag_name | split: ":" %}
+        <a href="/tags/{{ parts[0] }}/{{ parts[1] }}/">{{ tag_name }}</a>
+      {% else %}
+        <a href="/tags/{{ tag_name }}/">{{ tag_name }}</a>
+      {% endif %}
       ({{ site.data['tag_tally'][tag_name] }})
     </li>
   {% endfor %}


### PR DESCRIPTION
* Show all tags, and only filter by frequency for namespacing
* Namespaced tags are now at namespaced URLs, e.g. `python:pillow` is under `/tags/python/pillow/`
* Namespaced tags now link to the parent tag