### PR TITLE
article_cards: choose better sizes for each screen width

### DIFF
--- a/src/_includes/article_card.html
+++ b/src/_includes/article_card.html
@@ -27,9 +27,20 @@
       {% if article.card.index %}
         <picture>
           {% for src in article.card.index_image_template_params.sources %}
+          {% comment %}
+            There are two breakpoints for cards:
+            
+            * If the screen is 450px or narrower, there's only a single column
+              of cards -- which take up almost all the screen width.
+            * If the screen is 1000px or narrower, there are two columns of
+              cards, each of which takes up about half the screen
+            * If the screen is wider, there are three columns of cards,
+              which all have a fixed width of ~300px
+
+          {% endcomment %}
           <source
             srcset="{{ src.srcset }}"
-            sizes="(max-width: 450px) 405px,405px"
+            sizes="(max-width: 450px) 100vw,(max-width:1000px) 50vw,300px"
             type="{{ src.type }}"
           >
           {% endfor %}

--- a/src/_plugins/article_cards.rb
+++ b/src/_plugins/article_cards.rb
@@ -194,7 +194,7 @@ Jekyll::Hooks.register :site, :post_read do |site|
     # the light image.  If you're running a browser which doesn't
     # know about the <picture> tag, you're unlikely to be on a
     # device with a hi-res screen or dark mode.
-    default_image = sources[image['format'][:mime_type]].split[0]
+    default_image = sources[image['format']['mime_type']].split[0]
 
     sources = sources.map do |media_type, srcset|
       {

--- a/src/_plugins/tag_picture.rb
+++ b/src/_plugins/tag_picture.rb
@@ -199,7 +199,7 @@ module Jekyll
       # the light image.  If you're running a browser which doesn't
       # know about the <picture> tag, you're unlikely to be on a
       # device with a hi-res screen or dark mode.
-      default_image = lt_sources[im_format[:mime_type]].split[0]
+      default_image = lt_sources[im_format['mime_type']].split[0]
 
       # This creates a `sizes` attribute like
       #
@@ -233,7 +233,7 @@ module Jekyll
 
       if @link_to_original
         dst_prefix = get_dst_prefix(lt_source_path)
-        link_target = "#{dst_prefix.gsub('_site', '')}#{im_format[:extension]}"
+        link_target = "#{dst_prefix.gsub('_site', '')}#{im_format['extension']}"
       elsif @link_to
         link_target = @link_to
       else

--- a/src/_plugins/utils/pictures.rb
+++ b/src/_plugins/utils/pictures.rb
@@ -1,10 +1,10 @@
 class ImageFormat
-  AVIF = { extension: '.avif', mime_type: 'image/avif' }
+  AVIF = { 'extension' => '.avif', 'mime_type' => 'image/avif' }
 
-  WEBP = { extension: '.webp', mime_type: 'image/webp' }
+  WEBP = { 'extension' => '.webp', 'mime_type' => 'image/webp' }
 
-  JPEG = { extension: '.jpg',  mime_type: 'image/jpeg' }
-  PNG  = { extension: '.png',  mime_type: 'image/png' }
+  JPEG = { 'extension' => '.jpg',  'mime_type' => 'image/jpeg' }
+  PNG  = { 'extension' => '.png',  'mime_type' => 'image/png' }
 end
 
 # Get basic information about a single image
@@ -101,7 +101,7 @@ def create_source_elements(sources, source_im_format, options)
         <source
           srcset="#{sources[im_format].join(', ')}"
           sizes="#{options[:sizes]}"
-          type="#{im_format[:mime_type]}"
+          type="#{im_format['mime_type']}"
           media="(prefers-color-scheme: dark)"
         >
       HTML
@@ -110,7 +110,7 @@ def create_source_elements(sources, source_im_format, options)
         <source
           srcset="#{sources[im_format].join(', ')}"
           sizes="#{options[:sizes]}"
-          type="#{im_format[:mime_type]}"
+          type="#{im_format['mime_type']}"
         >
       HTML
     end
@@ -240,7 +240,7 @@ def create_image_sizes(source_path, dst_prefix, desired_formats, desired_widths,
                  "#{this_width}w"
                end
 
-      out_path = "#{dst_prefix}_#{suffix}#{out_format[:extension]}"
+      out_path = "#{dst_prefix}_#{suffix}#{out_format['extension']}"
 
       request = { 'in_path' => source_path, 'out_path' => out_path, 'target_width' => this_width }
       convert_image(request)
@@ -249,5 +249,5 @@ def create_image_sizes(source_path, dst_prefix, desired_formats, desired_widths,
     end
   end
 
-  sources.to_h { |fmt, srcset_values| [fmt[:mime_type], srcset_values.join(',')] }
+  sources.to_h { |fmt, srcset_values| [fmt['mime_type'], srcset_values.join(',')] }
 end

--- a/src/index.md
+++ b/src/index.md
@@ -160,7 +160,11 @@ Here are some of the topics I write about:
     const prefix = card.s.slice(0, card.p);
     const imPrefix = `/c/${yr}/${prefix}`;
 
-    const ws = [365,730,302,504,405,810];
+    const ws = [
+      365, 365 * 2,  /* 2-up column => ~365px wide */
+      302, 302 * 2,  /* 3-up column => ~302px wide */
+      405, 405 * 2   /* 1-up column => ~405px wide */
+    ];
     const avif    = ws.map(s => `${imPrefix}_${s}w.avif ${s}w`).join(", ");
     const webp    = ws.map(s => `${imPrefix}_${s}w.webp ${s}w`).join(", ");
     const primary = ws.map(s => `${imPrefix}_${s}w${suffix} ${s}w`).join(", ");

--- a/src/index.md
+++ b/src/index.md
@@ -154,8 +154,11 @@ Here are some of the topics I write about:
   function CardImage(card) {
     const yr = card.y;
 
-    const suffix = card.fm === 'J' ? '.jpg' : '.png';
-    const mimeType = card.fm === 'J' ? 'image/jpg' : 'image/png';
+    const suffix = card.fm === 0 ? '.jpg' : '.png';
+    const mimeType = card.fm === 0 ? 'image/jpg' : 'image/png';
+
+    console.log(card);
+    console.log(suffix);
 
     const prefix = card.s.slice(0, card.p);
     const imPrefix = `/c/${yr}/${prefix}`;
@@ -212,7 +215,7 @@ Here are some of the topics I write about:
     y = year - 2000
     s = slug
     p = length of prefix
-    fm = image format (J = JPEG, P = PNG)
+    fm = image format (0 = JPEG, 1 = PNG)
     d = description
   {% endcomment %}
   const keys = ["cl","cd","n","t","y","s","p","fm","d"];
@@ -228,9 +231,13 @@ Here are some of the topics I write about:
           {{ article.date | date: "%Y" | minus: 2000 }},
           {{ article.slug | jsonify }},
           {{ article.card.index_prefix | size }},
-          {{ article.card.index_image.format | slice: "0" | jsonify }},
+          {% if article.card.index_image.format.mime_type == "image/jpeg" %}
+            0
+          {% else %}
+            1
+          {% endif %},
           {% if article.summary %}
-            {{ article.summary | markdownify_oneline | cleanup_text | jsonify }}
+            {{ article.summary | markdownify_oneline | cleanup_text | replace: ' class="language-plaintext highlighter-rouge"', "" | jsonify }}
           {% else %}
             ""
           {% endif %}

--- a/src/index.md
+++ b/src/index.md
@@ -165,7 +165,8 @@ Here are some of the topics I write about:
     const webp    = ws.map(s => `${imPrefix}_${s}w.webp ${s}w`).join(", ");
     const primary = ws.map(s => `${imPrefix}_${s}w${suffix} ${s}w`).join(", ");
 
-    const sizes = "(max-width: 450px) 405px,405px";
+    // See comment in `article_card.html`
+    const sizes = "(max-width: 450px) 100vw,(max-width:1000px) 50vw,300px";
 
     return `
       <div class="c_im_w${card.n ? ' n' : ''}">


### PR DESCRIPTION
I got a warning in Google Pagespeed Insights that I was selecting overly large card images in some cases, especially on the homepage. Oops!

There are two fixes:

* Change the `sizes` attribute on the `<source>` element, so it's more dynamic with the size of the page – the use of `100vw`/`50vw` may cause browsers to select images which are larger than necessary, but only slightly so, and overall it's going to be an improvement
* Fix the `sizes` attribute of cards on the homepage – 604px wide, not 504px
* Fix the original format of cards on the homepage, as a fallback for browsers that don't support WebP or AVIF