### PR TITLE
mosaic/{linters,text}: fix block elements inside `<p>`

### DIFF
--- a/mosaic/linters.py
+++ b/mosaic/linters.py
@@ -2,8 +2,41 @@
 Linter rules for verifying the final website output.
 """
 
+import re
+
 from bs4 import BeautifulSoup
 import hyperlink
+
+
+def check_no_broken_html(html_str: str) -> list[str]:
+    """
+    Check an HTML file doesn't have any <p> tags followed by unexpected
+    HTML, which is often a sign of a rendering error.
+    """
+    errors = []
+
+    for m in re.finditer(r"<p><(?P<tag_name>[^\s>/]+)(.*?)/?>", html_str):
+        tag_name = m.group("tag_name")
+
+        if tag_name in {
+            "a",
+            "br",
+            "cite",
+            "code",
+            "em",
+            "img",
+            "picture",
+            "s",
+            "strong",
+        }:
+            continue
+
+        errors.append(f"unexpected tag following <p>: {m.group(0)}")
+
+    for m in re.finditer(r"<p>&lt;(.*?)&gt;", html_str):
+        errors.append(f"malformed tag following <p>: {m.group(0)}")
+
+    return errors
 
 
 def check_no_localhost_links(html: BeautifulSoup) -> list[str]:

--- a/mosaic/text.py
+++ b/mosaic/text.py
@@ -44,6 +44,13 @@ def markdownify(text: str) -> str:
     html = html.replace(
         '<span class="toctitle">Table of Contents</span>', "<h3>Table of contents</h3>"
     )
+
+    # Fix a couple of block elements which Python-Markdown will wrap
+    # in <p> tags if it sees them in a list.
+    for tag in ("dl", "pre", "table", "ul"):
+        html = html.replace(f"<p><{tag}", f"<{tag}")
+        html = html.replace(f"</{tag}></p>", f"</{tag}>")
+
     return html
 
 

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -5,7 +5,27 @@ Tests for `mosaic.linters`.
 import bs4
 import pytest
 
-from mosaic.linters import check_no_localhost_links
+from mosaic.linters import check_no_broken_html, check_no_localhost_links
+
+
+class TestCheckNoBrokenHtml:
+    """
+    Tests for `check_no_broken_html`.
+    """
+
+    @pytest.mark.parametrize("html", ["<p><table>", "<p>&lt;pre&gt;", "<p><p>"])
+    def test_spots_bad_tag_after_p(self, html: str) -> None:
+        """
+        The lint catches a <p> tag followed by a block element.
+        """
+        assert check_no_broken_html(html)
+
+    @pytest.mark.parametrize("html", ["<p><em>", "<p>Abc"])
+    def test_allows_inline_tag_after_p(self, html: str) -> None:
+        """
+        The lint catches a <p> tag followed by a block element.
+        """
+        assert check_no_broken_html(html) == []
 
 
 class TestCheckNoLocalhostLinks:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -7,14 +7,29 @@ import pytest
 from mosaic import text as t
 
 
-def test_markdownify() -> None:
+@pytest.mark.parametrize(
+    "md, expected",
+    [
+        (
+            "This is some text.\n\nThis is *emphasised* text.",
+            "<p>This is some text.</p>\n<p>This is <em>emphasised</em> text.</p>",
+        ),
+        (
+            "*   This is a list item\n\n"
+            "    <table><tr><td>Hello</td><td>World</td></tr></table>\n\n"
+            "*   This is another list item",
+            "<ul>\n<li>\n<p>This is a list item</p>\n"
+            "<table><tr><td>Hello</td><td>World</td></tr></table>\n</li>\n"
+            "<li>\n<p>This is another list item</p>\n</li>\n</ul>",
+        ),
+    ],
+)
+def test_markdownify(md: str, expected: str) -> None:
     """
     Test markdownify().
     """
-    md = "This is some text.\n\nThis is *emphasised* text."
-    expected = "<p>This is some text.</p>\n<p>This is <em>emphasised</em> text.</p>"
     actual = t.markdownify(md)
-
+    print(repr(actual))
     assert actual == expected
 
 


### PR DESCRIPTION
I've found a number of issues with where Python-Markdown inserts `<p>` tags, especially around block elements which are inside an indented list.

This patch adds a manual fix to the Markdown converter, and a new lint that checks for a `<p>` followed by a block element or other malformed syntax.

For #1196