### PR TITLE
Add a GitHub Actions step to print the Netlify Deploy URL

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -111,6 +111,7 @@ jobs:
           fi
 
       - name: Deploy to Netlify
+        id: deploy_to_netlify
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: "_site"
@@ -124,6 +125,11 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: "da37a488-4df9-4cc2-b267-947179af20bd"
         timeout-minutes: 1
+
+      - name: Print Netlify Deploy URL
+        env:
+          SITE_URL: ${{steps.deploy_to_netlify.outputs.deploy-url}}
+        run: echo "$SITE_URL"
 
       - name: "Push any commits to GitHub"
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
This is a first step towards #933 – if I know where the site is deployed on Netlify, I can run tests against branch previews.