### PR TITLE
mosaic/syntax_highlighting: fix a bug with code blocks in lists

### DIFF
--- a/mosaic/syntax_highlighting.py
+++ b/mosaic/syntax_highlighting.py
@@ -50,7 +50,7 @@ def apply_syntax_highlighting(
 
     # Insert an inner <code> block inside the <pre> tag
     html = re.sub(r"^<pre>", f'<pre class="lng-{lang}"><code>', html)
-    html = re.sub("</pre>$", "</code></pre>", html)
+    html = re.sub(r"\s*</pre>$", "</code></pre>", html)
 
     html = html.replace("<span></span>", "")
 
@@ -114,10 +114,17 @@ class SyntaxHighlighterPreprocessor(Preprocessor):
                 **highlighter_args,
             )
 
+            # If the original Markdown was indented, collapse all the
+            # newlines into <br/> tags.
+            #
+            # This means Python-Markdown will treat it as a single HTML
+            # element, and won't break it into separate paragraphs.
             if m.group("indent"):
-                html = "\n".join(m.group("indent") + line for line in html.splitlines())
+                assert html.endswith("\n")
+                html = html.rstrip().replace("\n", "<br/>")
+                assert not html.endswith("\n")
 
-            text = text.replace(m.group(0), html)
+            text = text.replace(m.group(0), m.group("indent") + html)
 
         return text.split("\n")
 

--- a/mosaic/text.py
+++ b/mosaic/text.py
@@ -30,7 +30,6 @@ def markdownify(text: str) -> str:
     html = markdown(
         text,
         extensions=[
-            "codehilite",
             "smarty",
             SyntaxHighlighterExtension(),
             #

--- a/tests/test_syntax_highlighting.py
+++ b/tests/test_syntax_highlighting.py
@@ -49,7 +49,7 @@ def test_syntax_highlighting() -> None:
         # {name}
         '<span class="si">{</span><span class="n">name</span><span class="si">}</span>'
         # !")
-        '<span class="s2">!&quot;</span><span class="p">)</span>\n'
+        '<span class="s2">!&quot;</span><span class="p">)</span>'
         "</code></pre>\n\n"
         # This is some more text
         "<p>This is some more text</p>\n<ul>\n<li>\n"
@@ -69,11 +69,11 @@ def test_syntax_highlighting() -> None:
         # ->
         '<span class="o">-&gt;</span> '
         # int:
-        '<span class="nb">int</span><span class="p">:</span>\n    '
+        '<span class="nb">int</span><span class="p">:</span><br/>    '
         # return x +
         '<span class="k">return</span> <span class="n">x</span> '
         # + y
-        '<span class="o">+</span> <span class="n">y</span>\n</code></pre>'
+        '<span class="o">+</span> <span class="n">y</span></code></pre>'
         "</p>\n</li>\n</ul>"
     )
 
@@ -121,10 +121,83 @@ def test_fenced_code_block_without_lang_is_still_pre() -> None:
         extensions=[SyntaxHighlighterExtension()],
     )
 
-    print(repr(html))
     assert html == (
         "<p>This is some text</p>\n"
-        '<pre class="lng-text"><code>line 1\nline 2\n</code></pre>\n\n'
+        '<pre class="lng-text"><code>line 1\nline 2</code></pre>\n\n'
         "<p>This is some more text</p>\n"
-        '<pre class="lng-text"><code>line 3\nline 4\n</code></pre>'
+        '<pre class="lng-text"><code>line 3\nline 4</code></pre>'
+    )
+
+
+def test_syntax_highlighting_with_indent() -> None:
+    """
+    We handle empty lines in indented code blocks.
+    """
+    html = markdown(
+        "This is some text\n"
+        "\n"
+        "```python\n"
+        "def add(x, y):\n"
+        "    return x + y\n"
+        "\n"
+        "def greeting(name)\n"
+        '    print(f"Hello {name}!")\n'
+        "```\n"
+        "\n"
+        "*   This is a bulleted list\n"
+        "\n"
+        "    ```python\n"
+        "    def add(x, y)\n"
+        "        return x + y\n"
+        "\n"
+        "    def greeting(name)\n"
+        '        print(f"Hello {name}!")\n'
+        "    ```",
+        extensions=[SyntaxHighlighterExtension()],
+    )
+
+    assert html == (
+        "<p>This is some text</p>\n"
+        '<pre class="lng-python"><code>'
+        # def add(x, y):
+        '<span class="k">def</span><span class="w"> </span><span class="nf">add</span>'
+        '<span class="p">(</span><span class="n">x</span><span class="p">,</span> '
+        '<span class="n">y</span><span class="p">):</span>\n'
+        # return x + y
+        '    <span class="k">return</span> <span class="n">x</span> '
+        '<span class="o">+</span> <span class="n">y</span>\n'
+        "\n"
+        # def greeting(name)
+        '<span class="k">def</span><span class="w"> </span>'
+        '<span class="nf">greeting</span><span class="p">(</span>'
+        '<span class="n">name</span><span class="p">)</span>\n'
+        # print(f"Hello {name}!")
+        '    <span class="nb">print</span><span class="p">(</span>'
+        '<span class="sa">f</span><span class="s2">&quot;Hello </span>'
+        '<span class="si">{</span><span class="n">name</span><span class="si">}</span>'
+        '<span class="s2">!&quot;</span><span class="p">)</span>'
+        "</code></pre>\n"
+        "\n"
+        "<ul>\n<li>\n"
+        "<p>This is a bulleted list</p>\n"
+        '<p><pre class="lng-python"><code>'
+        # Notice this second block uses <br/> instead of \n
+        # def add(x, y):
+        '<span class="k">def</span><span class="w"> </span><span class="nf">add</span>'
+        '<span class="p">(</span><span class="n">x</span><span class="p">,</span> '
+        '<span class="n">y</span><span class="p">)</span><br/>'
+        # return x + y
+        '    <span class="k">return</span> <span class="n">x</span> '
+        '<span class="o">+</span> <span class="n">y</span><br/>'
+        "<br/>"
+        # def greeting(name):
+        '<span class="k">def</span><span class="w"> </span>'
+        '<span class="nf">greeting</span><span class="p">(</span>'
+        '<span class="n">name</span><span class="p">)</span><br/>'
+        # print(f"Hello {name}!")
+        '    <span class="nb">print</span><span class="p">(</span>'
+        '<span class="sa">f</span><span class="s2">&quot;Hello </span>'
+        '<span class="si">{</span><span class="n">name</span><span class="si">}</span>'
+        '<span class="s2">!&quot;</span><span class="p">)</span>'
+        "</code></pre></p>\n</li>\n</ul>"
     )


### PR DESCRIPTION
In particular, code blocks in lists which have empty lines, which would cause Python-Markdown to treat the rest of the code as new paragraphs instead.

For #1196