### PR TITLE
Trim the page weight slightly, especially on the homepage

### DIFF
--- a/scripts/measure_pageweight.rb
+++ b/scripts/measure_pageweight.rb
@@ -2,6 +2,7 @@
 
 puts format('Homepage (/):           %2.1f KiB', File.size('_site/index.html') / 1024.0)
 puts format('Articles (/articles/): %3.1f KiB', File.size('_site/articles/index.html') / 1024.0)
+puts format('TIL      (/til/):       %2.1f KiB', File.size('_site/til/index.html') / 1024.0)
 
 sizes = []
 

--- a/src/_includes/article_card.html
+++ b/src/_includes/article_card.html
@@ -59,7 +59,7 @@
       </p>
       {%- if article.card.summary -%}
         <p class="c_desc">
-          {{- article.card.summary -}}
+          {{- article.card.summary | strip -}}
         </p>
       {%- endif -%}
     </div>

--- a/src/_layouts/til.html
+++ b/src/_layouts/til.html
@@ -8,7 +8,7 @@ layout: default
   
   {% if page.summary %}
     <p class="summary">
-      {{ page.summary | markdownify_oneline }}
+      {{ page.summary | markdownify_oneline | cleanup_text }}
     </p>
   {% endif %}
 

--- a/src/_plugins/cleanup_text.rb
+++ b/src/_plugins/cleanup_text.rb
@@ -170,7 +170,7 @@ module Jekyll
         text = text.gsub(' class="language-console highlighter-rouge"', 'class="language-console"')
         text = text.gsub(/ class="language-[a-z]+ highlighter-rouge"/, '')
 
-        text
+        text.strip
       end
     end
   end

--- a/src/_plugins/cleanup_text.rb
+++ b/src/_plugins/cleanup_text.rb
@@ -158,6 +158,19 @@ module Jekyll
         text
           .gsub('&#8617;', '&#8617;&#xFE0E;')
           .gsub('↩', '&#8617;&#xFE0E;')
+
+        # The syntax highlighter adds a couple of classes to my HTML,
+        # but I don't have any CSS that targets those classes.
+        #
+        # Removing them reduces the size of the final HTML, especially
+        # in the TIL index.
+        #
+        # The one class I leave behind is `language-console`, which I
+        # have some special styles for.
+        text = text.gsub(' class="language-console highlighter-rouge"', 'class="language-console"')
+        text = text.gsub(/ class="language-[a-z]+ highlighter-rouge"/, '')
+
+        text
       end
     end
   end

--- a/src/_plugins/compress_html.rb
+++ b/src/_plugins/compress_html.rb
@@ -6,11 +6,16 @@ module Jekyll
       cache = Jekyll::Cache.new('CompressHtml')
 
       cache.getset(html) do
-        # The syntax highlighter will add these classes to my HTML
-        # by default, but these are unstyled code blocks -- I don't
-        # need the classes.  Removing them reduces the size of the
-        # final HTML, especially in the TIL index.
-        html = html.gsub('<code class="language-plaintext highlighter-rouge">', '<code>')
+        # The syntax highlighter adds a couple of classes to my HTML,
+        # but I don't have any CSS that targets those classes.
+        #
+        # Removing them reduces the size of the final HTML, especially
+        # in the TIL index.
+        #
+        # The one class I leave behind is `language-console`, which I
+        # have some special styles for.
+        html = html.gsub(' class="language-console highlighter-rouge"', 'class="language-console"')
+        html = html.gsub(/ class="language\-[a-z]+ highlighter\-rouge"/, '')
 
         compressor = HtmlCompressor::Compressor.new
         html = compressor.compress(html)

--- a/src/_plugins/compress_html.rb
+++ b/src/_plugins/compress_html.rb
@@ -6,8 +6,16 @@ module Jekyll
       cache = Jekyll::Cache.new('CompressHtml')
 
       cache.getset(html) do
+        # The syntax highlighter will add these classes to my HTML
+        # by default, but these are unstyled code blocks -- I don't
+        # need the classes.  Removing them reduces the size of the
+        # final HTML, especially in the TIL index.
+        html = html.gsub('<code class="language-plaintext highlighter-rouge">', '<code>')
+
         compressor = HtmlCompressor::Compressor.new
-        compressor.compress(html)
+        html = compressor.compress(html)
+
+        html
       end
     end
   end

--- a/src/_plugins/compress_html.rb
+++ b/src/_plugins/compress_html.rb
@@ -6,21 +6,8 @@ module Jekyll
       cache = Jekyll::Cache.new('CompressHtml')
 
       cache.getset(html) do
-        # The syntax highlighter adds a couple of classes to my HTML,
-        # but I don't have any CSS that targets those classes.
-        #
-        # Removing them reduces the size of the final HTML, especially
-        # in the TIL index.
-        #
-        # The one class I leave behind is `language-console`, which I
-        # have some special styles for.
-        html = html.gsub(' class="language-console highlighter-rouge"', 'class="language-console"')
-        html = html.gsub(/ class="language\-[a-z]+ highlighter\-rouge"/, '')
-
         compressor = HtmlCompressor::Compressor.new
-        html = compressor.compress(html)
-
-        html
+        compressor.compress(html)
       end
     end
   end

--- a/src/_plugins/utils/markdownify_oneline.rb
+++ b/src/_plugins/utils/markdownify_oneline.rb
@@ -3,4 +3,5 @@ def apply_markdownify_oneline(site, input)
       .convert(input)
       .sub('<p>', '')
       .sub('</p>', '')
+      .strip
 end


### PR DESCRIPTION
* Remove some HTML classes that I'm not using, which are added by my syntax highlighting plugin
* Encode the JSON on the homepage in a slightly more efficient way

<table>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>Average page size</td>
<td>14.8 KiB</td>
<td>14.6 KiB (~1%)</td>
</tr>
<tr>
<td>Articles index (<code>/articles/</code>)</td>
<td>140.6 KiB</td>
<td>138.7 KiB (~1.4%)</td>
</tr>
<tr>
<td>TIL index (<code>/til/</code>)</td>
<td>45.4 KiB</td>
<td>38.5 KiB (~15%)</td>
</tr>
<tr>
<td>Homepage (<code>/</code>)</td>
<td>27.8 KiB</td>
<td>25.0 KiB (~10%)</td>
</tr>
</table>

These are fairly small gains, but they offset the fact that these pages are gradually getting larger as I write more stuff!

I want all of these pages to be nice and fast because they're how a lot of people will find stuff to read.