### PR TITLE
Fix the linter when you're running locally

### DIFF
--- a/scripts/linting/check_with_html_proofer.rb
+++ b/scripts/linting/check_with_html_proofer.rb
@@ -33,7 +33,7 @@ class CardImages < HTMLProofer::Check
     @html.css('meta[name="twitter:image"]').each do |node|
       @meta = create_element(node)
 
-      path = node['content'].gsub('https://alexwlchan.net/', '')
+      path = node['content'].gsub('http://localhost:5757/', '').gsub('https://alexwlchan.net/', '')
 
       return add_failure("Missing card image at #{path}", element: @meta) unless File.file?("_site/#{path}")
     end
@@ -41,7 +41,7 @@ class CardImages < HTMLProofer::Check
     @html.css('meta[name="og:image"]').each do |node|
       @meta = create_element(node)
 
-      path = node['content'].gsub('https://alexwlchan.net/', '')
+      path = node['content'].gsub('http://localhost:5757/', '').gsub('https://alexwlchan.net/', '')
 
       return add_failure("Missing card image at #{path}", element: @meta) unless File.file?("_site/#{path}")
     end


### PR DESCRIPTION
Previously the local linter would fail with hundreds of errors like:

    At _site/til/index.html:1:
    Missing card image at http://localhost:5757/images/profile_green_square.jpg

because we weren't snipping the localhost properly, now we do.

We were snipping the host in prod, but not for local dev.  This made it harder to spot linting errors locally.