### PR TITLE
Use an SQLite-backed cache to cache the generated HTML and speed up the site build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 .coverage*
 .hypothesis
 _out
+
+.mosaic_cache.db

--- a/mosaic/cache.py
+++ b/mosaic/cache.py
@@ -1,0 +1,81 @@
+"""
+SQLite-based caching for common operations, to speed up the site build.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+import sys
+from typing import cast, Literal
+
+from .git import git_root
+
+
+__all__ = ["SQLiteCache"]
+
+
+class SQLiteCache:
+    """
+    A basic SQLite-backed cache which supports reading and writing values.
+    """
+
+    conn: sqlite3.Connection
+
+    def __init__(self, database: Path | Literal[":memory:"]):
+        """
+        Create the initial SQLite connection.
+        """
+        self.conn = sqlite3.connect(database)
+
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "CREATE TABLE IF NOT EXISTS "
+            "cache_entries(namespace, key, value, date_saved)"
+        )
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS cache_entries_idx "
+            "ON cache_entries(namespace, key)"
+        )
+        self.conn.commit()
+
+    def close(self) -> None:
+        """
+        Close the SQLite connection.
+        """
+        self.conn.close()
+
+    def set(self, namespace: str, key: str, value: str | bool = "true") -> None:
+        """
+        Save a key in the cache.
+        """
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "INSERT INTO cache_entries VALUES (?,?,?,?)",
+            (namespace, key, value, datetime.now(tz=timezone.utc).isoformat()),
+        )
+        self.conn.commit()
+
+    def get(self, namespace: str, key: str) -> str | None:
+        """
+        Retrieve a key from the cache, or return None if it's not present.
+        """
+        cursor = self.conn.cursor()
+        res = cursor.execute(
+            "SELECT value FROM cache_entries WHERE namespace=? AND key=?",
+            (namespace, key),
+        )
+
+        try:
+            (value,) = res.fetchone()
+            return cast(str, value)
+        except TypeError:
+            return None
+
+
+if "pytest" in sys.modules:
+    _cache = SQLiteCache(database=":memory:")
+else:  # pragma: no cover
+    _cache = SQLiteCache(database=git_root() / ".mosaic_cache.db")
+
+set = _cache.set
+get = _cache.get

--- a/mosaic/css.py
+++ b/mosaic/css.py
@@ -3,7 +3,6 @@ Code for dealing with CSS and website styles.
 """
 
 from collections import OrderedDict
-import hashlib
 from pathlib import Path
 import re
 from typing import TypedDict
@@ -11,6 +10,7 @@ from typing import TypedDict
 import lightningcss
 
 from .git import git_root
+from .text import md5
 
 
 __all__ = ["CSS_DIR", "create_base_css", "get_inline_styles"]
@@ -41,8 +41,7 @@ def create_base_css() -> tuple[str, str]:
     # Using three characters of hash gives me 16^3 = 4096 bits of entropy.
     # Given I cache CSS for a year and only change it a handful of times,
     # that should be plenty.
-    h = hashlib.md5(css.encode("utf8")).hexdigest()
-    h = h[:3]
+    h = md5(css)[:3]
 
     return f"style.{h}.css", css
 

--- a/mosaic/git.py
+++ b/mosaic/git.py
@@ -371,6 +371,7 @@ class GitRepository(BaseModel):
             tree=tree,
         )
 
+    @property
     def navigable_tree(self) -> NavigableTree:
         """
         Return a navigable tree for the /files/ page.

--- a/mosaic/page_types/_base.py
+++ b/mosaic/page_types/_base.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from typing import TypedDict
 
 from jinja2 import Environment
-import minify_html
 from pydantic import BaseModel, Field
 
+from mosaic import cache
 from mosaic.tint_colours import TintColours
-from mosaic.text import markdownify
+from mosaic.text import markdownify, md5, minify_html
 from mosaic.topics import get_topic_by_name
 
 
@@ -172,26 +172,29 @@ class BaseHtmlPage(ABC, BaseModel):
         This is the content unique to the page; it doesn't include any
         of the shared template code.
         """
+        cache_ns = "render_body_html"
+        cache_key = f"{self.md_path}:{md5(self.content)}"
+
+        if body := cache.get(cache_ns, cache_key):
+            return body
+
         # Expanding any Jinja2 plugins and templates, then convert
         # the Markdown to HTML. The Jinja2 expansion has to come first
         # so anything in the Jinja2 elements doesn't get Markdown-ified.
-        return markdownify(env.from_string(self.content).render(page=self))
+        body = markdownify(env.from_string(self.content).render(page=self))
+
+        cache.set(cache_ns, cache_key, body)
+
+        return body
 
     def render_full_html(self, env: Environment) -> str:
         """
         Return the HTML to be written to disk.
         """
-        html_content = self.render_body_html(env)
+        html_body = self.render_body_html(env)
         template = env.get_template(self.template_name)
-        html = template.render(page=self, content=html_content)
-
-        html = minify_html.minify(
-            html,
-            keep_html_and_head_opening_tags=True,
-            keep_closing_tags=True,
-            minify_css=True,
-            minify_js=True,
-        )
+        html = template.render(page=self, content=html_body)
+        html = minify_html(html)
 
         return html
 
@@ -200,9 +203,27 @@ class BaseHtmlPage(ABC, BaseModel):
         Write this HTML file to disk, and return the path of the
         newly-written file.
         """
-        html = self.render_full_html(env)
-
         out_path = self.out_path(out_dir)
+
+        # The cache key includes the path and modified time of the template.
+        # This means the cache could contain stale data if a template partial
+        # has changed but the main template didn't; I'll see if that becomes
+        # an issue in practice.
+        cache_ns = "render_full_html"
+        template_mtime = (Path("templates") / self.template_name).stat().st_mtime
+        cache_key = f"{self.md_path}:{template_mtime}:{md5(self.content)}"
+
+        # If the HTML exists in the cache, we don't need to regenerate it
+        # and we can skip writing if the file already exists.
+        if html := cache.get(cache_ns, cache_key):
+            if not out_path.exists():
+                out_path.parent.mkdir(exist_ok=True, parents=True)
+                out_path.write_text(html)
+            return out_path
+
+        html = self.render_full_html(env)
+        cache.set(cache_ns, cache_key, html)
+
         out_path.parent.mkdir(exist_ok=True, parents=True)
         out_path.write_text(html)
 

--- a/mosaic/page_types/_base.py
+++ b/mosaic/page_types/_base.py
@@ -90,9 +90,6 @@ class BaseHtmlPage(ABC, BaseModel):
     # The content of the Markdown source file
     content: str = ""
 
-    # The HTML content of the file
-    html_content: str = ""
-
     # The title of the page or post
     title: str = ""
 
@@ -168,23 +165,25 @@ class BaseHtmlPage(ABC, BaseModel):
         """
         return out_dir / self.url.strip("/") / "index.html"
 
-    def write(self, env: Environment, out_dir: Path) -> Path:
+    def render_body_html(self, env: Environment) -> str:
         """
-        Write this HTML file to disk, and return the path of the
-        newly-written file.
+        Return the HTML-ified content from the page.
+
+        This is the content unique to the page; it doesn't include any
+        of the shared template code.
         """
-        out_path = self.out_path(out_dir)
+        # Expanding any Jinja2 plugins and templates, then convert
+        # the Markdown to HTML. The Jinja2 expansion has to come first
+        # so anything in the Jinja2 elements doesn't get Markdown-ified.
+        return markdownify(env.from_string(self.content).render(page=self))
 
-        # Steps to render HTML:
-        #
-        #   1. Run the HTML through the Jinja2 templates, so plugins
-        #      and embeds are expanded
-        #   2. Convert the Markdown to HTML
-        #
-        self.html_content = markdownify(env.from_string(self.content).render(page=self))
-
+    def render_full_html(self, env: Environment) -> str:
+        """
+        Return the HTML to be written to disk.
+        """
+        html_content = self.render_body_html(env)
         template = env.get_template(self.template_name)
-        html = template.render(page=self, content=self.html_content)
+        html = template.render(page=self, content=html_content)
 
         html = minify_html.minify(
             html,
@@ -194,6 +193,16 @@ class BaseHtmlPage(ABC, BaseModel):
             minify_js=True,
         )
 
+        return html
+
+    def write(self, env: Environment, out_dir: Path) -> Path:
+        """
+        Write this HTML file to disk, and return the path of the
+        newly-written file.
+        """
+        html = self.render_full_html(env)
+
+        out_path = self.out_path(out_dir)
         out_path.parent.mkdir(exist_ok=True, parents=True)
         out_path.write_text(html)
 

--- a/mosaic/site.py
+++ b/mosaic/site.py
@@ -264,19 +264,12 @@ class Site(BaseModel):
         """
         Generate the RSS feeds for the site.
         """
-        assert all(a.html_content for a in self.articles), (
-            "html_content has not been set for all articles"
-        )
-        assert all((n.html_content or not n.content.strip()) for n in self.notes), (
-            "html_content has not been set for all notes"
-        )
-
         atom_template = env.get_template("atom.xml")
-        atom_xml = atom_template.render(articles=self.articles)
+        atom_xml = atom_template.render(env=env, articles=self.articles)
         (self.out_dir / "atom.xml").write_text(atom_xml)
 
         notes_atom_template = env.get_template("notes_atom.xml")
-        notes_atom_xml = notes_atom_template.render(notes=self.notes)
+        notes_atom_xml = notes_atom_template.render(env=env, notes=self.notes)
         (self.out_dir / "notes/atom.xml").write_text(notes_atom_xml)
 
     def prepare_project_pages(

--- a/mosaic/text.py
+++ b/mosaic/text.py
@@ -4,12 +4,13 @@ Utilities for dealing with text.
 
 import collections
 import functools
+import hashlib
 import json
 import re
 from typing import Any, Literal, Match
 
 from chives.text import smartify
-import minify_html
+import minify_html as minify_html_lib
 import mistune
 from mistune.core import BlockState
 
@@ -27,6 +28,19 @@ def strip_html(text: str) -> str:
     input, but should be fine for my site.
     """
     return STRIP_HTML_RE.sub("", text)
+
+
+def minify_html(html: str) -> str:
+    """
+    Minify an HTML string.
+    """
+    return minify_html_lib.minify(
+        html,
+        keep_html_and_head_opening_tags=True,
+        keep_closing_tags=True,
+        minify_css=True,
+        minify_js=True,
+    )
 
 
 class AlexwlchanRenderer(mistune.HTMLRenderer):
@@ -168,7 +182,6 @@ def _parse_to_end_of_svg(state: BlockState, start_pos: int) -> int:
 markdown = mistune.Markdown(renderer=AlexwlchanRenderer(), block=MosaicBlockParser())
 
 
-@functools.cache
 def markdownify(text: str) -> str:
     """
     Format text using Markdown.
@@ -185,7 +198,6 @@ def markdownify_oneline(text: str) -> str:
     return markdownify(text).replace("<p>", "").replace("</p>", "").strip()
 
 
-@functools.cache
 def cleanup_text(text: str) -> str:
     """
     Apply all my cleanup rules to text.
@@ -396,9 +408,9 @@ def assert_is_invariant_under_markdown(html: str) -> None:
         markdownified = markdownified.replace("<p>", "", 1)
         markdownified = re.sub(r"</p>$", "", markdownified)
 
-    assert minify_html.minify(markdownified) == minify_html.minify(html), (
-        minify_html.minify(markdownified),
-        minify_html.minify(html),
+    assert minify_html(markdownified) == minify_html(html), (
+        minify_html(markdownified),
+        minify_html(html),
     )
 
 
@@ -461,3 +473,11 @@ def coloured(text: str, colour: Literal["red", "yellow", "green", "blue"]) -> st
     end_code = "\033[0m"
 
     return start_code + text + end_code
+
+
+@functools.cache
+def md5(s: str) -> str:
+    """
+    Return the hex-encoded MD5 hash of a string.
+    """
+    return hashlib.md5(s.encode("utf8")).hexdigest()

--- a/templates/partials/rss_feed_entry.xml
+++ b/templates/partials/rss_feed_entry.xml
@@ -16,7 +16,7 @@
     {%- if post.template_name == "note.html" and post.summary -%}
       <p><strong>{{ post.summary | markdownify_oneline | fix_html_for_feed_readers }}</strong></p>
     {%- endif -%}
-    {{- post.html_content | cleanup_text | fix_html_for_feed_readers | fix_youtube_iframes }}
+    {{- post.render_body_html(env) | cleanup_text | fix_html_for_feed_readers | fix_youtube_iframes }}
 
     <p>[If the formatting of this post looks odd in your feed reader, <a href="{{ post.url | absolute_url | xml_escape }}?ref=rss">visit the original article</a>]</p>
     ]]>

--- a/templates/projects/tree.html
+++ b/templates/projects/tree.html
@@ -70,7 +70,7 @@
   </style>
   
   {% set repo = page.repo %}
-  {% set tree = repo.navigable_tree() %}
+  {% set tree = repo.navigable_tree %}
 
   <article>
     <h1 class="title">Files</h1>

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,32 @@
+"""
+Tests for `mosaic.cache`.
+"""
+
+from collections.abc import Iterator
+
+import pytest
+
+from mosaic.cache import SQLiteCache
+
+
+@pytest.fixture
+def cache() -> Iterator[SQLiteCache]:
+    """
+    Create an empty SQLiteCache which only exists for the duration
+    of this test.
+    """
+    c = SQLiteCache(":memory:")
+    yield c
+    c.close()
+
+
+def test_basic_cache(cache: SQLiteCache) -> None:
+    """
+    Basic cache usage for SQLiteCache.
+    """
+    assert cache.get(namespace="fibonacci", key="10") is None
+
+    cache.set(namespace="fibonacci", key="10", value="55")
+
+    assert cache.get(namespace="fibonacci", key="10") == "55"
+    assert cache.get(namespace="fibonacci", key="11") is None

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -328,7 +328,7 @@ def test_git_tree(git: GitFn, repo_root: Path) -> None:
             is_binary=True,
         ),
     ]
-    assert repo.tree.navigable_tree.files == [
+    assert repo.navigable_tree.files == [
         NavigableFile(name="greeting.txt"),
         NavigableFile(name="zero.bin", is_binary=True),
     ]

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import functools
 from pathlib import Path
 import random
+import time
 
 from jinja2 import Environment
 
@@ -245,6 +246,7 @@ def test_copy_static_files(src_dir: Path, out_dir: Path) -> None:
 
     # Update one of the binary files, and check the updated version is
     # copied to the out_dir.
+    time.sleep(2)
     (src_dir / "images/123.bin").write_bytes(b"this image has been updated")
     site.copy_static_files()
     assert (out_dir / "images/123.bin").read_bytes() == b"this image has been updated"

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -20,6 +20,7 @@ from mosaic.page_types import (
     TopicPage,
 )
 from mosaic.site import Site
+from mosaic.templates import get_jinja_environment
 
 
 def test_page_properties(src_dir: Path) -> None:
@@ -157,6 +158,63 @@ def test_generate_rss_feeds(env: Environment, src_dir: Path, out_dir: Path) -> N
     assert "Note posted in 2050" in notes_rss
     assert "Note posted in 2026" in notes_rss
     assert "Note posted in 2025" not in notes_rss
+
+
+def test_writing_page_repeatedly(
+    env: Environment, src_dir: Path, out_dir: Path
+) -> None:
+    """
+    Test writing a page multiple times.
+
+    This tests the caching logic for generating the page HTML; rather than
+    generating it fresh every time, it's cached in the database and only
+    regenerated when the page content or template changes.
+    """
+    a = Article(
+        src_dir=src_dir,
+        md_path=src_dir / "_articles/2001/2001-01-01-article.md",
+        date=datetime(2001, 1, 1),
+        content="An example article",
+    )
+
+    env = get_jinja_environment(src_dir, out_dir)
+    env.globals.update({"css_url": "/static/style.css"})
+
+    out_path1 = a.write(env, out_dir)
+    out_body1 = a.render_body_html(env)
+    out_text1 = out_path1.read_text()
+    assert out_path1 == out_dir / "2001/article/index.html"
+
+    out_path2 = a.write(env, out_dir)
+    out_body2 = a.render_body_html(env)
+    out_text2 = out_path2.read_text()
+    assert out_path1 == out_path2
+    assert out_body1 == out_body2
+    assert out_text1 == out_text2
+
+
+def test_writing_page_checks_for_deletion(
+    env: Environment, src_dir: Path, out_dir: Path
+) -> None:
+    """
+    If a page was written previously but no longer exists, it gets re-written.
+    """
+    a = Article(
+        src_dir=src_dir,
+        md_path=src_dir / "_articles/2001/2001-01-01-article.md",
+        date=datetime(2001, 1, 1),
+        content="An example article",
+    )
+
+    env = get_jinja_environment(src_dir, out_dir)
+    env.globals.update({"css_url": "/static/style.css"})
+
+    out_path1 = a.write(env, out_dir)
+    assert out_path1.exists()
+    out_path1.unlink()
+
+    out_path2 = a.write(env, out_dir)
+    assert out_path2.exists()
 
 
 def test_copy_static_files(src_dir: Path, out_dir: Path) -> None:

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -125,7 +125,7 @@ def test_generate_rss_feeds(env: Environment, src_dir: Path, out_dir: Path) -> N
             src_dir=src_dir,
             md_path=src_dir / f"_articles/{year}/{year}-01-01-article.md",
             date=datetime(year, 1, 1),
-            html_content=f"Article posted in {year}",
+            content=f"Article posted in {year}",
         )
         for year in range(2000, 2051)
     ] + [
@@ -134,7 +134,7 @@ def test_generate_rss_feeds(env: Environment, src_dir: Path, out_dir: Path) -> N
             md_path=src_dir / f"notes/{year}/{year}-02-02-note.md",
             date=datetime(year, 2, 2),
             topics=["Topic 1", "Topic 2", "Topic 3"],
-            html_content=f"Note posted in {year}",
+            content=f"Note posted in {year}",
         )
         for year in range(2000, 2051)
     ]


### PR DESCRIPTION
With a warm cache, a local build now takes just 2 seconds.