### PR TITLE
mosaic/site: only copy static files which have changed

### DIFF
--- a/mosaic/site.py
+++ b/mosaic/site.py
@@ -4,7 +4,6 @@ Build system for alexwlchan.net.
 
 from collections import Counter
 from datetime import datetime, timezone
-import filecmp
 import itertools
 from pathlib import Path
 import shutil
@@ -177,8 +176,7 @@ class Site(BaseModel):
         for repo in GIT_REPOS:
             self.prepare_project_pages(env, repo)
 
-        if not incremental:
-            self.copy_static_files()
+        self.copy_static_files()
 
         # Create all the tint colour assets
         for tc in tint_colours:
@@ -241,25 +239,26 @@ class Site(BaseModel):
 
         return "/" + str(out_path.relative_to(self.out_dir))
 
-    def copy_static_files(self) -> None:  # pragma: no cover
+    def copy_static_files(self) -> None:
         """
         Copy all the static files from the src to the dst directory.
         """
-        static_files = []
+        # A list of (src, dst) static files to be copied.
+        static_files: list[tuple[Path, Path]] = []
 
         for src_p in find_paths_under(self.src_dir):
-            if src_p.suffix == ".md" and "files" not in src_p.parts:
+            if src_p.suffix == ".md":
                 continue
-            else:
-                static_files.append(
-                    (src_p, self.out_dir / src_p.relative_to(self.src_dir))
-                )
+            static_files.append((src_p, self.out_dir / src_p.relative_to(self.src_dir)))
 
+        # Actually copy the files. Use the cache to record the mtime
+        # of the source file when it's copied, to skip copying files
+        # which haven't changed.
         with tqdm(desc="static files", total=len(static_files)) as pbar:
             for src_p, out_p in static_files:
-                if not out_p.exists() or not filecmp.cmp(src_p, out_p, shallow=False):
+                if not out_p.exists() or src_p.stat().st_mtime != out_p.stat().st_mtime:
                     out_p.parent.mkdir(exist_ok=True, parents=True)
-                    shutil.copyfile(src_p, out_p)
+                    shutil.copy2(src_p, out_p)
 
                 pbar.update(1)
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -143,3 +143,44 @@ def test_generate_rss_feeds(env: Environment, src_dir: Path, out_dir: Path) -> N
 
     assert (out_dir / "atom.xml").exists()
     assert (out_dir / "notes/atom.xml").exists()
+
+
+def test_copy_static_files(src_dir: Path, out_dir: Path) -> None:
+    """
+    Test copying static files between the two directories.
+    """
+    site = Site(src_dir=src_dir, out_dir=out_dir, all_pages=[])
+
+    # Create three images in the source directory, and check that the
+    # two binary files are copied but the Markdown file is not.
+    files = [
+        ("my-article.md", b"this article should not be copied"),
+        ("images/123.bin", b"this image should be copied"),
+        ("files/2017/456.bin", b"this file should also be copied"),
+    ]
+
+    for path, contents in files:
+        (src_dir / path).parent.mkdir(parents=True, exist_ok=True)
+        (src_dir / path).write_bytes(contents)
+
+    site.copy_static_files()
+
+    assert not (out_dir / "my-article.md").exists()
+    assert (out_dir / "images/123.bin").read_bytes() == b"this image should be copied"
+    assert (
+        out_dir / "files/2017/456.bin"
+    ).read_bytes() == b"this file should also be copied"
+
+    # Update one of the binary files, and check the updated version is
+    # copied to the out_dir.
+    (src_dir / "images/123.bin").write_bytes(b"this image has been updated")
+    site.copy_static_files()
+    assert (out_dir / "images/123.bin").read_bytes() == b"this image has been updated"
+
+    # Remove one of the files from the output directory, and check it's
+    # replaced on the next run.
+    (out_dir / "files/2017/456.bin").unlink()
+    site.copy_static_files()
+    assert (
+        out_dir / "files/2017/456.bin"
+    ).read_bytes() == b"this file should also be copied"


### PR DESCRIPTION
When copying static files, check the file size/mtime before copying files; if they're the same, we can skip the copy.

In a local build, this reduces a full site build from 12.9s to 8.4s; copying static files with a warm cache is essentially instant.

This means I can do static file copying as part of an incremental build now, which will make the local dev experience a bit better.