### PR TITLE
Lay the groundwork for a couple of tag improvements

### DIFF
--- a/src/_data/tag_descriptions.yml
+++ b/src/_data/tag_descriptions.yml
@@ -1,0 +1,3 @@
+---
+liquid: Liquid is a template language made by Shopify, and I use it for the HTML templates that create this website.
+python: Python is a programming language that I use for scripting, automation and writing web apps. It’s the language I’m most familiar with, and my go-to language for new projects.

--- a/src/_includes/article_card.html
+++ b/src/_includes/article_card.html
@@ -36,11 +36,14 @@
               cards, each of which takes up about half the screen
             * If the screen is wider, there are three columns of cards,
               which all have a fixed width of ~300px
+              
+            However, we expand the default width to 370px to handle tag pages
+            which only have a small number of cards.
 
           {% endcomment %}
           <source
             srcset="{{ src.srcset }}"
-            sizes="(max-width: 450px) 100vw,(max-width:1000px) 50vw,300px"
+            sizes="(max-width: 450px) 100vw,(max-width:1000px) 50vw,370px"
             type="{{ src.type }}"
           >
           {% endfor %}

--- a/src/_layouts/tag.html
+++ b/src/_layouts/tag.html
@@ -19,20 +19,33 @@ layout: default
   .title + .article_cards {
     margin-top: 2.5em;
   }
-
-  article.til {
-    p.summary { font-weight: bold; }
+  
+  .tag_description {
+    font-weight: bold;
   }
 </style>
 
 <article>
-  <h1 class="title">
-    <a href="/tags/">Tags</a>
-    {% if page.namespace != "" %}
-    » <a href="/tags/{{ page.namespace }}/">{{ page.namespace }}</a>
-    {% endif %}
-    » {{ page.tag_name }}
-  </h1>
+  <hgroup>
+    <h1 class="title">
+      <a href="/tags/">Tags</a>
+      {% if page.namespace != "" %}
+      » <a href="/tags/{{ page.namespace }}/">{{ page.namespace }}</a>
+      {% endif %}
+      » {{ page.tag_name }}
+    </h1>
+
+    <p class="meta">
+      {% assign total_posts = page.featured_posts.size | plus: page.remaining_posts.size %}
+      {{ total_posts }} post{% if total_posts > 1 %}s{% endif %}
+    </p>
+  </hgroup>
+  
+  {% if site.data.tag_descriptions[page.tag_name] %}
+  <p class="tag_description">
+    {{ site.data.tag_descriptions[page.tag_name] }}
+  </p>
+  {% endif %}
 
   {% if page.featured_posts.size > 0 %}
     {% include article_cards.html articles=page.featured_posts %}
@@ -42,3 +55,4 @@ layout: default
     {% include article_links.html articles=page.remaining_posts %}
   {% endif %}
 </article>
+


### PR DESCRIPTION
* Show the number of posts in each tag on the individual tag pages
* Add optional descriptions for tag pages
* Fix a bug where card images weren't appearing correctly on tag pages with ≤4 featured posts