### PR TITLE
mosaic/git: cache Git data rather than fetching fresh each time

### DIFF
--- a/mosaic/git.py
+++ b/mosaic/git.py
@@ -18,6 +18,8 @@ from pydantic import BaseModel
 import pygit2
 from pygit2.enums import ReferenceFilter, SortMode
 
+from mosaic import cache
+
 
 __all__ = ["git_root"]
 
@@ -134,6 +136,18 @@ class Commit(BaseModel):
         """
         Create a `Commit` from the pygit2 data structures.
         """
+        commit_id = as_hex(commit.id)
+
+        # Look in the cache to see if we already have data about this
+        # Git commit; this is often faster than reading the data from Git.
+        #
+        # Use the commit ID as the key; the odds of a commit ID collision
+        # among my projects is essentially nil.
+        cache_ns = "get_git_commit"
+        if commit_json := cache.get(cache_ns, commit_id):
+            commit_data = Commit.model_validate_json(commit_json)
+            return commit_id, commit_data
+
         parent = commit.parents[0] if commit.parents else None
         if parent is None:
             diff = commit.tree.diff_to_tree(swap=True)
@@ -153,9 +167,7 @@ class Commit(BaseModel):
 
         changed_files = [ChangedFile.from_pygit2_patch(patch) for patch in patches]
 
-        commit_id = as_hex(commit.id)
-
-        return commit_id, Commit(
+        commit_data = Commit(
             id=commit_id,
             message=commit.message.strip(),
             author=f"{commit.author.name} <{commit.author.email}>",
@@ -163,6 +175,10 @@ class Commit(BaseModel):
             parent_ids=[as_hex(p) for p in commit.parent_ids],
             changed_files=changed_files,
         )
+
+        cache.set(cache_ns, commit_id, commit_data.model_dump_json())
+
+        return commit_id, commit_data
 
     @property
     def stats(self) -> Stats:
@@ -343,9 +359,23 @@ class GitTree(BaseModel):
         commit = repo.get(repo.head.target)
         assert isinstance(commit, pygit2.Commit)
 
-        files = list_files_for_tree(commit.tree)
+        # Look in the cache to see if we already have data about this
+        # tree; this is often faster than reading the data from Git.
+        #
+        # Use the tree ID as the key; the odds of a tree ID collision
+        # among my projects is essentially nil.
+        tree_id = as_hex(commit.tree.id)
+        cache_ns = "get_git_tree"
+        if tree_json := cache.get(cache_ns, tree_id):
+            tree_data = GitTree.model_validate_json(tree_json)
+            return tree_data
 
-        return GitTree(files=files)
+        files = list_files_for_tree(commit.tree)
+        tree_data = GitTree(files=files)
+
+        cache.set(cache_ns, tree_id, tree_data.model_dump_json())
+
+        return tree_data
 
     @property
     def navigable_tree(self) -> NavigableTree:

--- a/mosaic/site.py
+++ b/mosaic/site.py
@@ -42,27 +42,6 @@ from .tint_colours import get_default_tint_colours
 from .topics import rebuild_topics_by_name
 
 
-GIT_REPOS = [
-    GitRepository(
-        name="chives",
-        description="Utility functions for working with my local media archives",
-        repo_root=Path.home() / "repos/chives",
-    ),
-    GitRepository(
-        name="create_thumbnail",
-        description="A command-line tool for creating image thumbnails",
-        repo_root=Path.home() / "repos/create_thumbnail",
-    ),
-    GitRepository(
-        name="randline",
-        description=(
-            "Get a random selection of lines in a file using reservoir sampling"
-        ),
-        repo_root=Path.home() / "repos/randline",
-    ),
-]
-
-
 def register_task(label: str) -> Any:
     """
     Annotate a build task so it will be printed and profiled in output.
@@ -118,6 +97,9 @@ class Site(BaseModel):
 
     css_url: str = ""
 
+    # A list of Git repos used for this site build.
+    repos: list[GitRepository] = Field(default_factory=lambda: list())
+
     # The time the site was built. This is used in the RSS feed.
     time: datetime = Field(default_factory=lambda: datetime.now(tz=timezone.utc))
 
@@ -131,6 +113,7 @@ class Site(BaseModel):
         """
         self.build_options = options
 
+        self.read_git_repos()
         self.read_markdown_files()
         self.check_for_duplicate_urls()
         self.set_article_attributes()
@@ -154,6 +137,31 @@ class Site(BaseModel):
             self.cleanup_leftover_files()
 
         return True
+
+    @register_task("read git repos")  # type: ignore
+    def read_git_repos(self) -> None:  # pragma: no cover
+        """
+        Read all the Git repositories from disk.
+        """
+        if self.repos:
+            return
+
+        repos = {
+            "chives": "Utility functions for working with my local media archives",
+            "create_thumbnail": "A command-line tool for creating image thumbnails",
+            "randline": (
+                "Get a random selection of lines in a file using reservoir sampling"
+            ),
+        }
+
+        self.repos = [
+            GitRepository(
+                name=name,
+                description=description,
+                repo_root=Path.home() / "repos" / name,
+            )
+            for name, description in repos.items()
+        ]
 
     @register_task("read markdown files")  # type: ignore
     def read_markdown_files(self) -> None:  # pragma: no cover
@@ -327,7 +335,7 @@ class Site(BaseModel):
                 "css_url": css_url,
                 "site": self,
                 "all_topics": rebuild_topics_by_name(),
-                "git_repos": GIT_REPOS,
+                "git_repos": self.repos,
                 "elsewhere": elsewhere,
             }
         )
@@ -492,7 +500,7 @@ class Site(BaseModel):
         """
         Write the /projects/ folder for my Git repos.
         """
-        for repo in GIT_REPOS:
+        for repo in self.repos:
             self.write_pages_for_single_repo(env, repo)
 
     def write_pages_for_single_repo(


### PR DESCRIPTION
Previously, I spent ~0.5s in the initial site build reading all the Git repo information; now we can do the same in ~0.02s.