### PR TITLE
mosaic: fix syntax highlighting for plain fenced code blocks

### DIFF
--- a/mosaic/syntax_highlighting.py
+++ b/mosaic/syntax_highlighting.py
@@ -73,7 +73,7 @@ class SyntaxHighlighterPreprocessor(Preprocessor):
     FENCED_BLOCK_RE = re.compile(
         r"^(?P<indent>[ ]*)"              # leading indent
         r"```"                            # opening fence
-        r"(?P<lang>[a-z\-]+)"             # language name
+        r"(?P<lang>[a-z\-]+)?"             # language name
         r"(?:[ ](?P<attrs>\{[^\n]+\}))?"  # JSON attributes (optional)
         r"\n"                             # newline (end of opening fence)
         r"(?P<src>.*?)"                   # code content (non-greedy)
@@ -110,7 +110,7 @@ class SyntaxHighlighterPreprocessor(Preprocessor):
 
             html = apply_syntax_highlighting(
                 src,
-                lang=m.group("lang"),
+                lang=m.group("lang") or "text",
                 **highlighter_args,
             )
 

--- a/tests/test_syntax_highlighting.py
+++ b/tests/test_syntax_highlighting.py
@@ -100,3 +100,31 @@ def test_syntax_highlighting_is_not_greedy() -> None:
     )
 
     assert "<p>This is some more text</p>" in html
+
+
+def test_fenced_code_block_without_lang_is_still_pre() -> None:
+    """
+    A fenced code block without a language is still wrapped in <pre> tags.
+    """
+    html = markdown(
+        "This is some text\n"
+        "\n"
+        "```\n"
+        "line 1\n"
+        "line 2\n"
+        "```\n\n"
+        "This is some more text\n\n"
+        "```\n"
+        "line 3\n"
+        "line 4\n"
+        "```",
+        extensions=[SyntaxHighlighterExtension()],
+    )
+
+    print(repr(html))
+    assert html == (
+        "<p>This is some text</p>\n"
+        '<pre class="lng-text"><code>line 1\nline 2\n</code></pre>\n\n'
+        "<p>This is some more text</p>\n"
+        '<pre class="lng-text"><code>line 3\nline 4\n</code></pre>'
+    )


### PR DESCRIPTION
There was a bug in my regex where it was skipping fenced code blocks that didn't include the language tag. This tweaks the regex so it can match an empty language, and treats it as `text`.

For #1196