### PR TITLE
mosaic: fix a syntax highlighting bug

### DIFF
--- a/mosaic/syntax_highlighting.py
+++ b/mosaic/syntax_highlighting.py
@@ -76,7 +76,7 @@ class SyntaxHighlighterPreprocessor(Preprocessor):
         r"(?P<lang>[a-z\-]+)"             # language name
         r"(?:[ ](?P<attrs>\{[^\n]+\}))?"  # JSON attributes (optional)
         r"\n"                             # newline (end of opening fence)
-        r"(?P<src>.*)"                    # code content (non-greedy)
+        r"(?P<src>.*?)"                   # code content (non-greedy)
         r"(?<=\n)(?P=indent)```",         # closing fence (match opening indent)
         re.MULTILINE | re.DOTALL,
     )

--- a/tests/test_syntax_highlighting.py
+++ b/tests/test_syntax_highlighting.py
@@ -76,3 +76,27 @@ def test_syntax_highlighting() -> None:
         '<span class="o">+</span> <span class="n">y</span>\n</code></pre>'
         "</p>\n</li>\n</ul>"
     )
+
+
+def test_syntax_highlighting_is_not_greedy() -> None:
+    """
+    Syntax highlighting does a non-greedy match on the code.
+    """
+    html = markdown(
+        "This is some text\n"
+        "\n"
+        '```python {"debug": true}\n'
+        "def greeting(name: str) -> None:\n"
+        '    print(f"Hello {name}!")\n'
+        "```\n"
+        "\n"
+        "This is some more text\n"
+        "\n"
+        "```python\n"
+        "def add(x: int, y: int) -> int:\n"
+        "    return x + y\n"
+        "```",
+        extensions=[SyntaxHighlighterExtension()],
+    )
+
+    assert "<p>This is some more text</p>" in html


### PR DESCRIPTION
I messed up the regex, so it was greedy rather than non-greedy. The first code block would expand to suck in the entire post, oops.

For #1196