### PR TITLE
all: stop using the {% highlight %} tag

### DIFF
--- a/src/_posts/2020/2020-01-29-excluding-lots-of-folders-in-backblaze.md
+++ b/src/_posts/2020/2020-01-29-excluding-lots-of-folders-in-backblaze.md
@@ -65,8 +65,7 @@ If you'd like to use the script, you can find it below:
 <details>
 <summary>add_backblaze_exclusions.py</summary>
 
-{% highlight python %}
-#!/usr/bin/env python3
+{% code lang="python" names="0:datetime 1:os 2:pathlib 3:shutil 4:subprocess 5:sys 6:typing 7:Iterator 8:List 9:lxml 10:etree 11:get_dirs_to_exclude 18:dirname 19:argv 20:path 35:add_exclusion 36:root 39:exclude_dir 42:do_backup_elements 48:do_backup 50:already_excluded 62:dirfilter 81:save_backup_copy 82:bzinfo_path 85:today 90:backup_path 97:restart_backblaze 98:cmd 106:dirs_to_exclude 110:bzinfo_path 111:backup_path 116:root 120:exclude_dir 130:outfile" %}
 """
 Script for adding one-off folder exclusions to BackBlaze.
 
@@ -200,9 +199,7 @@ if __name__ == "__main__":
 
     print("*** Restarting BackBlaze")
     restart_backblaze()
-```
-
-{% endhighlight %}
+{% endcode %}
 </details>
 
 Since this is messing with your backup config, you should double-check when it's done -- does the list of folder exclusions in the settings look correct?

--- a/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
+++ b/src/_posts/2020/2020-02-23-adjusting-the-dominant-colour-of-an-image.md
@@ -66,9 +66,7 @@ A couple of people saw me doing it on Thursday, and asked me how, so here's my t
   <details>
   <summary>adjust_hue_in_svg.py</summary>
 
-{% highlight python %}
-#!/usr/bin/env python3
-
+{% code lang="python" names="0:colorsys 1:functools 2:pathlib 3:re 4:sys 5:adjust_hue 6:match 7:adjustment 8:hex_color_str 12:red 15:green 18:blue 21:hue 22:saturation 23:value 46:svg_path 55:svg_text 58:out_dir 66:color_matches 71:degrees_adjustment 73:new_svg_text 75:out_path" %}
 import colorsys
 import functools
 import pathlib
@@ -124,7 +122,7 @@ if __name__ == '__main__':
         )
 
         out_path.write_text(new_svg_text)
-{% endhighlight %}
+{% endcode %}
   </details>
   </li>
 </ul>

--- a/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
+++ b/src/_posts/2020/2020-03-08-stripey-flag-wallpapers.md
@@ -48,7 +48,7 @@ It always draws the stripes are roughly the same height and position on the scre
 
 <details>
   <summary>create_stripey_wallpapers.py</summary>
-{% highlight python %}
+{% code lang="python" names="0:PIL 1:Image 2:ImageDraw 3:create_wallpaper 4:stripes 5:background_color 6:im 12:draw 16:stripe_height 17:left_hand_midpoint 18:right_hand_midpoint 19:total_stripe_height 23:left_hand_top 25:right_hand_top 27:i 28:color 49:name 50:stripes 51:im" %}
 from PIL import Image, ImageDraw
 
 
@@ -121,7 +121,7 @@ if __name__ == '__main__':
     ]:
         im = create_wallpaper(stripes=stripes)
         im.save(f"wallpaper_{name}.jpg")
-{% endhighlight %}
+{% endcode %}
 </details>
 
 I've used it to create four mystery wallpapers, based on different flags with horizontal stripes:

--- a/src/_posts/2020/2020-04-27-using-dynamodb-as-a-calculator.md
+++ b/src/_posts/2020/2020-04-27-using-dynamodb-as-a-calculator.md
@@ -637,8 +637,7 @@ Sure, it's all here:
 <details>
 <summary>dynamo_calculator.py</summary>
 
-{% highlight python %}
-#!/usr/bin/env python
+{% code lang="python" names="0:contextlib 1:typing 2:Callable 3:uuid 4:boto3 5:dynamodb 8:DynamoCalculator 9:__enter__ 10:self 11:table_name 30:__exit__ 31:self 32:exc_type 33:exc_value 34:traceback 42:row_id 43:self 44:calculation_id 54:__repr__ 55:self 59:add 60:self 61:x 63:y 68:calculation_id 83:subtract 84:self 85:x 87:y 92:calculation_id 107:eq 108:self 109:x 111:y 116:calculation_id 127:exc 128:if_ 129:self 130:condition 132:if_true 135:if_false 141:calculation_id 151:exc 154:lt 155:self 156:x 158:y 163:calculation_id 174:exc 175:multiply 176:self 177:x 179:y 182:if_y_non_negative 192:if_y_negative 219:divide 220:self 221:x 223:y 226:if_y_negative 235:if_y_positive 262:not_ 263:self 264:condition 272:ne 273:self 274:x 276:y 285:or_ 286:self 287:condition1 289:condition2 310:le 311:self 312:x 314:y 327:gt 328:self 329:x 331:y 340:ge 342:x 344:y 353:and_ 354:self 355:condition1 357:condition2 378:nand 379:self 380:condition1 382:condition2 393:calculator 506:p 507:q" %}
 """
 What happens if you try to use DynamoDB as an integer calculator?
 """
@@ -963,7 +962,7 @@ if __name__ == "__main__":
                 f"{display(calculator.or_(p, q))}        | "
                 f"{display(calculator.nand(p, q))}"
             )
-{% endhighlight %}
+{% endcode %}
 
 </details>
 

--- a/src/_posts/2025/2025-03-10-new-banner.md
+++ b/src/_posts/2025/2025-03-10-new-banner.md
@@ -84,10 +84,10 @@ Let's step through it in detail.
     <p>
       First, create a container that includes both the image and the banner.
     </p>
-    {% highlight html %}<div class="container">
+    {% code lang="html" %}<div class="container">
   <div class="banner">NEW</div>
   <img src="computer.jpg">
-</div>{% endhighlight %}
+</div>{% endcode %}
     <p>
       Notice how the banner and image appear separately – they both have their own space in the layout.
     </p>
@@ -101,9 +101,9 @@ Let's step through it in detail.
     <p>
       I can add a CSS rule that makes the text appear on top of the image:
     </p>
-    {% highlight css %}.banner {
+    {% code lang="css" %}.banner {
   position: absolute;
-}{% endhighlight %}
+}{% endcode %}
     <p>
       This enables <a href="https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Positioning#absolute_positioning">absolute positioning</a>, which removes the banner from the normal document flow and allows it to be placed anywhere on the page.
       Now it sits alone, and it doesn't affect the layout of other elements on the page – in particular, the image no longer has to leave space for it.
@@ -117,7 +117,7 @@ Let's step through it in detail.
     <p>
       The text is in the top left corner of the image, but we can move it to the top right-hand instead:
     </p>
-    {% highlight css %}
+    {% code lang="css" %}
 .container {
   position: relative;
 }
@@ -126,7 +126,7 @@ Let's step through it in detail.
   transform: rotate(45deg);
   right:     16px;
   top:       20px;
-}{% endhighlight %}
+}{% endcode %}
   </div>
   <div class="container" id="wrapper3" style="width:200px;">
     <div class="banner">NEW</div>
@@ -175,10 +175,12 @@ This is because an absolutely positioned element takes its initial position from
     <p>
       Let's apply a colour to make this banner easier to read – the text is disappearing into the image.
     </p>
-    {% highlight css %}.banner {
+    {% code lang="css" %}
+.banner {
   background: red;
   color:      white;
-}{% endhighlight %}
+}
+    {% endcode %}
     <p>
       Right now the element is only as big as the letters in the word “NEW”, so it’s just floating in space – we need to make it wider, so it covers the whole corner.
     </p>
@@ -192,11 +194,13 @@ This is because an absolutely positioned element takes its initial position from
       We can make it wider by adding padding.
       Because this changes the size of the element, I had to adjust the position offsets to keep it in the right place.
     </p>
-    {% highlight css %}.banner {
+    {% code lang="css" %}
+.banner {
   right:   -34px;
   top:     18px;
   padding: 2px 50px;
-}{% endhighlight %}
+}
+    {% endcode %}
   </div>
   <div class="container" id="wrapper4" style="width:200px;">
     <div class="banner">NEW</div>
@@ -207,9 +211,11 @@ This is because an absolutely positioned element takes its initial position from
       Now the banner is too wide, and extending off the end of the image.
       Let’s clip the edges, so it fits neatly within the square:
     </p>
-    {% highlight css %}.container {
+    {% code lang="css" %}
+.container {
   overflow: hidden;
-}{% endhighlight %}
+}
+    {% endcode %}
     <p id="final_para">
       This is the banner effect I’m looking for – the text is clear and prominent on the image.
       I’ve added a <code>box-shadow</code> on my homepage to make it stand out further, but cosmetic details like that aren’t important for the rest of this post.

--- a/src/_posts/2025/2025-03-25-github-actions-audit.md
+++ b/src/_posts/2025/2025-03-25-github-actions-audit.md
@@ -101,9 +101,9 @@ Let's step through how it works.
 
 <dl>
 <dt>
-  {% highlight shell %}
+  {% code lang="shell" %}
 find . -path '*/.github/workflows/*' -type f -name '*.yml' -print0
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -127,9 +127,9 @@ find . -path '*/.github/workflows/*' -type f -name '*.yml' -print0
   </p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 xargs -0 grep --no-filename "uses:"
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -145,9 +145,9 @@ xargs -0 grep --no-filename "uses:"
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;uses: ruby/setup-ruby@v1</code></p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 sed 's/\- uses:/uses:/g' \
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -162,9 +162,9 @@ sed 's/\- uses:/uses:/g' \
   </p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 tr '"' ' '
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -180,9 +180,9 @@ tr '"' ' '
   </p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 awk '{print $2}'
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -197,9 +197,9 @@ ruby/setup-ruby@v1</code></p>
   </p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 sed 's/\r//g'
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>
@@ -208,9 +208,9 @@ sed 's/\r//g'
   </p>
 </dd>
 <dt>
-{% highlight shell %}
+{% code lang="shell" %}
 sort | uniq --count | sort --numeric-sort
-{% endhighlight %}
+{% endcode %}
 </dt>
 <dd>
   <p>

--- a/src/_posts/2025/2025-05-26-learning-how-to-make-websites.md
+++ b/src/_posts/2025/2025-05-26-learning-how-to-make-websites.md
@@ -206,10 +206,10 @@ I saw it on a number of sites that publish longer articles -- they used a progre
 </style>
 
 <blockquote id="progress_example">
-  {% highlight html -%}
+  {% code lang="html" wrap="true" %}
 <label for="file">Progress:</label>
 <progress id="file" max="100" value="70">70%</progress>
-  {%- endhighlight %}
+  {% endcode %}
 
   <div>
     <label for="file">File progress:</label>
@@ -319,9 +319,9 @@ Here's a link style from an old copy of the *Entertainment Weekly* website:
 </style>
 
 <blockquote id="underline_example">
-{% highlight css -%}
+{% code lang="css" %}
 a { box-shadow: inset 0 -6px 0 #b0e3fb; }
-{%- endhighlight %}
+{% endcode %}
 
   <div>
     <span style="box-shadow: inset 0 -6px 0 #b0e3fb;">

--- a/src/_til/2024/2024-06-06-how-to-highlight-python-console-in-jekyll.md
+++ b/src/_til/2024/2024-06-06-how-to-highlight-python-console-in-jekyll.md
@@ -15,12 +15,11 @@ I was writing another article for this site, and I created a code block with bac
   There's a zero-width space after "pycon" to stop my plugin from blatting it.
 {% endcomment %}
 
-{% highlight plain %}
-```pycon​
+<pre><code>```pycon​
 >>> print("Hello world!")
 Hello world!
 ```
-{% endhighlight %}
+</code></pre>
 
 Apparently this doesn't work with Rouge, the syntax highlighter used by Jekyll and this site -- I got an unformatted `<pre>` block.
 (A fact which has taken me far too long to notice!)
@@ -36,12 +35,11 @@ It's just a bit non-obvious.
 Rouge has a `console` lexer which I've used quite a few times, and that lexer can take options including `lang` and `prompt`.
 By passing these options to the language identifier, I was able to get Python console session with syntax highlighting:
 
-{% highlight plain %}
-```console?lang=python&prompt=>>>,...
+<pre><code>```console?lang=python&prompt=>>>,...
 >>> print("Hello world!")
 Hello world!
 ```
-{% endhighlight %}
+</code></pre>
 
 (It occurs to me that if Rouge ever adds support [for the Fish shell](https://github.com/rouge-ruby/rouge/issues/1108), I might want to add `lang=fish` to my other uses of <code>```console</code>.)
 
@@ -51,12 +49,12 @@ That solution works, but it's a bit ugly and I won't remember to do it.
 
 So I wrote [a Jekyll hook](https://jekyllrb.com/docs/plugins/hooks/) that modifies my Markdown source to replace `pycon` with `console?lang=…` whenever my site gets built:
 
-```ruby
+{% code lang="ruby" names="3:p" %}
 # _plugins/pycon_rouge_highlighter.rb
 Jekyll::Hooks.register(%i[pages posts], :pre_render) do |p|
   p.content = p.content.gsub("\n```pycon\n", "\n```console?lang=python&prompt=>>>,...\n")
 end
-```
+{% endcode %}
 
 This is quite a brittle fix, but for my small site it should be fine.
 

--- a/src/bookmarklets.md
+++ b/src/bookmarklets.md
@@ -33,7 +33,7 @@ This bookmarklet pops up a dialog with the exact date a post was published.
 
 <details><summary>Source code</summary>
 
-{% highlight javascript %}
+{% code lang="javascript" names="0:jsonLdElement 3:jsonLd 8:datePublished 11:format" %}
 /* In the <head> of each Tumblr post is a block of JSON-LD (=Linked Data)
  * which has some machine-readable info about the post, e.g.
  *
@@ -61,5 +61,5 @@ var format = new Intl.DateTimeFormat("en-GB", {
 alert(`This post was published on ${format.format(datePublished)}.`);
 ```
 
-{% endhighlight %}
+{% endcode %}
 </details>


### PR DESCRIPTION
I was only using this in a handful of posts, and otherwise I prefer to use {% code %}. The old tag wasn't even working correctly, and it's breaking the new Python build system. Get rid of it!

While I'm here, I added the new syntax highlighting to some old posts.

For #1138
For #1165