### PR TITLE
Assorted improvements and style fixes

### DIFF
--- a/src/_includes/article_cards.html
+++ b/src/_includes/article_cards.html
@@ -1,5 +1,5 @@
 <ul class="plain_list article_cards article_cards--{{ include.articles.size }}">
 {% for article in include.articles %}
-  {% include article_card.html hide_date="true" %}
+  {% include article_card.html %}
 {% endfor %}
 </ul>

--- a/src/_plugins/tag_picture.rb
+++ b/src/_plugins/tag_picture.rb
@@ -125,7 +125,7 @@ module Jekyll
       image = get_single_image_info(source_path)
       im_format = get_format(source_path, image)
 
-      @width = get_target_width(image, @bounding_box)
+      @width = get_target_width(source_path, image, @bounding_box)
 
       # These two attributes allow the browser to completely determine
       # the space that will be taken up by this image before it actually
@@ -344,7 +344,7 @@ module Jekyll
     #   - Setting the `width` attribute, which is used directly
     #   - Setting the `height` attribute, and then the width is scaled to match
     #
-    def get_target_width(image, bounding_box)
+    def get_target_width(source_path, image, bounding_box)
       if !bounding_box[:width].nil? && !bounding_box[:height].nil?
         raise "Picture #{@filename} supplies both width/height; this is unsupported"
       elsif !bounding_box[:width].nil?

--- a/src/_posts/2024/2024-08-20-create-thumbnail.md
+++ b/src/_posts/2024/2024-08-20-create-thumbnail.md
@@ -11,6 +11,8 @@ tags:
 colors:
   index_light: "#697c13"
   index_dark:  "#b6b86c"
+index:
+  feature: true
 ---
 I’ve made a new command-line tool: [create_thumbnail], which creates thumbnails of images.
 I need image thumbnails in a lot of projects, and I wanted a single tool I could use in all of them rather than having multiple copies of the same code.

--- a/src/_scss/components/code.css
+++ b/src/_scss/components/code.css
@@ -4,7 +4,7 @@ code, pre {
 }
 
 code {
-  font-size: calc(1em * var(--code-scaling-factor));
+  font-size: 88%;
 }
 
 pre {
@@ -12,7 +12,7 @@ pre {
     calc(2 * var(--default-padding) / 3)
     calc(var(--default-padding) - var(--border-width));
 
-  line-height: calc(var(--line-height) * var(--code-scaling-factor) * 1.08);
+  line-height: calc(var(--line-height) * 0.95);
 
   /* This ensures that code blocks don't get blown up to big sizes
    * on iPhone displays. */

--- a/src/_scss/text_styles.css
+++ b/src/_scss/text_styles.css
@@ -23,20 +23,20 @@ h2 {
 a {
   text-underline-offset: 2px;
   color: var(--link-color);
+}
 
-  &:visited { color: var(--link-visited-color); }
+a:visited { color: var(--link-visited-color); }
 
-  &:hover {
-    text-decoration: underline;
-    text-decoration-thickness: 4px;
-    text-decoration-skip-ink: none;
-  }
+a:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 4px;
+  text-decoration-skip-ink: none;
+}
 
-  &.download {
-    border-color: var(--link-color);
+a.download {
+  border-color: var(--link-color);
 
-    // We need to override the background styles
-    color: var(--link-color) !important;
-    background: rgba(white, 0.4) !important;
-  }
+  /* We need to override the background styles */
+  color: var(--link-color) !important;
+  background: rgba(white, 0.4) !important;
 }

--- a/src/_scss/text_styles.css
+++ b/src/_scss/text_styles.css
@@ -25,9 +25,12 @@ a {
   color: var(--link-color);
 }
 
-a:visited { color: var(--link-visited-color); }
+a:visited {
+  color: var(--body-text);
+}
 
 a:hover {
+  color: var(--link-color);
   text-decoration: underline;
   text-decoration-thickness: 4px;
   text-decoration-skip-ink: none;

--- a/src/_scss/text_styles.scss
+++ b/src/_scss/text_styles.scss
@@ -1,5 +1,5 @@
 body {
-  font: 13pt var(--text-font-family);
+  font: var(--font-size) var(--text-font-family);
   line-height: var(--line-height);
   color: var(--body-text);
 }

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -14,13 +14,12 @@ $body-text-dark:  #c7c7c7;
     --text-font-family: Charter, Georgia, Palatino, 'Palatino Linotype', Times, 'Times New Roman', serif;
     --mono-font-family: Menlo, Consolas, monospace;
 
-    --font-size: 1em;
+    --font-size: 13pt;
 
     --line-height: 1.5em;
 
     --meta-scaling-factor:     0.82;
     --footnote-scaling-factor: 0.95;
-    --code-scaling-factor:     0.88;
 
     /* =============================
      * Margins and page layout stuff

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -96,8 +96,7 @@ $body-text-dark:  #c7c7c7;
 
     --nav-background-url: url('/headers/specktre_#{color-to-hex-str($light-color)}.png');
 
-    --link-color:         #{$light-color};
-    --link-visited-color: #{darken($light-color, 15%)};
+    --link-color: #{$light-color};
 
     --block-border-color:     #{rgba($light-color, 0.1)};
     --block-background-color: #{hsla(hue($light-color), saturation($light-color), 95%, 0.4)};
@@ -107,8 +106,7 @@ $body-text-dark:  #c7c7c7;
     :root {
       --primary-color: #{$dark-color};
 
-      --link-color:         #{$dark-color};
-      --link-visited-color: #{darken($dark-color, 20%)};
+      --link-color: #{$dark-color};
 
       --block-border-color:     #{rgba($dark-color, 0.3)};
       --block-background-color: #{hsla(hue($dark-color), saturation($dark-color), 5%, 0.7)};

--- a/src/_til/2024/2024-12-25-limits-on-visited-styles.md
+++ b/src/_til/2024/2024-12-25-limits-on-visited-styles.md
@@ -1,0 +1,40 @@
+---
+layout: til
+title: There are limits on the styles you can apply with `:visited`
+date: 2024-12-25 20:04:39 +0000
+tags:
+  - css
+summary: |
+  Because the `:visited` selector will tell you whether somebody has been to a URL, browsers limit what styles you can apply to such links -- to prevent somebody nefarious stealing your browsing history.
+---
+I was tweaking the `a:visited` style on this site, and I was confused about why this wasn't working:
+
+```
+a:visited {
+  text-decoration-style: dashed;
+}
+```
+
+I thought it might be a browser bug, or maybe some bad interaction between other `text-decoration` rules, but it turns out to be an intentional choice.
+
+A [Stack Overflow answer](https://stackoverflow.com/a/35037025/1558022) pointed to a page on MDN [Privacy and the :visited selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Privacy_and_the_:visited_selector#limits_to_visited_link_styles), which explains:
+
+> Before about 2010, the CSS :visited selector allowed websites to uncover a user's browsing history and figure out what sites the user had visited. […] To mitigate this problem, browsers have limited the amount of information that can be obtained from visited links.
+
+and there are only a few styles you can apply to `:visited` links:
+
+> You can style visited links, but there are limits to which styles you can use. Only the following styles can be applied to visited links:
+>
+> * `color`
+> * `background-color`
+> * `border-color` (and its sub-properties)
+> * `column-rule-color`
+> * `outline-color`
+> * `text-decoration-color`
+> * `text-emphasis-color`
+> * The color parts of the `fill` and `stroke` attributes
+
+This is annoying for my purposes, but it makes sense, and I'm glad to know it's not my own incompetence that was preventing this CSS from working!
+
+I briefly considered trying to find ways around this, like doing something with variables or trying to trick the browser somehow, but I decided against it.
+It'd be a fragile hack, and any loophole I found should be reported and fixed rather than used for my own enjoyment.

--- a/src/index.md
+++ b/src/index.md
@@ -140,11 +140,17 @@ Here are some of my favourite things [that I've written](/articles/):
 
 Here are some of the topics I write about:
 
-<ul class="dot_list">
+<ul class="dot_list" id="popular_tags">
   {% for tag_name in site.data['popular_tags'] %}
     <li>{% include tag_link.html %}</li>
   {% endfor %}
 </ul>
+
+<style>
+  #popular_tags a:visited {
+    color: var(--link-color);
+  }
+</style>
 
 
 

--- a/src/static/style.scss
+++ b/src/static/style.scss
@@ -9,7 +9,7 @@
 
 @import "utils/functions.scss";
 
-@import "text_styles.scss";
+@import "text_styles";
 @import "utility_classes";
 
 @import "base/layout.scss";

--- a/src/tags.md
+++ b/src/tags.md
@@ -12,6 +12,10 @@ title: Tags
     line-height: 1.7em;
   }
 
+  #tags a:visited {
+    color: var(--link-color);
+  }
+
   @media screen and (min-width: 518px) {
     #tags {
       columns: 2;


### PR DESCRIPTION
This is a bunch of stuff extracted from my branch for "Not all blog posts are created equal", including:

* Converting `text_styles.scss` to vanilla CSS (for #893)
* Removing some redundant Liquid variables
* Fixing an error message when I try to create a `{% picture %}` which is wider than the source image
* Fixing a text sizing bug when you try to zoom in/out on the page
* Change the appearance of `:visited` links, because the current colour adjustments were quite confusing
* Add a quick TIL about the limitations of styling `:visited`

This reduces the average page size by ~5 bytes, which is to say basically nothing at all. 😢 