### PR TITLE
all: add YouTube to social embeds; add double quotes

### DIFF
--- a/src/_data/social_embeds.json
+++ b/src/_data/social_embeds.json
@@ -1,4 +1,32 @@
 {
+  "https://www.youtube.com/watch?v=Ej2EJVMkTKw": {
+    "site": "youtube",
+    "title": "Using privilege to improve inclusion"
+  },
+  "https://www.youtube.com/watch?v=QoKdDK3y-mQ": {
+    "site": "youtube",
+    "title": "ШАХМАТЫ в которые трудно играть даже ПРОфессионалам !"
+  },
+  "https://www.youtube.com/watch?v=A1FWQvaBoRg": {
+    "site": "youtube",
+    "title": "Attenborough: Golden Frog: Fighting & Mating | Life in Cold Blood | BBC Studios"
+  },
+  "https://www.youtube.com/watch?v=6Yf3iukx3tQ": {
+    "site": "youtube",
+    "title": "The Curb Cut Effect"
+  },
+  "https://www.youtube.com/watch?v=qwTWqy0uPbY": {
+    "site": "youtube",
+    "title": "Sans I/O programming patterns: what, why, and how"
+  },
+  "https://www.youtube.com/watch?v=XyGVRlRyT-E": {
+    "site": "youtube",
+    "title": "Assume Worst Intent"
+  },
+  "https://www.youtube.com/watch?v=B3XxPnbehqQ": {
+    "site": "youtube",
+    "title": "Building trust in an age of suspicious minds"
+  },
   "https://code4lib.social/@linguistory/113924700205617006": {
     "site": "mastodon",
     "id": "113924700205617006",

--- a/src/_includes/embeds/youtube.html
+++ b/src/_includes/embeds/youtube.html
@@ -1,10 +1,10 @@
-{% assign video_id = include.url | split: '=' | last %}
+{% assign video_id = post_url | split: '=' | last %}
 
 <iframe
   class="youtube"
   id="youtube_{{ video_id }}"
   src="https://www.youtube-nocookie.com/embed/{{ video_id }}"
-  title="{{ include.title }}"
+  title="{{ post_data['title'] }}"
   credentialless
   sandbox="allow-scripts allow-same-origin"
   allow="accelerometer 'none'; ambient-light-sensor 'none'; autoplay 'none'; battery 'none'; bluetooth 'none'; browsing-topics 'none'; camera 'none'; ch-ua 'none'; display-capture 'none'; domain-agent 'none'; document-domain 'none'; encrypted-media 'none'; execution-while-not-rendered 'none'; execution-while-out-of-viewport 'none'; gamepad 'none'; geolocation 'none'; gyroscope 'none'; hid 'none'; identity-credentials-get 'none'; idle-detection 'none'; keyboard-map 'none'; local-fonts 'none'; magnetometer 'none'; microphone 'none'; midi 'none'; navigation-override 'none'; otp-credentials 'none'; payment 'none'; picture-in-picture 'none'; publickey-credentials-create 'none'; publickey-credentials-get 'none'; screen-wake-lock 'none'; serial 'none'; speaker-selection 'none'; sync-xhr 'none'; usb 'none'; web-share 'none'; window-management 'none'; xr-spatial-tracking 'none'"

--- a/src/_plugins/social_embeds.rb
+++ b/src/_plugins/social_embeds.rb
@@ -193,7 +193,7 @@ end
 class SocialMedia < Liquid::Tag
   def initialize(_tag_name, text, _tokens)
     # The `text` variable should contain the URL of the post.
-    @post_url = text.strip
+    @post_url = text.strip.delete_prefix('"').delete_suffix('"')
   end
 
   def render(context)
@@ -225,3 +225,4 @@ Liquid::Template.register_filter(Jekyll::SocialEmbedFilters)
 Liquid::Template.register_tag('bluesky', SocialMedia)
 Liquid::Template.register_tag('mastodon', SocialMedia)
 Liquid::Template.register_tag('tweet', SocialMedia)
+Liquid::Template.register_tag('youtube', SocialMedia)

--- a/src/_posts/2013/2013-02-13-darwin.md
+++ b/src/_posts/2013/2013-02-13-darwin.md
@@ -10,7 +10,7 @@ title: Darwin, pancakes and birthdays
 
 I was browsing Twitter yesterday, and I happened to see a fun tweet about Darwin.
 
-{% tweet https://twitter.com/milkbutnotsugar/status/301278574533554176 %}
+{% tweet "https://twitter.com/milkbutnotsugar/status/301278574533554176" %}
 
 I quite like the idea of this, but I was a bit dubious about the plausibility. The tradition of pancakes on Shrove Tuesday is fairly well established, with pancake races dating back [to at least 1445][pancake], so we can be reasonably sure that Darwin was at least familiar with eating pancakes on the day.
 

--- a/src/_posts/2013/2013-08-20-google-maps.md
+++ b/src/_posts/2013/2013-08-20-google-maps.md
@@ -11,7 +11,7 @@ index:
 
 Earlier this morning, Fraser Speirs was bemoaning the design of the new Google&nbsp;Maps:
 
-{% tweet https://twitter.com/fraserspeirs/status/369736232546631680 %}
+{% tweet "https://twitter.com/fraserspeirs/status/369736232546631680" %}
 
 I decided to take him at his word, and spent an hour or so finding a way to de-clutter the interface. I've written a short bookmarklet which toggles the offending elements (the search box, and the other map overlays).
 

--- a/src/_posts/2014/2014-07-18-overcast.md
+++ b/src/_posts/2014/2014-07-18-overcast.md
@@ -50,7 +50,7 @@ In Overcast, the "and" is removed and authors are always shown in the second sty
 {% update 2014-07-25 %}
   Marco chimed in on Twitter to highlight one other aspect of his server-side normalisation of feeds:
 
-{% tweet https://twitter.com/OvercastFM/status/490968328723116032 %}
+{% tweet "https://twitter.com/OvercastFM/status/490968328723116032" %}
   At the beginning of the [latest episode of ATP](https://overcast.fm/podcasts/episode/2702410693577#t=226), Marco talked a little more about the server-side parsing, the motivation behind using a server rather than processing RSS feeds client side, and dealing with malformed or incorrect XML.
 {% endupdate %}
 

--- a/src/_posts/2014/2014-10-01-notes-on-tumblr.md
+++ b/src/_posts/2014/2014-10-01-notes-on-tumblr.md
@@ -16,7 +16,7 @@ I'll start with the small stuff:
 
 Then there's a new filter tool, under "Do you have lots of posts?". You can choose whether to include reblogs, or just show posts that you wrote. This wasn't my idea; it came from a tweet:
 
-{% tweet https://twitter.com/A5HRAJ/status/516449552102993920 %}
+{% tweet "https://twitter.com/A5HRAJ/status/516449552102993920" %}
 
 and after initially misunderstanding what they meant, I put something together pretty quickly. I'm not particularly keen on adding more options like this, because I don't want it to be too complicated: if you want really granular control, just play around with the API yourself.
 

--- a/src/_posts/2015/2015-02-12-lists.md
+++ b/src/_posts/2015/2015-02-12-lists.md
@@ -10,7 +10,7 @@ tags:
 
 Matt Gemmell had an interesting idea this evening:
 
-{% tweet https://twitter.com/mattgemmell/status/565967532608487427 %}
+{% tweet "https://twitter.com/mattgemmell/status/565967532608487427" %}
 
 I decided to see if it would be possible, and in doing so discovered how rusty I've become at JavaScript. This is simple enough that it can be done with a bookmarklet rather than a browser extension, and that's what I've done here.
 

--- a/src/_posts/2015/2015-09-16-http2-by-stealth.md
+++ b/src/_posts/2015/2015-09-16-http2-by-stealth.md
@@ -13,7 +13,7 @@ index:
 
 Amongst all the new features in iOS 9, I spotted one on Twitter that I hadn't seen before:
 
-{% tweet https://twitter.com/Lukasaoz/status/644243079445221376 %}
+{% tweet "https://twitter.com/Lukasaoz/status/644243079445221376" %}
 
 It turns out that Cory <a href="https://lukasa.co.uk/2015/06/HTTP2_Picks_Up_Steam_iOS9/">blogged about this</a> several months ago, but otherwise this change seems to have passed very quietly.
 

--- a/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
+++ b/src/_posts/2016/2016-02-24-how-i-use-textexpander-to-curb-my-language.md
@@ -12,7 +12,7 @@ title: How I use TextExpander to curb my language
 
 I saw a tweet yesterday that I really liked:
 
-{% tweet https://twitter.com/clamhead/status/701816106030239744 %}
+{% tweet "https://twitter.com/clamhead/status/701816106030239744" %}
 
 I’ve been making a concerted effort to cut down on this sort of phrasing as well.
 

--- a/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
+++ b/src/_posts/2016/2016-10-30-the-a-stands-for-asexual.md
@@ -92,7 +92,7 @@ Writing this post is my small contribution to that goal; yours is reading it.
 A week ago, I wasn't sure what, if anything, I wanted to write for Awareness Week.
 Then this tweet crossed my feed on Tuesday, and that's what got me started:
 
-{% tweet https://twitter.com/AsexualAndProud/status/790853542466564096 %}
+{% tweet "https://twitter.com/AsexualAndProud/status/790853542466564096" %}
 
 As I read the responses to this tweet, I felt a rush of ace positivity.
 It’s always nice to be reminded that there are other people like you!

--- a/src/_posts/2016/2016-11-30-low-tech-productivity.md
+++ b/src/_posts/2016/2016-11-30-low-tech-productivity.md
@@ -10,7 +10,7 @@ title: Some low-tech ways to get more ideas
 
 So on Tuesday, I saw [this tweet](https://twitter.com/DRMacIver/status/803223621439102976) from David MacIver:
 
-{% tweet https://twitter.com/DRMacIver/status/803223621439102976 %}
+{% tweet "https://twitter.com/DRMacIver/status/803223621439102976" %}
 
 "Intelligence expansion" is a phrase [that here means](https://twitter.com/DRMacIver/status/803223723549474820) "anything you can use to understand things or solve problems that would be hard with an unaided brain".
 

--- a/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
+++ b/src/_posts/2017/2017-04-04-lessons-from-alterconf.md
@@ -48,7 +48,7 @@ During one of the talks, a speaker inadvertently used some ableist language. Aft
 
 All the bathrooms at AlterConf are gender-neutral, and it's a staple of the conference tweets to see several pictures of the sign. Saturday was no exception:
 
-{% tweet https://twitter.com/iamkimiam/status/848188958567800832 %}
+{% tweet "https://twitter.com/iamkimiam/status/848188958567800832" %}
 
 ### A quiet room
 

--- a/src/_posts/2017/2017-10-28-lightning-talks.md
+++ b/src/_posts/2017/2017-10-28-lightning-talks.md
@@ -50,7 +50,7 @@ I think this system has been a resounding success, and I'd love to see it spread
 
   On Sunday, we changed the wording to be clearer: now, rather than saying "experienced speakers", we just have a bucket labelled "everyone else".
 
-  {% tweet https://twitter.com/alexwlchan/status/924569032170397696 %}
+  {% tweet "https://twitter.com/alexwlchan/status/924569032170397696" %}
 {% endupdate %}
 
 [youtube]: https://www.youtube.com/results?search_query=pycon%20uk%20lightning%20talks

--- a/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
+++ b/src/_posts/2017/2017-11-03-pyconuk-2017-privilege-inclusion.md
@@ -32,11 +32,7 @@ My spoken and written voice are quite different, but it gets the general gist ac
 
 If you'd prefer, you can watch the conference video on YouTube:
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=Ej2EJVMkTKw"
-  title="Using privilege to improve inclusion"
-%}
+{% youtube "https://www.youtube.com/watch?v=Ej2EJVMkTKw" %}
 
 [pycon]: http://2017.pyconuk.org/sessions/talks/using-privilege-to-help-not-hurt-diversity/
 

--- a/src/_posts/2017/2017-12-11-armed-police.md
+++ b/src/_posts/2017/2017-12-11-armed-police.md
@@ -41,7 +41,7 @@ Unfortunately, it's followed me home.
 
 Today I saw this tweet on my timeline:
 
-{% tweet https://twitter.com/CambsCops/status/940152354627874818 %}
+{% tweet "https://twitter.com/CambsCops/status/940152354627874818" %}
 
 The text of the tweet tries to be reassuring: it's just a precaution, about our safety, not a response to a specific threat.
 (This doesn't reassure me, but at least they're trying!)

--- a/src/_posts/2017/2017-12-18-building-your-repo.md
+++ b/src/_posts/2017/2017-12-18-building-your-repo.md
@@ -44,7 +44,7 @@ It's not perfect, but I'm very pleased with the results.
 
 In this post, I'll explain my typical setup, and how I use Make and Docker to get fast and reliable builds.
 
-{% tweet https://twitter.com/alexwlchan/status/938694360681590791 %}
+{% tweet "https://twitter.com/alexwlchan/status/938694360681590791" %}
 
 I really felt the benefits last Monday.
 Normally I commute to London on the train, but there was snow and ice at the weekend, and cold weather wreaks havoc on the railways.

--- a/src/_posts/2018/2018-08-13-inclusive-conferences.md
+++ b/src/_posts/2018/2018-08-13-inclusive-conferences.md
@@ -235,7 +235,7 @@ Modifying your venue to have some gender-neutral bathrooms is a nice way to make
 
 When AlterConf was still running, it was a staple of the conference tweets to see somebody take a photo of the gender-neutral bathroom signs (this is in Berlin):
 
-{% tweet https://twitter.com/iamkimiam/status/848188958567800832 %}
+{% tweet "https://twitter.com/iamkimiam/status/848188958567800832" %}
 
 If it's not possible (for example, you're sharing your conference space), remind your attendees not to challenge somebody else's choice of bathroom.
 For example, here's [a sign from one of the Write The Docs conferences](https://twitter.com/carolstran/status/906888286370660352):

--- a/src/_posts/2018/2018-09-17-lessons-in-signage.md
+++ b/src/_posts/2018/2018-09-17-lessons-in-signage.md
@@ -23,7 +23,7 @@ We got a lot of stuff right off the bat:
 
 But this was a first attempt, and inevitably I didn't get it all right -- for the benefit of my future self, and anybody else making venue signage, here's a few of the things I've learnt this year.
 
-{% tweet https://twitter.com/anabalica/status/1040947442735345664 %}
+{% tweet "https://twitter.com/anabalica/status/1040947442735345664" %}
 
 [inclusivity]: /2018/inclusive-conferences/#clear-internal-signage
 

--- a/src/_posts/2018/2018-09-22-suspicious-minds.md
+++ b/src/_posts/2018/2018-09-22-suspicious-minds.md
@@ -26,11 +26,7 @@ This is my abstract:
 
 The talk was recorded, and thanks to the wizardry of Tim&nbsp;Williams, it was on YouTube within a day:
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=B3XxPnbehqQ"
-  title="Building trust in an age of suspicious minds"
-%}
+{% youtube "https://www.youtube.com/watch?v=B3XxPnbehqQ" %}
 
 You can read the slides and transcript on this page, or download the slides [as a PDF](/files/2018/suspicious-minds.pdf).
 The transcript is based on the captions on the YouTube video, with some light editing and editorial notes where required.

--- a/src/_posts/2018/2018-09-24-assume-worst-intent.md
+++ b/src/_posts/2018/2018-09-24-assume-worst-intent.md
@@ -28,11 +28,7 @@ Here's the abstract:
 
 The talk was recorded, and you can watch it on YouTube:
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=XyGVRlRyT-E"
-  title="Assume Worst Intent"
-%}
+{% youtube "https://www.youtube.com/watch?v=XyGVRlRyT-E" %}
 
 You can read the slides and transcript on this page, or download the slides [as a PDF](/files/2018/assume_worst_intent.pdf).
 The transcript is based on the captions on the YouTube video, with some light tweaking and editorial notes where required.

--- a/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
+++ b/src/_posts/2019/2019-01-31-monki-gras-the-curb-cut-effect.md
@@ -23,11 +23,7 @@ It was a lot of fun to write and present.
 
 The talk was recorded, and you can watch it on YouTube:
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=6Yf3iukx3tQ"
-  title="The Curb Cut Effect"
-%}
+{% youtube "https://www.youtube.com/watch?v=6Yf3iukx3tQ" %}
 
 You can read the slides and my notes on this page, or download the slides [as a PDF](/files/2019/curbcut-monkigras.pdf).
 

--- a/src/_posts/2019/2019-02-05-inclusive-events-redux.md
+++ b/src/_posts/2019/2019-02-05-inclusive-events-redux.md
@@ -17,7 +17,7 @@ I kept all the suggestions in a text file, but I never quite got around to writi
 
 Just before the weekend, I sent a link to the post in a reply to this tweet by Ada Powers:
 
-{% tweet https://twitter.com/mspowahs/status/1091409665290788864 %}
+{% tweet "https://twitter.com/mspowahs/status/1091409665290788864" %}
 
 Her original tweet got a huge response (so many good replies), and sent a spike of traffic to my old blog post.
 I realised it was time to update it properly, so I dusted it off and wrote a new version.

--- a/src/_posts/2019/2019-03-15-forth-bridge.md
+++ b/src/_posts/2019/2019-03-15-forth-bridge.md
@@ -77,7 +77,7 @@ You can still see a handful of small boats in the harbour, but I'm sure it used 
   It turns out the lighthouse isn't the only reminder of the ferry service!
   Chris, an ex-Wellcome colleague and archivist extraordinaire, found some pictures from the Britten-Pears foundation (whose archive and library he runs), including a ticket from the ferry service:
 
-  {% tweet https://twitter.com/CHilton_BB/status/1107671088950063107 %}
+  {% tweet "https://twitter.com/CHilton_BB/status/1107671088950063107" %}
 {% endupdate %}
 
 Although most of the boats are gone, one part of the ferry service survives -- the lighthouse!

--- a/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
+++ b/src/_posts/2019/2019-03-25-creating-a-github-action-to-auto-merge-pull-requests.md
@@ -18,7 +18,7 @@ If you’ve not looked at Actions yet, the [awesome-actions repo](https://github
 I love playing with build systems, so I wanted to try it out -- but I had a lot of problems getting started.
 At the start of March, I tweeted in frustration:
 
-{% tweet https://twitter.com/alexwlchan/status/1101601909310439429 %}
+{% tweet "https://twitter.com/alexwlchan/status/1101601909310439429" %}
 
 A few days later, I got a DM from [Angie Rivera][angie], the Product Manager for GitHub Actions.
 We arranged a three-way call with [Phani Rajuyn][phani], one of GitHub's software engineers, and together we spent an hour talking about Actions.

--- a/src/_posts/2019/2019-05-24-first-thoughts-on-trans-inclusion.md
+++ b/src/_posts/2019/2019-05-24-first-thoughts-on-trans-inclusion.md
@@ -11,7 +11,7 @@ tags:
 
 A fortnight ago, I tweeted a question:
 
-{% tweet https://twitter.com/alexwlchan/status/1126802445517099008 %}
+{% tweet "https://twitter.com/alexwlchan/status/1126802445517099008" %}
 
 Doing more to help our trans colleagues is a big focus for the LGBTQ+ Staff network and the [Diversity & Inclusion team][d&i] this year.
 Part of that is a proper policy that affirms our support for them, and setting some expectations for how trans people should be treated as Wellcome.

--- a/src/_posts/2019/2019-07-01-ten-braille-facts.md
+++ b/src/_posts/2019/2019-07-01-ten-braille-facts.md
@@ -224,7 +224,7 @@ Compared to a printed alphabet, braille takes up much more space on the page -- 
 You think your copy of *Harry Potter and the Order of the Phoenix* is big?
 It's nothing compared to the braille editions, ["each of which amounts to a 13-volume stack of paper more than a foot high"](https://www.csmonitor.com/2003/0701/p12s01-lecl.html).
 
-{% tweet https://twitter.com/BrookeCottrell_/status/876825684202663937 %}
+{% tweet "https://twitter.com/BrookeCottrell_/status/876825684202663937" %}
 
 
 

--- a/src/_posts/2019/2019-07-18-section-28.md
+++ b/src/_posts/2019/2019-07-18-section-28.md
@@ -11,7 +11,7 @@ index:
 
 This tweet was getting a lot of attention in my feed last week:
 
-{% tweet https://twitter.com/pomarawrites/status/1150143170287587328 %}
+{% tweet "https://twitter.com/pomarawrites/status/1150143170287587328" %}
 
 Like many people, the answer for me is "never".
 I was in full-time education until I was 21, and I don't remember having any openly LGBTQ+ teachers.

--- a/src/_posts/2019/2019-10-14-sans-io-programming.md
+++ b/src/_posts/2019/2019-10-14-sans-io-programming.md
@@ -20,11 +20,7 @@ This isn't an original idea or term: I first encountered it a couple of years ag
 
 The talk was recorded, and you can watch it [on YouTube](https://www.youtube.com/watch?v=qwTWqy0uPbY):
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=qwTWqy0uPbY"
-  title="Sans I/O programming patterns: what, why, and how"
-%}
+{% youtube "https://www.youtube.com/watch?v=qwTWqy0uPbY" %}
 
 You can read the slides and my notes on this page, or download the slides [as a PDF](/files/2019/pyconuk_2019_sans_io.pdf).
 

--- a/src/_posts/2019/2019-11-17-saving-a-copy-of-a-tweet-by-typing-twurl.md
+++ b/src/_posts/2019/2019-11-17-saving-a-copy-of-a-tweet-by-typing-twurl.md
@@ -13,7 +13,7 @@ It saves me a few clicks, and it's an idea I originally stole [from Dr. Drang][d
 
 I have a couple of variations on this snippet, and I recently added another one to the mix:
 
-{% tweet https://twitter.com/alexwlchan/status/1188721070234394626 %}
+{% tweet "https://twitter.com/alexwlchan/status/1188721070234394626" %}
 
 [km]: https://www.keyboardmaestro.com/main/
 [drang]: https://leancrew.com/all-this/2010/10/textexpander-snippets-for-google-chrome/

--- a/src/_posts/2020/2020-05-02-how-long-is-my-data.md
+++ b/src/_posts/2020/2020-05-02-how-long-is-my-data.md
@@ -17,7 +17,7 @@ index:
 
 Yesterday, Stuart Lewis posted a photo of his [latest hardware](https://twitter.com/stuartlewis/status/1255825450485628928):
 
-{% tweet https://twitter.com/stuartlewis/status/1255825450485628928 %}
+{% tweet "https://twitter.com/stuartlewis/status/1255825450485628928" %}
 
 After some [back-and-forth in our replies](https://twitter.com/stuartlewis/status/1256135586651439112), he made me realise that the true unit of data isn't bytes or volume, it's shelving length.
 Specifically, if you wrote all your data to 3&#189;&Prime; floppy disks, how much shelf space would you need to hold them all?

--- a/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
+++ b/src/_posts/2020/2020-05-12-reflecting-on-bad-life-choices.md
@@ -10,7 +10,7 @@ tags:
 
 A week ago, I posted [a snippet of code on Twitter](https://twitter.com/alexwlchan/status/1258147811851460608) that has upset people:
 
-{% tweet https://twitter.com/alexwlchan/status/1258147811851460608 %}
+{% tweet "https://twitter.com/alexwlchan/status/1258147811851460608" %}
 
 Making that tweet work requires a horrific misuse of tuple unpacking, a feature that is usually used for sensible things.
 It needs reflection and the `exec()` function to work, and should never be used for anything serious.

--- a/src/_posts/2020/2020-05-15-downloading-the-ao3-fics-that-i-ve-saved-in-pinboard.md
+++ b/src/_posts/2020/2020-05-15-downloading-the-ao3-fics-that-i-ve-saved-in-pinboard.md
@@ -11,7 +11,7 @@ tags:
 
 A couple of days ago, I tweeted about one of my scripts:
 
-{% tweet https://twitter.com/alexwlchan/status/1260225157672697858 %}
+{% tweet "https://twitter.com/alexwlchan/status/1260225157672697858" %}
 
 The tweet got a fair amount of interest, so in this post I'm going to share that script.
 

--- a/src/_posts/2021/2021-01-31-kempisbot.md
+++ b/src/_posts/2021/2021-01-31-kempisbot.md
@@ -52,11 +52,11 @@ Seasoned tweeters will know that's more than you can fit in a single tweet, so w
 You could try to do this programatically, but the results probably wouldn't be very good.
 In some cases, a sentence works well as a standalone tweet:
 
-{% tweet https://twitter.com/KempisBot/status/1355552988199325696 %}
+{% tweet "https://twitter.com/KempisBot/status/1355552988199325696" %}
 
 In others, it makes more sense to put adjacent sentences together:
 
-{% tweet https://twitter.com/KempisBot/status/1355611529325015041 %}
+{% tweet "https://twitter.com/KempisBot/status/1355611529325015041" %}
 
 It's non-trivial for a computer to even recognise sentences, let alone decide which ones belong in the same tweet.
 (This is the topic of an entire field, called [*natural language processing*](https://en.wikipedia.org/wiki/Natural_language_processing).)

--- a/src/_posts/2021/2021-07-04-a-wise-choice-of-test-strings.md
+++ b/src/_posts/2021/2021-07-04-a-wise-choice-of-test-strings.md
@@ -8,7 +8,7 @@ index:
 
 A few weeks ago, somebody at HBO Max had a bad day, when a mysterious email went out to their subscribers:
 
-{% tweet https://twitter.com/juliehubs/status/1405689243393986561 %}
+{% tweet "https://twitter.com/juliehubs/status/1405689243393986561" %}
 
 As the subject line suggests and was later confirmed, this was an email [sent from their test system](https://twitter.com/HBOMaxHelp/status/1405712235108917249).
 

--- a/src/_posts/2021/2021-09-06-perfect-planks.md
+++ b/src/_posts/2021/2021-09-06-perfect-planks.md
@@ -16,7 +16,7 @@ colors:
 
 My friend Madeline is busy renovating her new house, and two nights ago she posted an interesting combinatorics problem:
 
-{% tweet https://twitter.com/oldenoughtosay/status/1434281850709610498 %}
+{% tweet "https://twitter.com/oldenoughtosay/status/1434281850709610498" %}
 
 If you start with a pencil and paper, you can start to find some valid combinations.
 Here's a few:

--- a/src/_posts/2022/2022-07-02-saturn-v.md
+++ b/src/_posts/2022/2022-07-02-saturn-v.md
@@ -45,7 +45,7 @@ I tried to correct them after the fact, but I never got it quite right.
 I've taken dozens of pictures, and they all have different shades of blue.
 (For example, the picture below has a green-ish sheen that doesn't look quite right.)
 
-{% tweet https://twitter.com/alexwlchan/status/1533882908770983943 %}
+{% tweet "https://twitter.com/alexwlchan/status/1533882908770983943" %}
 
 But it's not all bad: I also discovered that the iPhone's OCR is now good enough to read the text from the stitched image (and it's [not the first time][first_time], either).
 This still feels like magic to me.

--- a/src/_posts/2022/2022-09-23-moomin-mathematics.md
+++ b/src/_posts/2022/2022-09-23-moomin-mathematics.md
@@ -20,7 +20,7 @@ index:
 
 Yesterday evening, Kate posted this tweet:
 
-{% tweet https://twitter.com/thingskatedid/status/1573017572022571009 %}
+{% tweet "https://twitter.com/thingskatedid/status/1573017572022571009" %}
 
 This tweet promptly crawled inside my brain and sat there until I figured out how to make it work.
 I did, and because I'm so generous, now I'm going to share this secret with you.

--- a/src/_posts/2022/2022-11-06-tweet-alt-text.md
+++ b/src/_posts/2022/2022-11-06-tweet-alt-text.md
@@ -17,7 +17,7 @@ colors:
 It seems like Twitter might be circling a drain, and so a lot of people are [downloading a copy of their archive][download] in case the site goes down unexpectedly.
 But large as it is, the archive doesn't contain everything:
 
-{% tweet https://twitter.com/thingskatedid/status/1588790271940395008 %}
+{% tweet "https://twitter.com/thingskatedid/status/1588790271940395008" %}
 
 And since Twitter's [Accessibility Experience team have just been laid off][a11y], it seems unlikely this omission is going to be fixed any time soon.
 

--- a/src/_posts/2022/2022-12-16-marquee-rocket.md
+++ b/src/_posts/2022/2022-12-16-marquee-rocket.md
@@ -524,7 +524,7 @@ I was following [Danielle Leong][leong], who was a fearless cheerleader of the m
 
 The four finalists were &lt;a&gt;, &lt;div&gt;, &lt;marquee&gt; and &lt;script&gt;, and Laurie tweeted what could only be read as a challenge:
 
-{% tweet https://twitter.com/seldo/status/1461848209769197573 %}
+{% tweet "https://twitter.com/seldo/status/1461848209769197573" %}
 
 How far could I get with just &lt;marquee&gt;?
 

--- a/src/_posts/2023/2023-07-08-spy-for-spy.md
+++ b/src/_posts/2023/2023-07-08-spy-for-spy.md
@@ -22,7 +22,7 @@ It's a romantic comedy with a clever narrative twist – it’s being told in th
 Unfortunately it only had a limited run, and it's already closed.
 I don't know if or when it will be staged again, but I wanted to capture a bit of why I enjoyed it so much.
 
-{% tweet https://twitter.com/SpyForSpyPlay/status/1675112286103429123 %}
+{% tweet "https://twitter.com/SpyForSpyPlay/status/1675112286103429123" %}
 
 The play is a [two-hander], and it stars two women -- a bit of a rarity in theatre -- and it's a romance story.
 I'm not sure I've ever seen a sapphic romance on stage, and that itself was quite refreshing.

--- a/src/_posts/2024/2024-01-31-big-pdf.md
+++ b/src/_posts/2024/2024-01-31-big-pdf.md
@@ -13,7 +13,7 @@ index:
 
 I was browsing social media this morning, and I saw a claim I've seen go past a few times now -- that there's a maximum size for a PDF document:
 
-{% tweet https://twitter.com/TerribleMaps/status/1674813732260655106 %}
+{% tweet "https://twitter.com/TerribleMaps/status/1674813732260655106" %}
 
 Some version of this has been floating around the Internet [since 2007][tw_2007], probably earlier.
 This tweet is pretty emblematic of posts about this claim: it's stated as pure fact, with no supporting evidence or explanation.

--- a/src/_posts/2024/2024-05-14-what-comes-after-aws.md
+++ b/src/_posts/2024/2024-05-14-what-comes-after-aws.md
@@ -17,7 +17,7 @@ colors:
 
 James Governor posed some interesting questions yesterday:
 
-{% tweet https://twitter.com/monkchips/status/1790018203478876243 %}
+{% tweet "https://twitter.com/monkchips/status/1790018203478876243" %}
 
 I started writing a reply, but it was too long for Twitter, so I'm posting it here.
 

--- a/src/_posts/2025/2025-02-08-bagit-errors.md
+++ b/src/_posts/2025/2025-02-08-bagit-errors.md
@@ -15,7 +15,7 @@ colors:
 ---
 Last week, James Truitt asked a question on Mastodon:
 
-{% mastodon https://code4lib.social/@linguistory/113924700205617006 %}
+{% mastodon "https://code4lib.social/@linguistory/113924700205617006" %}
 
 The "bags" he's referring to are BagIt bags.
 BagIt is [an open format][rfc] developed by the Library of Congress for packaging digital files.

--- a/src/_posts/2025/2025-03-11-anonymised-art.md
+++ b/src/_posts/2025/2025-03-11-anonymised-art.md
@@ -70,11 +70,7 @@ I don't speak Russian, but YouTube has auto-translated subtitles.
 Now I know how this amazing set was made, and I have a much better understanding of the materials and techniques involved.
 (This includes the delightful name [Wenge wood][wenge], which I'd never heard before.)
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=QoKdDK3y-mQ"
-  title="ШАХМАТЫ в которые трудно играть даже ПРОфессионалам !"
-%}
+{% youtube "https://www.youtube.com/watch?v=QoKdDK3y-mQ" %}
 
 [summary]: https://usamodelkina.ru/11041-miniatyurnye-shahmaty-svoimi-rukami.html
 [chess_yt]: https://www.youtube.com/watch?v=QoKdDK3y-mQ

--- a/src/_posts/2025/2025-11-21-ox-in-oxford.md
+++ b/src/_posts/2025/2025-11-21-ox-in-oxford.md
@@ -13,7 +13,7 @@ tags:
 At the [end of last month][news-intro], Oxford introduced a [£5 congestion charge][ox-cc]  for passenger cars driving through the city centre.
 Some vehicles are exempt, like taxis, emergency vehicles, and delivery vans -- but what about animals?
 
-{% bluesky https://bsky.app/profile/oldenoughtosay.com/post/3m62qe3jrac2e %}
+{% bluesky "https://bsky.app/profile/oldenoughtosay.com/post/3m62qe3jrac2e" %}
 
 I’m not a city councillor or a lawyer, but I tried to work out the answer anyway.
 

--- a/src/_til/2024/2024-03-16-mastodon-retrying.md
+++ b/src/_til/2024/2024-03-16-mastodon-retrying.md
@@ -8,12 +8,12 @@ tags:
 Simon Willison had some DNS issues which meant his personal Mastodon instance (which is similar to my Masto.host setup) was knocked offline for a day or so.
 He was [wondering whether](https://fedi.simonwillison.net/@simon/112100279854237102) this would cause a flood of traffic when it came back online:
 
-{% mastodon https://fedi.simonwillison.net/@simon/112100279854237102 %}
+{% mastodon "https://fedi.simonwillison.net/@simon/112100279854237102" %}
 
 And there were a couple of replies to his post, explaining what would happen, including a link to the relevant part of the Mastodon codebase -- if a job fails, it gets retried with an exponential delay.
 
-{% mastodon https://shakedown.social/@clifff/112100294144816566 %}
+{% mastodon "https://shakedown.social/@clifff/112100294144816566" %}
 
 and
 
-{% mastodon https://flipboard.social/@JsonCulverhouse/112101163947801880 %}
+{% mastodon "https://flipboard.social/@JsonCulverhouse/112101163947801880" %}

--- a/src/_til/2025/2025-05-19-semaphore-frogs.md
+++ b/src/_til/2025/2025-05-19-semaphore-frogs.md
@@ -21,11 +21,7 @@ From a [2008 BBC News article](http://news.bbc.co.uk/1/hi/sci/tech/7219803.stm):
 That article links to a now-broken video, but I think I found the clip on a BBC YouTube account.
 You can see the movements quite clearly -- calling it semaphore might be a stretch, but there's some form of non-audible communication going on here.
 
-{%
-  include embeds/youtube.html
-  url="https://www.youtube.com/watch?v=A1FWQvaBoRg"
-  title="Attenborough: Golden Frog: Fighting & Mating | Life in Cold Blood | BBC Studios"
-%}
+{% youtube "https://www.youtube.com/watch?v=A1FWQvaBoRg" %}
 
 For reasons I won't put in a blog post, this idea is particularly amusing to me.
 If you want to know why, ask about it when you see me in person. 😉


### PR DESCRIPTION
This is preparatory work for #1196; it gets rid of the Liquid-specific `{% include %}` tag and moves everything to a more generic social media plugin. The double quotes are something I can easily remove with Liquid and should make it a bit easier with Jinja2.