### PR TITLE
mosaic: first pass of syntax highlighting in Python

### DIFF
--- a/mosaic/syntax_highlighting.py
+++ b/mosaic/syntax_highlighting.py
@@ -1,0 +1,138 @@
+"""
+Syntax highlighting for code snippets.
+
+This uses syntax inspired by Python-Markdown:
+
+    ```python {"arg1": true, "arg2": false}
+    def greeting(name: str) -> None:
+        print(f"Hello, {name}!")
+    ```
+
+After the language name is an optional JSON blob where I can pass other
+arguments to my syntax highlighting code.
+
+In Python-Markdown, those curly braces are used for extra attributes
+instead.
+"""
+
+import json
+import re
+
+from markdown import Extension, Markdown
+from markdown.preprocessors import Preprocessor
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import HtmlFormatter
+
+
+def apply_syntax_highlighting(
+    src: str,
+    lang: str,
+    names: dict[int, str] | None = None,
+    debug: bool = False,
+    wrap: bool = False,
+    linenos: bool = False,
+) -> str:
+    """
+    Apply syntax highlighting rules to a block of code.
+
+    This has all my custom logic for adding line numbers, tidying up
+    the output HTML, and so on. It doesn't know anything about Markdown.
+    """
+    lexer = get_lexer_by_name(lang)
+    formatter = HtmlFormatter()
+
+    html = highlight(src, lexer, formatter)
+
+    # Remove the wrapper <div> applied by Pygments
+    html = re.sub(r'^<div class="highlight">', "", html)
+    html = re.sub("</div>$", "", html)
+
+    # Insert an inner <code> block inside the <pre> tag
+    html = re.sub(r"^<pre>", f'<pre class="lng-{lang}"><code>', html)
+    html = re.sub("</pre>$", "</code></pre>", html)
+
+    html = html.replace("<span></span>", "")
+
+    return html
+
+
+class SyntaxHighlighterPreprocessor(Preprocessor):
+    """
+    Find and extract fenced code blocks.
+    """
+
+    # This matches fenced code blocks like:
+    #
+    #     ```python {"debug": true, "names": {0: "greet", 1: "name"}}
+    #     def greet(name):
+    #         print(f"Hello {name}!")
+    #     ```
+    #
+    # fmt: off
+    FENCED_BLOCK_RE = re.compile(
+        r"^(?P<indent>[ ]*)"              # leading indent
+        r"```"                            # opening fence
+        r"(?P<lang>[a-z\-]+)"             # language name
+        r"(?:[ ](?P<attrs>\{[^\n]+\}))?"  # JSON attributes (optional)
+        r"\n"                             # newline (end of opening fence)
+        r"(?P<src>.*)"                    # code content (non-greedy)
+        r"(?<=\n)(?P=indent)```",         # closing fence (match opening indent)
+        re.MULTILINE | re.DOTALL,
+    )
+    # fmt: on
+
+    def __init__(self, md: Markdown):
+        """
+        Create a new instance of SyntaxHighlighterPreprocessor.
+        """
+        super().__init__(md)
+
+    def run(self, lines: list[str]) -> list[str]:
+        """
+        Match and store fenced code blocks.
+        """
+        text = "\n".join(lines)
+
+        while m := self.FENCED_BLOCK_RE.search(text):
+            if m.group("attrs"):
+                highlighter_args = json.loads(m.group("attrs"))
+            else:
+                highlighter_args = {}
+
+            if m.group("indent"):
+                src = "\n".join(
+                    re.sub(r"^" + m.group("indent"), "", line)
+                    for line in m.group("src").splitlines()
+                )
+            else:
+                src = m.group("src")
+
+            html = apply_syntax_highlighting(
+                src,
+                lang=m.group("lang"),
+                **highlighter_args,
+            )
+
+            if m.group("indent"):
+                html = "\n".join(m.group("indent") + line for line in html.splitlines())
+
+            text = text.replace(m.group(0), html)
+
+        return text.split("\n")
+
+
+class SyntaxHighlighterExtension(Extension):
+    """
+    Markdown extension to handle syntax highlighting.
+    """
+
+    def extendMarkdown(self, md: Markdown) -> None:
+        """
+        Add `SyntaxHighlighterPreprocessor` to the `Markdown` instance.
+        """
+        md.registerExtension(self)
+
+        md.preprocessors.register(
+            SyntaxHighlighterPreprocessor(md), "syntax_highlighting", 25
+        )

--- a/mosaic/templates/text.py
+++ b/mosaic/templates/text.py
@@ -7,6 +7,8 @@ import re
 from markdown import markdown
 from markdown.extensions.toc import TocExtension
 
+from mosaic.syntax_highlighting import SyntaxHighlighterExtension
+
 
 STRIP_HTML_RE = re.compile(r"<[^<]+?>")
 
@@ -29,8 +31,8 @@ def markdownify(text: str) -> str:
         text,
         extensions=[
             "codehilite",
-            "fenced_code",
             "smarty",
+            SyntaxHighlighterExtension(),
             TocExtension(
                 marker="{% table_of_contents %}",
                 title="Table of Contents",

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ markdown
 minify-html
 Pillow
 pydantic
+Pygments
 PyYAML
 termcolor
 tqdm
@@ -27,5 +28,6 @@ mypy
 pytest-cov
 ruff
 types-Markdown
+types-Pygments
 types-PyYAML
 types-tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,9 @@ pydantic==2.12.5
 pydantic-core==2.41.5
     # via pydantic
 pygments==2.19.2
-    # via pytest
+    # via
+    #   -r requirements.in
+    #   pytest
 pytest==9.0.2
     # via
     #   -r requirements.in
@@ -85,7 +87,11 @@ termcolor==3.3.0
     # via -r requirements.in
 tqdm==4.67.1
     # via -r requirements.in
+types-docutils==0.22.3.20251115
+    # via types-pygments
 types-markdown==3.10.0.20251106
+    # via -r requirements.in
+types-pygments==2.19.0.20251121
     # via -r requirements.in
 types-pyyaml==6.0.12.20250915
     # via -r requirements.in

--- a/tests/test_syntax_highlighting.py
+++ b/tests/test_syntax_highlighting.py
@@ -1,0 +1,78 @@
+"""
+Tests for `mosaic.syntax_highlighting`.
+"""
+
+from markdown import markdown
+
+from mosaic.syntax_highlighting import SyntaxHighlighterExtension
+
+
+def test_syntax_highlighting() -> None:
+    """
+    Test a snippet of syntax highlighting.
+    """
+    html = markdown(
+        "This is some text\n\n"
+        '```python {"debug": true}\n'
+        "def greeting(name: str) -> None:\n"
+        '    print(f"Hello {name}!")\n'
+        "```\n\n"
+        "This is some more text\n\n"
+        "*   This is a bulleted list\n\n"
+        "    ```python\n"
+        "    def add(x: int, y: int) -> int:\n"
+        "        return x + y\n"
+        "    ```",
+        extensions=[SyntaxHighlighterExtension()],
+    )
+
+    assert html == (
+        # This is some text
+        "<p>This is some text</p>\n"
+        '<pre class="lng-python"><code>'
+        # def
+        '<span class="k">def</span><span class="w"> </span>'
+        # greeting
+        '<span class="nf">greeting</span>'
+        # (name
+        '<span class="p">(</span><span class="n">name</span>'
+        # : str)
+        '<span class="p">:</span> <span class="nb">str</span><span class="p">)</span> '
+        # -> None
+        '<span class="o">-&gt;</span> <span class="kc">None</span>'
+        # :
+        '<span class="p">:</span>\n    '
+        # print(
+        '<span class="nb">print</span><span class="p">(</span>'
+        # "Hello
+        '<span class="sa">f</span><span class="s2">&quot;Hello </span>'
+        # {name}
+        '<span class="si">{</span><span class="n">name</span><span class="si">}</span>'
+        # !")
+        '<span class="s2">!&quot;</span><span class="p">)</span>\n'
+        "</code></pre>\n\n"
+        # This is some more text
+        "<p>This is some more text</p>\n<ul>\n<li>\n"
+        # This is a bulleted list
+        "<p>This is a bulleted list</p>\n<p>"
+        '<pre class="lng-python"><code>'
+        # def
+        '<span class="k">def</span><span class="w"> </span>'
+        # add(
+        '<span class="nf">add</span><span class="p">(</span>'
+        # x: int
+        '<span class="n">x</span><span class="p">:</span> <span class="nb">int</span>'
+        # , y:
+        '<span class="p">,</span> <span class="n">y</span><span class="p">:</span> '
+        # int)
+        '<span class="nb">int</span><span class="p">)</span> '
+        # ->
+        '<span class="o">-&gt;</span> '
+        # int:
+        '<span class="nb">int</span><span class="p">:</span>\n    '
+        # return x +
+        '<span class="k">return</span> <span class="n">x</span> '
+        # + y
+        '<span class="o">+</span> <span class="n">y</span>\n</code></pre>'
+        "</p>\n</li>\n</ul>"
+    )


### PR DESCRIPTION
This adds a Python-Markdown extension which handles fenced code blocks with arguments. I don't use the arguments yet, which I'll do in a follow-up patch -- but this lays the groundwork for that.

For #1196