### PR TITLE
meta: replace the `page.meta` variable with `page.part_of`

### DIFF
--- a/front-matter.json
+++ b/front-matter.json
@@ -81,12 +81,20 @@
             },
             "additionalProperties": false
         },
-        "meta": {
-            "description": "Used on pages for miscellaneous information. Deprecated; should be replaced by purpose-named fields.",
-            "type": "array",
-            "items": {
-                "type": "string"
-            }
+        "part_of": {
+            "description": "An anchor tag that describes what section of the site this is part of",
+            "type": "object",
+            "properties": {
+                "url": {
+                    "description": "The URL of the site section",
+                    "type": "string"
+                },
+                "label": {
+                    "description": "The description of this section",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
         },
         "nav_section": {
             "description": "Which section of the site this page/post belongs to.",

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -14,7 +14,7 @@
 
 {%- if page.date or
       page.visible_tags.size > 0 or
-      page.meta or
+      page.part_of or
       page.date_updated or
       page.link -%}
 <ul class="dot_list meta">
@@ -31,10 +31,10 @@
   {%- if page.date -%}
   <li>Posted {% include timestamp.html date = page.date -%}</li>
   {%- endif -%}
-
-  {%- for m in page.meta -%}
-  <li>{{- m -}}</li>
-  {%- endfor -%}
+  
+  {%- if page.part_of -%}
+  <li>Part of <a href="{{ page.part_of.url }}">{{ page.part_of.label|smartify }}</a></li>
+  {%- endif -%}
 
   {%- if page.date_updated -%}
   <li>Last updated {% include timestamp.html date = page.date_updated -%}</li>

--- a/src/a-plumbers-guide-to-git/1-the-git-object-store.md
+++ b/src/a-plumbers-guide-to-git/1-the-git-object-store.md
@@ -2,8 +2,9 @@
 layout: page
 date_updated: 2018-03-13T08:20:41Z
 title: "Part 1: The Git object store"
-meta:
-  - Part of <a href="/a-plumbers-guide-to-git/">A Plumber&rsquo;s Guide to Git</a>
+part_of:
+  url: /a-plumbers-guide-to-git/
+  label: "A Plumber's Guide to Git"
 ---
 
 We'll start by working with single files.

--- a/src/a-plumbers-guide-to-git/2-blobs-and-trees.md
+++ b/src/a-plumbers-guide-to-git/2-blobs-and-trees.md
@@ -2,8 +2,9 @@
 layout: page
 date_updated: 2018-03-13T08:20:49Z
 title: "Part 2: Blobs and trees"
-meta:
-  - Part of <a href="/a-plumbers-guide-to-git/">A Plumber&rsquo;s Guide to Git</a>
+part_of:
+  url: /a-plumbers-guide-to-git/
+  label: "A Plumber's Guide to Git"
 ---
 
 I'm assuming you've already read and completed [part 1][part 1], which explains how to store and retrieve single files.

--- a/src/a-plumbers-guide-to-git/3-context-from-commits.md
+++ b/src/a-plumbers-guide-to-git/3-context-from-commits.md
@@ -2,8 +2,9 @@
 layout: page
 date_updated: 2018-03-13T08:20:51Z
 title: "Part 3: Context from commits"
-meta:
-  - Part of <a href="/a-plumbers-guide-to-git/">A Plumber&rsquo;s Guide to Git</a>
+part_of:
+  url: /a-plumbers-guide-to-git/
+  label: "A Plumber's Guide to Git"
 ---
 
 If you've got this far, you should have finished [part 1][part 1] and [part 2] -- if not, return to those first.

--- a/src/a-plumbers-guide-to-git/4-refs-and-branches.md
+++ b/src/a-plumbers-guide-to-git/4-refs-and-branches.md
@@ -2,8 +2,9 @@
 layout: page
 date_updated: 2018-03-13T08:20:53Z
 title: "Part 4: Refs and branches"
-meta:
-  - Part of <a href="/a-plumbers-guide-to-git/">A Plumber&rsquo;s Guide to Git</a>
+part_of:
+  url: /a-plumbers-guide-to-git/
+  label: "A Plumber's Guide to Git"
 ---
 
 At the end of part 3, we've seen how to take snapshots of the repo with trees, attach context with commits, and construct commits into a sequence -- but passing around commit hashes is unwieldy.

--- a/src/a-plumbers-guide-to-git/conclusion.md
+++ b/src/a-plumbers-guide-to-git/conclusion.md
@@ -2,8 +2,9 @@
 layout: page
 date_updated: 2018-03-13T08:20:56Z
 title: "A Plumber's Guide to Git: Conclusion"
-meta:
-  - Part of <a href="/a-plumbers-guide-to-git/">A Plumber&rsquo;s Guide to Git</a>
+part_of:
+  url: /a-plumbers-guide-to-git/
+  label: "A Plumber's Guide to Git"
 ---
 
 Well done for getting this far!


### PR DESCRIPTION
I was only using the `meta` variable for one thing, and it was confusing. Replacing it with a named field makes it clearer what this is for.