### PR TITLE
all: run Caddy for local dev; switch to FSEvents-based live watcher

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,50 +9,12 @@ alexwlchan.net {
 	import caddy/gone.Caddyfile
 	import caddy/projects.Caddyfile
 
-	# Enable compression for responses
-	encode zstd gzip
-
-	# I can set long-lived caches on all these static assets because I treat
-	# most files as immutable by filename -- if I modify a file, I'll upload a new
-	# file with a different name, so it won't be a cache hit.
-	#
-	# The one exception is CSS files, but I cache-bust those by passing a query parameter
-	# that includes the hash of my CSS source.
-	@cached {
-		path /b/* /c/* /f/* /h/* /files/* /images/* /static/* /theme/*
-	}
-
-	header @cached {
-		Cache-Control "public, max-age=31536000"
-	}
-
+	import caddy/errors.Caddyfile
+	import caddy/caching_headers.Caddyfile
 	import caddy/security_headers.Caddyfile
 
-	# If somebody gets a 4xx error, respond with my custom error pages.
-	handle_errors 404 {
-		root * /home/alexwlchan/repos/alexwlchan.net/_site
-		rewrite * 404/index.html
-		file_server
-	}
-
-	handle_errors 410 {
-		root * /home/alexwlchan/repos/alexwlchan.net/_site
-		rewrite * 410/index.html
-		file_server
-	}
-
-	# If somebody is trying to look for PHP pages on my site, and WordPress
-	# pages in particular, they probably have nefarious goals.
-	#
-	# This is mostly automated bots -- serve them my minimal 400 Bad Request
-	# error rather than the complete 404 Not Found page.
-	@spam {
-		path /.env /index.php /xmlrpc.php /wp-* /blog/wp-* /cms/wp-* /shop/wp-* /site/wp-* /test/wp-* /wordpress/wp-* /wp/wp-* /wp2/wp-* /zb_system/*
-	}
-
-	handle @spam {
-		respond "400 Bad Request" 400
-	}
+	# Enable compression for responses
+	encode zstd gzip
 
 	# Run a static file server for anything not yet handled
 	root * /home/alexwlchan/repos/alexwlchan.net/_site

--- a/caddy/caching_headers.Caddyfile
+++ b/caddy/caching_headers.Caddyfile
@@ -1,0 +1,13 @@
+# I can set long-lived caches on all these static assets because I treat
+# most files as immutable by filename -- if I modify a file, I'll upload a new
+# file with a different name, so it won't be a cache hit.
+#
+# The one exception is CSS files, but I cache-bust those by passing a query parameter
+# that includes the hash of my CSS source.
+@cached {
+	path /b/* /c/* /f/* /h/* /files/* /images/* /static/* /theme/*
+}
+
+header @cached {
+	Cache-Control "public, max-age=31536000"
+}

--- a/caddy/errors.Caddyfile
+++ b/caddy/errors.Caddyfile
@@ -1,0 +1,25 @@
+# If somebody gets a 4xx error, respond with my custom error pages.
+handle_errors 404 {
+	root * /home/alexwlchan/repos/alexwlchan.net/_site
+	rewrite * 404/index.html
+	file_server
+}
+
+handle_errors 410 {
+	root * /home/alexwlchan/repos/alexwlchan.net/_site
+	rewrite * 410/index.html
+	file_server
+}
+
+# If somebody is trying to look for PHP pages on my site, and WordPress
+# pages in particular, they probably have nefarious goals.
+#
+# This is mostly automated bots -- serve them my minimal 400 Bad Request
+# error rather than the complete 404 Not Found page.
+@spam {
+	path /.env /index.php /xmlrpc.php /wp-* /blog/wp-* /cms/wp-* /shop/wp-* /site/wp-* /test/wp-* /wordpress/wp-* /wp/wp-* /wp2/wp-* /zb_system/*
+}
+
+handle @spam {
+	respond "400 Bad Request" 400
+}

--- a/caddy/local_dev.Caddyfile
+++ b/caddy/local_dev.Caddyfile
@@ -1,0 +1,14 @@
+# Run a local instance of the site on port 5757.
+#
+# This inherits the redirects and file handling behaviour of the main
+# site, but doesn't need HTTPS or alternative domains.
+
+:5757 {
+	import errors.Caddyfile
+	import gone.Caddyfile
+	import projects.Caddyfile
+	import redirects.Caddyfile
+
+	root * /Users/alexwlchan/repos/alexwlchan.net/_out
+	file_server
+}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -51,8 +51,6 @@ librt==0.8.1
     #   mypy
 lightningcss==0.3.1
     # via -r requirements.txt
-livereload==2.7.1
-    # via -r requirements.txt
 lxml==6.0.2
     # via -r requirements.txt
 lxml-stubs==0.5.1
@@ -147,10 +145,6 @@ soupsieve==2.8.3
     # via
     #   -r requirements.txt
     #   beautifulsoup4
-tornado==6.5.5
-    # via
-    #   -r requirements.txt
-    #   livereload
 typing-extensions==4.15.0
     # via
     #   -r dns/requirements.txt

--- a/mosaic/page_types/projects.py
+++ b/mosaic/page_types/projects.py
@@ -3,7 +3,6 @@ Models for project/Git repo pages.
 """
 
 from pathlib import Path
-import platform
 from typing import Self, TypedDict
 
 from pydantic import model_validator
@@ -243,11 +242,4 @@ class ProjectSingleFile(BaseProjectPage):
         """
         Return the path where this HTML file should be written.
         """
-        # For Caddy and the live website, these pages get `.html` appended
-        # so they can be served without a path.
-        #
-        # That doesn't work with the web server I use for local dev, so use
-        # the folder-based path instead.
-        if platform.system() == "Darwin":
-            return super().out_path(out_dir)
         return out_dir / (self.url.strip("/") + ".html")

--- a/mosaic/site.py
+++ b/mosaic/site.py
@@ -86,6 +86,9 @@ class BuildOptions(BaseModel):
     # Whether to print detailed timings about each step in the build
     profile: bool = False
 
+    # Whether to inject the LiveReload snippet into the site
+    livereload: bool = False
+
 
 class Site(BaseModel):
     """

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ beautifulsoup4
 inquirerpy
 jinja2
 lightningcss
-livereload
 lxml
 minify-html
 mistune

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,6 @@ librt==0.8.1
     #   mypy
 lightningcss==0.3.1
     # via -r requirements.in
-livereload==2.7.1
-    # via -r requirements.in
 lxml==6.0.2
     # via -r requirements.in
 lxml-stubs==0.5.1
@@ -105,8 +103,6 @@ sortedcontainers==2.4.0
     # via hypothesis
 soupsieve==2.8.3
     # via beautifulsoup4
-tornado==6.5.5
-    # via livereload
 typing-extensions==4.15.0
     # via
     #   -r uptime_tests/requirements.txt

--- a/scripts/build_site.py
+++ b/scripts/build_site.py
@@ -9,12 +9,13 @@ import time
 sys.path.append(str(Path(__file__).parent.parent))
 
 from mosaic import Site
+from mosaic.site import BuildOptions
 
 
 if __name__ == "__main__":
     site = Site()
     now = time.time()
-    result = site.build_site()
+    result = site.build_site(BuildOptions(livereload=True, profile=True))
     elapsed = time.time() - now
     if result:
         print(f"✅ Build successful in {elapsed:.1f}s.")

--- a/scripts/serve_site.py
+++ b/scripts/serve_site.py
@@ -3,60 +3,138 @@ Build the site and serve it at http://localhost:5757, then rebuild
 it whenever something changes.
 """
 
-from collections.abc import Callable
+from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
+from socketserver import ThreadingMixIn
+import subprocess
 import sys
 import time
-from typing import Literal
+import threading
 
-from livereload import Server
 
 sys.path.append(str(Path(__file__).parent.parent))
 
 from mosaic import Site
 from mosaic.site import BuildOptions
+from watch_folders import watch_folders
 
 
-SITE = Site()
+# All waiting pages are told to reload when this event is set to true
+reload_event = threading.Event()
 
 
-def build_and_reload(
-    reason: Literal["css", "src", "templates", "topics"],
-) -> Callable[[], None]:
+class WaitForReloadHandler(SimpleHTTPRequestHandler):
+    """
+    A basic server that only serves the `/wait-for-reload` endpoint.
+
+    The page can long poll this endpoint for either:
+
+    - a 200 OK with 'reload' (refresh to pick up changes), or
+    - a 204 No Content (no changes in the last 30 seconds).
+    """
+
+    def do_GET(self) -> None:
+        """
+        Handle GET requests.
+        """
+        if self.path != "/wait-for-reload":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        # We've received a request from a web browser.
+        #
+        # Wait until reload_event is set, or 30 seconds have passed.
+        # The choice of 30 seconds is arbitrary; we just don't want the
+        # browser to time out the connection if nothing changes.
+        changed = reload_event.wait(timeout=30)
+
+        if changed:
+            self.send_response(200)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Content-type", "text/plain")
+            self.end_headers()
+
+            try:
+                self.wfile.write(b"reload")
+            except BrokenPipeError:
+                pass
+        else:
+            self.send_response(204)
+            self.end_headers()
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    """
+    An HTTP server where each "hanging" fetch request runs in its own thread.
+    """
+
+    daemon_threads = True
+
+
+def rebuild(site: Site, changed_folder: Path) -> None:
     """
     Build a new version of the site.
     """
+    has_changes = False
+
+    if any(changed_folder.is_relative_to(p) for p in ("css", "src", "templates")):
+        has_changes = True
+
+    if (
+        changed_folder == Path(".")
+        and Path("topics.json").stat().st_mtime > time.time() - 60
+    ):
+        has_changes = True
+
+    if not has_changes:
+        return
+
+    print(f"detected changes in {changed_folder}")
+
     options = BuildOptions(
-        copy_static_files=reason == "src",
+        copy_static_files=changed_folder.is_relative_to("src"),
         cleanup_leftover_files=False,
         incremental_read=True,
         profile="--profile" in sys.argv,
+        livereload=True,
     )
 
-    def build() -> None:
-        try:
-            print("🔨 Rebuilding site...")
-            now = time.time()
-            SITE.build_site(options)
-            elapsed = time.time() - now
-            print(f"✅ Build successful in {elapsed:.2f}s")
-        except Exception as e:
-            print(f"❌ Build failed with error: {e}", file=sys.stderr)
+    try:
+        print("🔨 Rebuilding site...")
+        now = time.time()
+        site.build_site(options)
+        elapsed = time.time() - now
+        print(f"✅ Build successful in {elapsed:.2f}s")
 
-    return build
+        # Trigger the reload event, so any waiting browsers will refresh
+        reload_event.set()
+        reload_event.clear()
+
+    except Exception as e:
+        print(f"❌ Build failed with error: {e}", file=sys.stderr)
 
 
 if __name__ == "__main__":
-    now = time.time()
-    SITE.build_site(options=BuildOptions(profile=True))
-    elapsed = time.time() - now
-    print(f"✅ Initial build successful in {elapsed:.2f}s")
+    reload_server = ThreadedHTTPServer(("localhost", 5656), WaitForReloadHandler)
+    threading.Thread(target=reload_server.serve_forever, daemon=True).start()
 
-    server = Server()
+    cmd = ["caddy", "run", "--config", "caddy/local_dev.Caddyfile"]
+    proc = subprocess.Popen(
+        cmd, stderr=subprocess.DEVNULL, stdout=subprocess.PIPE, text=True
+    )
+    print("🌐 Listening on http://localhost:5757")
 
-    server.watch("css/", build_and_reload("css"))
-    server.watch("src/", build_and_reload("src"))
-    server.watch("templates/", build_and_reload("templates"))
-    server.watch("topics.json", build_and_reload("topics"))
+    site = Site()
 
-    server.serve(root=SITE.out_dir, port=5757, restart_delay=0)
+    try:
+        now = time.time()
+        site.build_site(options=BuildOptions(profile=True, livereload=True))
+        elapsed = time.time() - now
+        print(f"✅ Initial build successful in {elapsed:.2f}s")
+
+        for changed_folder in watch_folders():
+            rebuild(site, changed_folder)
+    except KeyboardInterrupt:
+        proc.terminate()
+        reload_server.shutdown()

--- a/scripts/watch_folders.py
+++ b/scripts/watch_folders.py
@@ -1,0 +1,26 @@
+"""
+Watch a directory for changes.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+import subprocess
+
+
+def watch_folders(root: str | Path = ".") -> Iterator[Path]:
+    """
+    Watch a folder for changes, and yield changed directories.
+    """
+    cmd = ["swift", "scripts/watch_folders.swift", str(root)]
+
+    proc = subprocess.Popen(
+        cmd, stderr=subprocess.DEVNULL, stdout=subprocess.PIPE, text=True
+    )
+
+    try:
+        # TODO: Implement de-bouncing or queueing.
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            yield Path(line.strip()).relative_to(Path(root).absolute())
+    except KeyboardInterrupt:
+        proc.terminate()

--- a/scripts/watch_folders.swift
+++ b/scripts/watch_folders.swift
@@ -1,0 +1,48 @@
+// Watch for changes in the specified directories, and print
+// directories with changes to stdout.
+
+import Foundation
+
+
+
+
+// TODO: Allow passing multiple paths to this script.
+let pathsToWatch = CommandLine.arguments.count > 1 ? [CommandLine.arguments[1]] : ["."]
+
+fputs("Watching for changes in \(pathsToWatch[0])\n", stderr)
+
+let callback: FSEventStreamCallback = { (_, _, _, eventpathsToWatchs, _, _) in
+  // TODO: Can I simplify this line?
+  // https://developer.apple.com/documentation/swift/unsafebitcast(_:to:)
+  let pathsToWatchs = Unmanaged<CFArray>.fromOpaque(eventpathsToWatchs).takeUnretainedValue() as! [String]
+
+  for pathsToWatch in Set(pathsToWatchs) {
+    let output = "\(pathsToWatch)\n"
+    if let data = output.data(using: .utf8) {
+      FileHandle.standardOutput.write(data)
+    }
+  }
+
+  // Flush stdout to ensure it's printed immediately
+  fflush(stdout)
+}
+
+let sinceWhen = FSEventStreamEventId(kFSEventStreamEventIdSinceNow)
+let latency = 0.1
+let flags = FSEventStreamCreateFlags(
+  kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagNoDefer
+  // TODO: Use kFSEventStreamCreateFlagFileEvents instead
+  // | kFSEventStreamCreateFlagFileEvents
+)
+
+// TODO: Improve error handling here
+let eventStream = FSEventStreamCreate(
+  kCFAllocatorDefault, callback, nil, pathsToWatch as CFArray, sinceWhen, latency, flags
+)!
+
+let queue = DispatchQueue(label: "net.alexwlchan.watcher")
+
+FSEventStreamSetDispatchQueue(eventStream, queue)
+FSEventStreamStart(eventStream)
+
+dispatchMain()

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -36,3 +36,9 @@
 {% include "partials/head/css_variables.html" %}
 
 <meta name="color-scheme" content="light dark"/>
+
+{% if site.build_options.livereload %}
+<script>
+  {% include "partials/head/livereload.js" %}
+</script>
+{% endif %}

--- a/templates/partials/head/livereload.js
+++ b/templates/partials/head/livereload.js
@@ -1,0 +1,15 @@
+async function startListener() {
+  while (true) {
+    try {
+      const response = await fetch('http://localhost:5656/wait-for-reload');
+      if (response.status === 200) {
+        console.log("Change detected! Reloading...");
+        window.location.reload();
+        break;
+      }
+    } catch (e) {
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  }
+}
+startListener();

--- a/tests/page_types/test_projects.py
+++ b/tests/page_types/test_projects.py
@@ -3,7 +3,6 @@ Tests for `mosaic.page_types.projects`.
 """
 
 from pathlib import Path
-import platform
 
 from jinja2 import Environment
 
@@ -133,13 +132,7 @@ def test_single_file(env: Environment, repo: GitRepository, out_dir: Path) -> No
         BreadcrumbEntry(label="files", href="/projects/example-project/files/"),
     ]
 
-    if platform.system() == "Darwin":  # pragma: no cover
-        assert (
-            p.write(env, out_dir)
-            == out_dir / "projects/example-project/files/README.md/index.html"
-        )
-    else:  # pragma: no cover
-        assert (
-            p.write(env, out_dir)
-            == out_dir / "projects/example-project/files/README.md.html"
-        )
+    assert (
+        p.write(env, out_dir)
+        == out_dir / "projects/example-project/files/README.md.html"
+    )

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -181,7 +181,8 @@ def test_writing_page_repeatedly(
     )
 
     env = get_jinja_environment(src_dir, out_dir)
-    env.globals.update({"css_url": "/static/style.css"})
+    site = Site(src_dir=src_dir, out_dir=out_dir, all_pages=[a])
+    env.globals.update({"css_url": "/static/style.css", "site": site})
 
     out_path1 = a.write(env, out_dir)
     out_body1 = a.render_body_html(env)
@@ -210,7 +211,8 @@ def test_writing_page_checks_for_deletion(
     )
 
     env = get_jinja_environment(src_dir, out_dir)
-    env.globals.update({"css_url": "/static/style.css"})
+    site = Site(src_dir=src_dir, out_dir=out_dir, all_pages=[a])
+    env.globals.update({"css_url": "/static/style.css", "site": site})
 
     out_path1 = a.write(env, out_dir)
     assert out_path1.exists()


### PR DESCRIPTION
The per-file Git repo pages don't have a trailing slash on the real site, but I couldn't make that work with the Python web server, so I was using different paths for prod/dev. This breaks the local linter, so rather than continuing to diverge those paths, I'm switching to Caddy for the local preview server -- it can reuse the prod config, and now I have the same server running in prod/dev.

To get the livereload behaviour, I wrote a Swift script that uses the FSEvents API to detect file changes, and some JavaScript that does a long poll of a small Python server to know when to reload.

Right now the Swift script only reports per-folder changes, but I know the flag for per-file changes. Once this has been working for a while, I'll switch to that, and write a blog post about this.