### PR TITLE
Add dark mode variants of the headers/footers

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -20,18 +20,21 @@
 <meta name="jekyll-environment" content="{{ jekyll.environment}}" >
 
 {% if page.colors.css_light %}
-  <meta name="theme-color" content="{{ page.colors.css_light }}" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="{{ page.colors.css_dark }}"  media="(prefers-color-scheme: dark)">
-
-  <link rel="shortcut icon" type="image/png"    href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.png">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.ico">
+  {% assign primary_color_light = page.colors.css_light | replace: "#", "" %}
+  {% assign primary_color_dark  = page.colors.css_dark  | replace: "#", "" %}
 {% else %}
-  <meta name="theme-color" content="#d01c11" media="(prefers-color-scheme: light)">
-  <meta name="theme-color" content="#ff4242" media="(prefers-color-scheme: dark)">
-
-  <link rel="shortcut icon" type="image/png"    href="/favicon.png" sizes="32x32">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" sizes="32x32">
+  {% assign primary_color_light = "d01c11" %}
+  {% assign primary_color_dark  = "ff4242" %}
 {% endif %}
+
+<meta name="theme-color" content="#{{ primary_color_light }}" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#{{ primary_color_dark  }}" media="(prefers-color-scheme: dark)">
+
+<link rel="icon" type="image/png"    href="/favicons/{{ primary_color_light }}.png" media="(prefers-color-scheme: light)">
+<link rel="icon" type="image/x-icon" href="/favicons/{{ primary_color_light }}.ico" media="(prefers-color-scheme: light)">
+
+<link rel="icon" type="image/png"    href="/favicons/{{ primary_color_dark }}.png" media="(prefers-color-scheme: dark)">
+<link rel="icon" type="image/x-icon" href="/favicons/{{ primary_color_dark }}.ico" media="(prefers-color-scheme: dark)">
 
 <link rel="apple-touch-icon" href="/theme/apple-touch-icon.png">
 

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -21,13 +21,15 @@
 <meta name="jekyll-environment" content="{{ jekyll.environment}}" >
 
 {% if page.colors.css_light %}
-  <link rel="icon" type="image/png"    href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.png">
-  <link rel="icon" type="image/x-icon" href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.ico">
-  <meta name="theme-color" content="{{ page.colors.css_light }}">
+  <link rel="shortcut icon" type="image/png"    href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.png">
+  <link rel="shortcut icon" type="image/x-icon" href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.ico">
+  <meta name="theme-color" content="{{ page.colors.css_light }}" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="{{ page.colors.css_dark }}"  media="(prefers-color-scheme: dark)">
 {% else %}
-  <link rel="icon" type="image/png"    href="/favicon.png" sizes="32x32">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="32x32">
-  <meta name="theme-color" content="#d01c11">
+  <link rel="shortcut icon" type="image/png"    href="/favicon.png" sizes="32x32">
+  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" sizes="32x32">
+  <meta name="theme-color" content="#d01c11" media="(prefers-color-scheme: light)">
+  <meta name="theme-color" content="#ff4242" media="(prefers-color-scheme: dark)">
 {% endif %}
 
 <link rel="apple-touch-icon" href="/theme/apple-touch-icon.png">

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -12,7 +12,6 @@
 {% endif %}
 
 {% assign safe_title = page.title | markdownify_oneline | strip_html %}
-
 <title>{% if page.title and page.title != site.title and page.title != "" %}{{ safe_title }} &ndash; {% endif %}{{ site.title }}</title>
 
 <meta name="description" content="{{ page.summary | default: site.description | escape }}">
@@ -21,15 +20,17 @@
 <meta name="jekyll-environment" content="{{ jekyll.environment}}" >
 
 {% if page.colors.css_light %}
-  <link rel="shortcut icon" type="image/png"    href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.png">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.ico">
   <meta name="theme-color" content="{{ page.colors.css_light }}" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="{{ page.colors.css_dark }}"  media="(prefers-color-scheme: dark)">
+
+  <link rel="shortcut icon" type="image/png"    href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.png">
+  <link rel="shortcut icon" type="image/x-icon" href="/favicons/{{ page.colors.css_light | replace: "#", "" }}.ico">
 {% else %}
-  <link rel="shortcut icon" type="image/png"    href="/favicon.png" sizes="32x32">
-  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" sizes="32x32">
   <meta name="theme-color" content="#d01c11" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#ff4242" media="(prefers-color-scheme: dark)">
+
+  <link rel="shortcut icon" type="image/png"    href="/favicon.png" sizes="32x32">
+  <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" sizes="32x32">
 {% endif %}
 
 <link rel="apple-touch-icon" href="/theme/apple-touch-icon.png">

--- a/src/_includes/head/css_variables.html
+++ b/src/_includes/head/css_variables.html
@@ -5,7 +5,7 @@
     --primary-color-dark:  {{ page.colors.css_dark  }};
 
     --nav-background-image-light: url('/headers/specktre_{{ page.colors.css_light | replace: "#", "" }}.png');
-    --nav-background-image-dark:  url('/headers/specktre_{{ page.colors.css_light | replace: "#", "" }}.png');
+    --nav-background-image-dark:  url('/headers/specktre_{{ page.colors.css_dark  | replace: "#", "" }}.png');
   }
 </style>
 {% endif %}

--- a/src/_includes/head/preload.html
+++ b/src/_includes/head/preload.html
@@ -1,13 +1,27 @@
 <link
   rel="preload"
-  href="https://alexwlchan.net/theme/white-waves-transparent.png"
+  href="{{ site.url }}/theme/white-waves-transparent.png"
   as="image"
   type="image/png"
   media="(prefers-color-scheme: light)"
 />
 <link
   rel="preload"
-  href="https://alexwlchan.net/theme/black-waves-transparent.png"
+  href="{{ site.url }}/theme/black-waves-transparent.png"
+  as="image"
+  type="image/png"
+  media="(prefers-color-scheme: dark)"
+/>
+<link
+  rel="preload"
+  href="{{ site.url }}/headers/specktre_{{ primary_color_light }}.png"
+  as="image"
+  type="image/png"
+  media="(prefers-color-scheme: light)"
+/>
+<link
+  rel="preload"
+  href="{{ site.url }}/headers/specktre_{{ primary_color_dark }}.png"
   as="image"
   type="image/png"
   media="(prefers-color-scheme: dark)"

--- a/src/_includes/head/socialgraph.html
+++ b/src/_includes/head/socialgraph.html
@@ -1,8 +1,13 @@
 <meta name="twitter:site" content="@alexwlchan">
 <meta name="twitter:title" content="{{ safe_title | xml_escape | strip }}">
 
+<meta property="og:type" content="article">
+<meta property="og:url" content="{{ site.url }}{{ page.url }}">
+<meta property="og:title" content="{{ safe_title | xml_escape | strip }}">
+
 {% if page.summary %}
   <meta name="twitter:description" content="{{ page.summary | xml_escape }}">
+  <meta property="og:description" content="{{ page.summary | xml_escape }}">
 {% endif %}
 
 {% if page.card.social %}
@@ -20,14 +25,6 @@
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="{{ site.url }}/images/profile_green_square.jpg">
   <meta property="og:image" content="{{ site.url }}/images/profile_green_square.jpg">
-{% endif %}
-
-<meta property="og:type" content="article">
-<meta property="og:url" content="{{ site.url }}{{ page.url }}">
-<meta property="og:title" content="{{ safe_title | xml_escape | strip }}">
-
-{% if page.summary %}
-  <meta property="og:description" content="{{ page.summary | xml_escape }}">
 {% endif %}
 
 <meta name="fediverse:creator" content="@alex@alexwlchan.net">

--- a/src/_plugins/tint_colors.rb
+++ b/src/_plugins/tint_colors.rb
@@ -44,34 +44,44 @@ def ensure_sufficient_contrast(css_colors)
   end
 end
 
+# This hook creates a header image and favicon for the default
+# light/dark colours.
 Jekyll::Hooks.register :site, :pre_render do
-  light_color = read_default_light_color
+  default_light_color = read_default_light_color
+  default_dark_color = read_default_dark_color
 
-  create_header_image(light_color)
-  create_favicon(light_color)
+  create_header_image(default_light_color)
+  create_header_image(default_dark_color)
 
-  hex_string = light_color.gsub('#', '')
+  create_favicon(default_light_color)
+  create_favicon(default_dark_color)
+
+  hex_string = default_light_color.gsub('#', '')
 
   FileUtils.cp("_site/favicons/#{hex_string}.png", '_site/favicon.png')
   FileUtils.cp("_site/favicons/#{hex_string}.ico", '_site/favicon.ico')
 end
 
-Jekyll::Hooks.register :pages, :pre_render do |page|
-  css_colors = get_css_colors(page.data)
-
-  unless css_colors.nil?
-    ensure_sufficient_contrast(css_colors)
-    create_header_image(css_colors['light'])
-    create_favicon(css_colors['light'])
-  end
-end
-
-Jekyll::Hooks.register :documents, :pre_render do |doc|
+# These hooks create the asset images for the custom CSS colors
+# on each post, page, and TIL.
+def create_asset_images(doc)
   css_colors = get_css_colors(doc.data)
 
   unless css_colors.nil?
     ensure_sufficient_contrast(css_colors)
+
     create_header_image(css_colors['light'])
+    create_header_image(css_colors['dark'])
+
     create_favicon(css_colors['light'])
+    create_favicon(css_colors['dark'])
   end
+end
+
+Jekyll::Hooks.register :pages, :pre_render do |page|
+  create_asset_images(page)
+end
+
+Jekyll::Hooks.register :documents, :pre_render do |doc|
+  create_asset_images(doc)
 end

--- a/src/_plugins/tint_colors.rb
+++ b/src/_plugins/tint_colors.rb
@@ -44,6 +44,24 @@ def ensure_sufficient_contrast(css_colors)
   end
 end
 
+# This hooks assigns CSS colors to every page.
+#
+# The colors are either:
+#
+#   - from the YAML front matter in the Markdown file, or
+#   - the default values
+#
+# def ensure_has_css_colors(doc)
+# end
+
+Jekyll::Hooks.register :pages, :pre_render do |page|
+  create_asset_images(page)
+end
+
+Jekyll::Hooks.register :documents, :pre_render do |doc|
+  create_asset_images(doc)
+end
+
 # This hook creates a header image and favicon for the default
 # light/dark colours.
 Jekyll::Hooks.register :site, :pre_render do

--- a/src/_plugins/utils/tint_colors.rb
+++ b/src/_plugins/utils/tint_colors.rb
@@ -27,6 +27,16 @@ def read_default_light_color
   match.named_captures['color']
 end
 
+# Get the dark color that will be used as the default colour if
+# no override tint color is specified.
+def read_default_dark_color
+  sass_source = File.read 'src/_scss/variables.scss'
+
+  match = sass_source.match('\-\-default-primary\-color\-dark:\s+(?<color>#[0-9a-f]{6});')
+
+  match.named_captures['color']
+end
+
 # Given a given hex colour as a string (e.g. '#123456') generate
 # an infinite sequence of colours which vary only in brightness.
 def get_colors_like(hex_color)

--- a/src/_posts/2025/2025-06-11-swift-bird-animation.md
+++ b/src/_posts/2025/2025-06-11-swift-bird-animation.md
@@ -10,7 +10,9 @@ index:
   feature: true
 colors:
   index_light: "#f8631e"
-  index_dark:  "#f4c790"
+  index_dark:  "#f7c057"
+  css_light:   "#cd4506"
+  css_dark:    "#f7c057"
 ---
 Last week, the Swift.org website [got a redesign][redesign].
 I don't write much Swift at the moment, but I glanced at the new website to see what's up and OOH COOL BIRD!

--- a/src/_scss/components/footer.css
+++ b/src/_scss/components/footer.css
@@ -8,7 +8,7 @@ footer {
    *
    * It looks the same in light/dark mode.
    */
-  background: var(--primary-color-light);
+  background: var(--primary-color);
 }
 
 footer,
@@ -16,6 +16,15 @@ footer a,
 footer a:hover,
 footer a:visited {
   color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+  footer,
+  footer a,
+  footer a:hover,
+  footer a:visited {
+    color: black;
+  }
 }
 
 @media print {

--- a/src/_scss/components/nav.css
+++ b/src/_scss/components/nav.css
@@ -9,12 +9,6 @@ nav {
   padding-top: calc(1px + env(safe-area-inset-top));
   padding-bottom: 1px;
 
-  /* The nav gets the primary accent colour as background, with white text.
-   *
-   * It looks the same in light/dark mode.
-   *
-   * TODO: Should I have light/dark mode for the nav?
-   */
   background: var(--nav-background-image) var(--primary-color);
   background-size: auto 100%;
 }

--- a/src/_scss/components/nav.css
+++ b/src/_scss/components/nav.css
@@ -34,11 +34,16 @@ nav, nav a, nav a:visited, nav a:hover {
 @media (prefers-color-scheme: dark) {
   /* These styles create a solid colour region behind the text, which gives
    * it a more consistent background than the header image. */
-  nav a,
-  nav ul.dot_list li:not(:last-child)::after {
+  nav a {
     background: var(--primary-color);
     padding: 10px  5px;
     margin: -10px -5px;
+  }
+  
+  nav ul.dot_list li:not(:last-child)::after {
+    background: var(--primary-color);
+    padding: 10px 0px;
+    margin: -10px 0px;
   }
 
   nav h1 a,

--- a/src/_scss/components/nav.css
+++ b/src/_scss/components/nav.css
@@ -15,7 +15,7 @@ nav {
    *
    * TODO: Should I have light/dark mode for the nav?
    */
-  background: var(--nav-background-image) var(--primary-color-light);
+  background: var(--nav-background-image) var(--primary-color);
   background-size: auto 100%;
 }
 
@@ -26,6 +26,7 @@ nav h1 {
 
 nav h1 a {
   text-decoration: none;
+  display: inline-block;
 }
 
 nav ul {
@@ -34,6 +35,33 @@ nav ul {
 
 nav, nav a, nav a:visited, nav a:hover {
   color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+  /* These styles create a solid colour region behind the text, which gives
+   * it a more consistent background than the header image. */
+  nav a,
+  nav ul.dot_list li:not(:last-child)::after {
+    background: var(--primary-color);
+    padding: 10px  5px;
+    margin: -10px -5px;
+  }
+
+  nav h1 a,
+  nav ul li:first-child a {
+    padding-left: 9px;
+    margin-left: -9px;
+  }
+
+  nav h1 a,
+  nav ul li:last-child a {
+    padding-right: 9px;
+    margin-right: -9px;
+  }
+  
+  nav, nav a, nav a:visited {
+    color: black;
+  }
 }
 
 /* Add an extra thick underline so you know which part of the site

--- a/src/_scss/variables.scss
+++ b/src/_scss/variables.scss
@@ -47,7 +47,7 @@ $default-padding: 20px;
   --primary-color-dark:  var(--default-primary-color-dark);
   
   --nav-background-image-light: url('/headers/specktre_d01c11.png');
-  --nav-background-image-dark:  url('/headers/specktre_d01c11.png');
+  --nav-background-image-dark:  url('/headers/specktre_ff4242.png');
   
   --link-color: var(--primary-color);
 


### PR DESCRIPTION
Headers and footers now match the tint colour:

![Screenshot 2025-06-16 at 07 40 11](https://github.com/user-attachments/assets/dd32efd3-735a-48e6-98ba-e86d5554869a)

The tricky part was working out how to render black text on top of the header graphics; I always found it quite difficult to read. It finally struck me that I could just add a solid colour background of the tint colour, and it's subtle enough not to stand out too much, and now the whole page matches. 💪 