### PR TITLE
mosaic: escape attributes on the `picture` tag

### DIFF
--- a/mosaic/templates/__init__.py
+++ b/mosaic/templates/__init__.py
@@ -6,7 +6,7 @@ import collections
 from datetime import datetime
 from pathlib import Path
 import re
-from typing import TypedDict
+from typing import TypedDict, TypeVar
 
 import bs4
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
@@ -45,6 +45,7 @@ def get_jinja_environment(src_dir: Path, out_dir: Path) -> Environment:
     env.filters.update(
         {
             "cleanup_text": cleanup_text,
+            "escape_attribute_value": escape_attribute_value,
             "format_date": format_date,
             "get_inline_styles": get_inline_styles,
             "markdownify": markdownify,
@@ -95,3 +96,28 @@ def format_date(date_string: str, format: str) -> str:
     Reads an ISO-formatted date, and reformats it in the specified format.
     """
     return datetime.fromisoformat(date_string).strftime(format)
+
+
+T = TypeVar("T")
+
+
+def escape_attribute_value(value: T) -> T:
+    """
+    Escape an attribute value, especially in alt text.
+
+    Ensure characters that might be interpreted as HTML or Markdown
+    don't get included in their raw form.
+    """
+    if not isinstance(value, str):
+        return value
+
+    for old, new in [
+        ("<", "&lt;"),
+        (">", "&gt;"),
+        ("`", "&grave;"),
+        ("*", "&ast;"),
+        ("_", "&lowbar;"),
+    ]:
+        value = value.replace(old, new)  # type: ignore
+
+    return value

--- a/templates/partials/picture.html
+++ b/templates/partials/picture.html
@@ -29,7 +29,7 @@
     src="{{ default_image }}"
     {%- if extra_attributes is defined -%}
       {%- for name, value in extra_attributes.items() %}
-      {{ name }}="{{ value }}"
+      {{ name }}="{{ value | escape_attribute_value }}"
       {%- endfor -%}
     {%- endif -%}
   >

--- a/tests/templates/test_pictures.py
+++ b/tests/templates/test_pictures.py
@@ -350,6 +350,37 @@ class TestPictureExtension:
         ):
             assert (out_dir / "images/2026" / name).exists()
 
+    @pytest.mark.parametrize(
+        "alt, rendered_alt",
+        [
+            ("This node goes A ~> B", "This node goes A ~&gt; B"),
+            ("This node goes A <~ B", "This node goes A &lt;~ B"),
+            ("This `code` is in backticks", "This &grave;code&grave; is in backticks"),
+            ("This text is *important*", "This text is &ast;important&ast;"),
+            ("This text is _underlined_", "This text is &lowbar;underlined&lowbar;"),
+        ],
+    )
+    def test_markdown_chars_are_escaped_in_alt_text(
+        self, alt: str, rendered_alt: str, src_dir: Path, env: Environment
+    ) -> None:
+        """
+        Characters that look like HTML or Markdown get escaped in the alt text.
+        """
+        (src_dir / "_images/2026").mkdir(parents=True)
+        shutil.copyfile(
+            "tests/fixtures/truchet-tiles-800x400.png",
+            src_dir / "_images/2026/truchet-tiles-800x400.png",
+        )
+        page = StubPage(date=datetime(2026, 1, 1))
+
+        md = (
+            '{% picture filename="truchet-tiles-800x400.png" width="400" alt="'
+            + alt
+            + '" %}'
+        )
+        html = env.from_string(md).render(page=page)
+        assert rendered_alt in html
+
 
 class TestChooseTargetWidth:
     """


### PR DESCRIPTION
I discovered a number of pictures where the Markdown renderer affects the HTML after it comes from the picture extension, because it sees control characters. Escape those characters so that can't happen.

For #1196