### PR TITLE
mosaic/linters: check links in the `href` of SVG `<use>` elements

### DIFF
--- a/mosaic/linters.py
+++ b/mosaic/linters.py
@@ -8,9 +8,10 @@ from collections.abc import Iterator
 import os
 from pathlib import Path
 import re
-from urllib.parse import unquote, urlparse, urlsplit
+from typing import Any
+from urllib.parse import unquote, urlsplit
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from .caddy import parse_caddy_redirects
 from .fs import find_paths_under
@@ -94,15 +95,9 @@ def check_no_localhost_links(html: BeautifulSoup) -> list[str]:
     """
     errors = []
 
-    for anchor in html.find_all("a"):
-        try:
-            url = anchor.attrs["href"]
-        except KeyError:
-            continue
-        assert isinstance(url, str)
-
-        if urlparse(url).netloc == "localhost:5757":
-            errors.append(f"linking to localhost URL: {url}")
+    for tag_name, url in find_all_links(html):
+        if urlsplit(url).netloc == "localhost:5757":
+            errors.append(f"linking to localhost URL in <{tag_name}>: {url}")
 
     return errors
 
@@ -261,6 +256,71 @@ def get_all_hackable_urls(url: str) -> Iterator[str]:
             yield url + "/"
 
 
+def assert_str(s: Any) -> str:
+    """
+    Type-check a string value.
+    """
+    assert isinstance(s, str), s
+    return s
+
+
+def find_all_links(html: BeautifulSoup) -> Iterator[tuple[str, str]]:
+    """
+    Find all links to external resources in this HTML.
+
+    Returns the tag name and external URL.
+    """
+    # Look for <a> and <link> tags and their `href` attribute.
+    # TODO: Should it be an error to omit the href value?
+    for anchor in html.find_all(["a", "link"]):
+        if "data-proofer-ignore" in anchor.attrs:  # pragma: no cover
+            continue
+        try:
+            yield anchor.name, assert_str(anchor.attrs["href"])
+        except KeyError:
+            pass
+
+    # Look for <img> and <script> tags and their `src` attribute
+    for tag in html.find_all(["img", "script"]):
+        try:
+            yield tag.name, assert_str(tag.attrs["src"])
+        except KeyError:
+            pass
+
+    # Look for <source> tags and their `srcset` attribute
+    for tag in html.find_all(["img", "source"]):
+        if tag.name == "img" and "srcset" not in tag.attrs:
+            continue
+
+        for srcset_entry in assert_str(tag.attrs["srcset"]).split(","):
+            parts = srcset_entry.split()
+            assert len(parts) <= 2, srcset_entry
+            url = parts[0]
+            yield tag.name, url
+
+    # Look for <meta> tags for cards
+    for meta in html.find_all("meta", {"name": "twitter:image"}):
+        yield meta.name, assert_str(meta["content"])
+    for meta in html.find_all("meta", {"name": "og:image"}):
+        yield meta.name, assert_str(meta["content"])
+
+    # Look for xlink:href or href on SVG elements
+    for svg in html.find_all("svg"):
+        for elem in svg.descendants:
+            if not isinstance(elem, Tag):
+                continue
+
+            try:
+                yield elem.name, assert_str(elem["href"])
+            except KeyError:
+                pass
+
+            try:
+                yield elem.name, assert_str(elem["xlink:href"])
+            except KeyError:
+                pass
+
+
 def check_links_are_consistent(
     out_dir: Path, pages: dict[Path, BeautifulSoup]
 ) -> dict[Path, list[str]]:
@@ -280,41 +340,8 @@ def check_links_are_consistent(
         if "fun-stuff" in p.parts or "files" in p.parts:  # pragma: no cover
             continue
 
-        # Look for <a> and <link> tags and their `href` attribute.
-        # TODO: Should it be an error to omit the href value?
-        for anchor in soup.find_all(["a", "link"]):
-            if "data-proofer-ignore" in anchor.attrs:  # pragma: no cover
-                continue
-            try:
-                entry = (p, anchor.name, anchor.attrs["href"])
-                linked_urls.append(entry)  # type: ignore
-            except KeyError:
-                pass
-
-        # Look for <img> and <script> tags and their `src` attribute
-        for tag in soup.find_all(["img", "script"]):
-            try:
-                entry = (p, tag.name, tag.attrs["src"])
-                linked_urls.append(entry)  # type: ignore
-            except KeyError:
-                pass
-
-        # Look for <source> tags and their `srcset` attribute
-        for tag in soup.find_all(["img", "source"]):
-            if tag.name == "img" and "srcset" not in tag.attrs:
-                continue
-
-            for srcset_entry in tag.attrs["srcset"].split(","):  # type: ignore
-                parts = srcset_entry.split()
-                assert len(parts) <= 2, srcset_entry
-                url = parts[0]
-                linked_urls.append((p, tag.name, url))
-
-        # Look for <meta> tags for cards
-        for meta in soup.find_all("meta", {"name": "twitter:image"}):
-            linked_urls.append((p, meta.name, meta["content"]))  # type: ignore
-        for meta in soup.find_all("meta", {"name": "og:image"}):
-            linked_urls.append((p, meta.name, meta["content"]))  # type: ignore
+        for tag_name, url in find_all_links(soup):
+            linked_urls.append((p, tag_name, url))
 
     # 2. Go through each URL in turn, and check if it exists.
     print("checking links...")

--- a/src/_articles/2025/2025-12-21-truchet-tiles.md
+++ b/src/_articles/2025/2025-12-21-truchet-tiles.md
@@ -359,6 +359,8 @@ One of the simplest Truchet tiles is a square made of two colours:
   </svg>
 </figure>
 
+AAA
+
 <figure style="width: 500px;" class="columns_4">
   {% set squares = ["#truchetSquare", "#truchetSquare90", "#truchetSquare180", "#truchetSquare270"] %}
   {% for tile in squares %}
@@ -402,22 +404,22 @@ These can be arranged in a regular pattern, but they also look nice when arrange
     <use href="#truchetSquare" x="300" y="300"/>
   </svg>
   <svg viewBox="0 0 400 400" style="width: 100%;" xmlns="http://www.w3.org/2000/svg" id="randomSquares" class="border">  
-    <use href="{{ squares | sample(1) }}"/>
-    <use href="{{ squares | sample(1) }}" x="100"/>
-    <use href="{{ squares | sample(1) }}" x="200"/>
-    <use href="{{ squares | sample(1) }}" x="300"/>
-    <use href="{{ squares | sample(1) }}"         y="100"/>
-    <use href="{{ squares | sample(1) }}" x="100" y="100"/>
-    <use href="{{ squares | sample(1) }}" x="200" y="100"/>
-    <use href="{{ squares | sample(1) }}" x="300" y="100"/>
-    <use href="{{ squares | sample(1) }}"         y="200"/>
-    <use href="{{ squares | sample(1) }}" x="100" y="200"/>
-    <use href="{{ squares | sample(1) }}" x="200" y="200"/>
-    <use href="{{ squares | sample(1) }}" x="300" y="200"/>
-    <use href="{{ squares | sample(1) }}"         y="300"/>
-    <use href="{{ squares | sample(1) }}" x="100" y="300"/>
-    <use href="{{ squares | sample(1) }}" x="200" y="300"/>
-    <use href="{{ squares | sample(1) }}" x="300" y="300"/>
+    <use href="{{ (squares | sample(1))[0] }}"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="100"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="200"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="300"/>
+    <use href="{{ (squares | sample(1))[0] }}"         y="100"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="100" y="100"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="200" y="100"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="300" y="100"/>
+    <use href="{{ (squares | sample(1))[0] }}"         y="200"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="100" y="200"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="200" y="200"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="300" y="200"/>
+    <use href="{{ (squares | sample(1))[0] }}"         y="300"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="100" y="300"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="200" y="300"/>
+    <use href="{{ (squares | sample(1))[0] }}" x="300" y="300"/>
   </svg>
 </figure>
 

--- a/tests/test_linters.py
+++ b/tests/test_linters.py
@@ -15,6 +15,7 @@ from mosaic.linters import (
     check_no_broken_html,
     check_no_localhost_links,
     check_redirects,
+    find_all_links,
     get_all_hackable_urls,
     get_expected_path,
 )
@@ -130,6 +131,46 @@ class TestCheckNoBrokenHtml:
         """
 
         self.assert_html_is_passed(html)
+
+
+@pytest.mark.parametrize(
+    "html, expected_links",
+    [
+        ("<p>hello world</p>", []),
+        (
+            '<a href="https://example.com">example link</a>',
+            [("a", "https://example.com")],
+        ),
+        (
+            '<a href="#heading">link to heading</a>',
+            [("a", "#heading")],
+        ),
+        ('<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><rect/></svg>', []),
+        (
+            '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">'
+            "<text>hello world</text></svg>",
+            [],
+        ),
+        (
+            '<svg version="1.1" '
+            'xmlns="http://www.w3.org/2000/svg" '
+            'xmlns:xlink="http://www.w3.org/1999/xlink">'
+            '<use xlink:href="#heart"/></svg>',
+            [("use", "#heart")],
+        ),
+        (
+            '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">'
+            '<use href="#heart"/></svg>',
+            [("use", "#heart")],
+        ),
+    ],
+)
+def test_find_all_links(html: str, expected_links: list[tuple[str, str]]) -> None:
+    """
+    Tests for `find_all_links`.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    assert list(find_all_links(soup)) == expected_links
 
 
 class TestCheckNoLocalhostLinks:


### PR DESCRIPTION
I thought of this while adding the lint for unique HTML `id` attributes, and it uncovered another broken page!