### PR TITLE
mosaic/templates: wrap the output of inline_svg in `<figure>`

### DIFF
--- a/mosaic/templates/inline_svg.py
+++ b/mosaic/templates/inline_svg.py
@@ -121,12 +121,17 @@ def render_inline_svg(
     xml_output = str(soup)
     xml_output = re.sub(r"<\?xml.*?\?>", "", xml_output).strip()
 
-    # 8. Wrap in link if necessary
+    # 8. Wrap in link if necessary.
+    #
+    # I always wrap the contents in a <figure> tag, which tells the
+    # Python-Markdown library to treat this as a block element and
+    # skip until it sees the closing </figure> -- otherwise it gets
+    # confused if there's an inline <style> tag.
     if link_to == "original":
         dst_path = out_dir / "images" / str(year) / filename
         dst_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(src_path, dst_path)
         href = "/" + str(dst_path.relative_to(out_dir))
-        return f'<a href="{href}">{xml_output}</a>'
+        return f'<figure><a href="{href}">{xml_output}</a></figure>'
     else:
-        return xml_output
+        return "<figure>" + xml_output + "</figure>"

--- a/tests/templates/test_inline_svg.py
+++ b/tests/templates/test_inline_svg.py
@@ -38,10 +38,10 @@ class TestInlineSvgExtension:
 
         html = env.from_string(md).render(page=page).strip()
         assert html == (
-            '<svg aria-labelledby="svg_example" role="img" viewBox="0 0 200 200" '
-            'xmlns="http://www.w3.org/2000/svg">'
+            '<figure><svg aria-labelledby="svg_example" role="img" '
+            'viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">'
             '<title id="svg_example">A yellow rectangle</title>\n'
-            '<rect fill="yellow" height="200" width="200"/>\n</svg>'
+            '<rect fill="yellow" height="200" width="200"/>\n</svg></figure>'
         )
 
     def test_link_multiple_svgs_in_same_page(
@@ -69,15 +69,15 @@ class TestInlineSvgExtension:
 
         html = env.from_string(md).render(page=page).strip()
         assert html == (
-            '<a href="/images/2026/rect_red.svg">'
+            '<figure><a href="/images/2026/rect_red.svg">'
             '<svg role="img" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">\n'
-            '<rect fill="red" height="200" width="200"/>\n</svg></a>'
-            '<a href="/images/2026/rect_green.svg">'
+            '<rect fill="red" height="200" width="200"/>\n</svg></a></figure>'
+            '<figure><a href="/images/2026/rect_green.svg">'
             '<svg role="img" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">\n'
-            '<rect fill="green" height="200" width="200"/>\n</svg></a>'
-            '<a href="/images/2026/rect_blue.svg">'
+            '<rect fill="green" height="200" width="200"/>\n</svg></a></figure>'
+            '<figure><a href="/images/2026/rect_blue.svg">'
             '<svg role="img" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">\n'
-            '<rect fill="blue" height="200" width="200"/>\n</svg></a>'
+            '<rect fill="blue" height="200" width="200"/>\n</svg></a></figure>'
         )
 
         for f in ("rect_red.svg", "rect_green.svg", "rect_blue.svg"):
@@ -102,11 +102,11 @@ class TestInlineSvgExtension:
 
         html = env.from_string(md).render(page=page).strip()
         assert html == (
-            '<svg aria-labelledby="svg_example" class="dark_aware" '
+            '<figure><svg aria-labelledby="svg_example" class="dark_aware" '
             'data_colour="yellow" role="img" viewBox="0 0 200 200" '
             'xmlns="http://www.w3.org/2000/svg">'
             '<title id="svg_example">A yellow rectangle</title>\n'
-            '<rect fill="yellow" height="200" width="200"/>\n</svg>'
+            '<rect fill="yellow" height="200" width="200"/>\n</svg></figure>'
         )
 
     def test_comments_are_removed(self, src_dir: Path, env: Environment) -> None:
@@ -126,10 +126,10 @@ class TestInlineSvgExtension:
 
         html = env.from_string(md).render(page=page).strip()
         assert html == (
-            '<svg aria-labelledby="svg_example" role="img" viewBox="0 0 200 200" '
-            'xmlns="http://www.w3.org/2000/svg">'
+            '<figure><svg aria-labelledby="svg_example" role="img" '
+            'viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">'
             '<title id="svg_example">A yellow rectangle</title>\n '
-            '<rect fill="yellow" height="200" width="200"/>\n</svg>'
+            '<rect fill="yellow" height="200" width="200"/>\n</svg></figure>'
         )
 
     def test_non_svg_is_error(self, env: Environment) -> None:


### PR DESCRIPTION
This fixes an annoying bug where the Markdown parser would interpret the contents of the inline SVG, especially inline `<style>` tags, and split the SVG into separate paragraphs.

For #1196